### PR TITLE
🚀 [DEPLOY] 초기 세팅 페이지 구현 후 배포

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,16 @@
   <img alt="Baro Banner" src="./public/assets/baro-banner-white.png">
 </picture>
 
-<br/><br/>
+<br/>
+
+<div align="center">
+
+[![서비스 바로가기](https://img.shields.io/badge/서비스_바로가기-baro--web.vercel.app-449CD4?style=for-the-badge&logo=vercel&logoColor=white)](https://baro-web.vercel.app/)
+[![테스트 서버](https://img.shields.io/badge/테스트_서버-qa--baro--web.vercel.app-679436?style=for-the-badge&logo=vercel&logoColor=white)](https://qa-baro-web.vercel.app/)
+
+</div>
+
+<br/>
 
 ### 시작하기 (Getting Started)
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,13 @@
 <br/>
 
 <div align="center">
-
-[![서비스 바로가기](https://img.shields.io/badge/서비스_바로가기-baro--web.vercel.app-449CD4?style=for-the-badge&logo=vercel&logoColor=white)](https://baro-web.vercel.app/)
-[![테스트 서버](https://img.shields.io/badge/테스트_서버-qa--baro--web.vercel.app-679436?style=for-the-badge&logo=vercel&logoColor=white)](https://qa-baro-web.vercel.app/)
-
+  <a href="https://baro-web.vercel.app/">
+    <img src="https://img.shields.io/badge/🌐 서비스 바로가기-Click-449CD4?style=flat-square" />
+  </a>
+  &nbsp;&nbsp;
+  <a href="https://qa-baro-web.vercel.app/">
+    <img src="https://img.shields.io/badge/🧪 테스트 서버-Click-679436?style=flat-square" />
+  </a>
 </div>
 
 <br/>

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "preview": "vite preview",
     "prepare": "husky"
   },

--- a/src/app/routes/Router.tsx
+++ b/src/app/routes/Router.tsx
@@ -3,6 +3,7 @@ import { Routes, Route } from 'react-router-dom';
 import AppLayout from '@/app/layouts/AppLayout';
 import { routePaths } from '@/app/routes/routePaths';
 import DashboardPage from '@/pages/DashboardPage';
+import InitialSetupPage from '@/pages/InitialSetupPage';
 import InventoryCurrentPage from '@/pages/InventoryCurrentPage';
 import InventoryDepletedPage from '@/pages/InventoryDepletedPage';
 import LandingPage from '@/pages/LandingPage';
@@ -17,6 +18,7 @@ export default function Router() {
       {/* 레이아웃 없는 페이지 */}
       <Route path={routePaths.landing} element={<LandingPage />} />
       <Route path={routePaths.login} element={<LoginPage />} />
+      <Route path={routePaths.initialSetup} element={<InitialSetupPage />} />
       <Route path={routePaths.notFound} element={<NotFoundPage />} />
 
       {/* 사이드바 + 상단바 공통 레이아웃 */}

--- a/src/app/routes/routePaths.ts
+++ b/src/app/routes/routePaths.ts
@@ -1,6 +1,7 @@
 export const routePaths = {
   landing: '/',
   login: '/login',
+  initialSetup: '/initial-setup',
   dashboard: '/dashboard',
   inventoryCurrent: '/inventory/current',
   inventoryDepleted: '/inventory/depleted',

--- a/src/features/initial-setup/components/InitialSetupForm.tsx
+++ b/src/features/initial-setup/components/InitialSetupForm.tsx
@@ -1,0 +1,196 @@
+import { useState } from 'react';
+
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+
+import { routePaths } from '@/app/routes/routePaths';
+import SetupProgressBar from '@/features/initial-setup/components/SetupProgressBar';
+import StepBasicInfo from '@/features/initial-setup/components/steps/StepBasicInfo';
+import StepKeyIngredients from '@/features/initial-setup/components/steps/StepKeyIngredients';
+import StepMenuRegistration from '@/features/initial-setup/components/steps/StepMenuRegistration';
+import StepNotifications from '@/features/initial-setup/components/steps/StepNotifications';
+import StepOperatingHours from '@/features/initial-setup/components/steps/StepOperatingHours';
+import StepRecipeInfo from '@/features/initial-setup/components/steps/StepRecipeInfo';
+import { SETUP_STEPS } from '@/features/initial-setup/constants/initialSetup.constants';
+import { DEFAULT_SETUP_DATA } from '@/features/initial-setup/data/initialSetup.mock';
+import type {
+  InitialSetupData,
+  StoreBasicInfo,
+} from '@/features/initial-setup/types/initialSetup.types';
+import { Button } from '@/shadcn/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shadcn/ui/card';
+import baroLogo from '@/shared/assets/images/baro-logo.png';
+
+type BasicInfoErrors = Partial<Record<keyof StoreBasicInfo, string>>;
+
+const InitialSetupForm = () => {
+  const navigate = useNavigate();
+  const [currentStep, setCurrentStep] = useState(1);
+  const [formData, setFormData] = useState<InitialSetupData>(DEFAULT_SETUP_DATA);
+  const [basicInfoErrors, setBasicInfoErrors] = useState<BasicInfoErrors>({});
+
+  const totalSteps = SETUP_STEPS.length;
+  const currentStepConfig = SETUP_STEPS[currentStep - 1];
+
+  const validateStep1 = (): boolean => {
+    const errors: BasicInfoErrors = {};
+    if (!formData.basicInfo.storeName.trim()) {
+      errors.storeName = '가게 이름을 입력해주세요';
+    }
+    setBasicInfoErrors(errors);
+    return Object.keys(errors).length === 0;
+  };
+
+  const handleNext = () => {
+    if (currentStep === 1 && !validateStep1()) return;
+    if (currentStep < totalSteps) {
+      setCurrentStep((prev) => prev + 1);
+    } else {
+      handleComplete();
+    }
+  };
+
+  const handleBack = () => {
+    if (currentStep > 1) {
+      setCurrentStep((prev) => prev - 1);
+    }
+  };
+
+  const handleComplete = () => {
+    // TODO: API 연동 후 실제 저장 로직으로 교체
+    navigate(routePaths.dashboard);
+  };
+
+  const handleSkip = () => {
+    navigate(routePaths.dashboard);
+  };
+
+  const renderStep = () => {
+    switch (currentStep) {
+      case 1:
+        return (
+          <StepBasicInfo
+            data={formData.basicInfo}
+            onChange={(basicInfo) => setFormData({ ...formData, basicInfo })}
+            errors={basicInfoErrors}
+          />
+        );
+      case 2:
+        return (
+          <StepOperatingHours
+            data={formData.operatingHours}
+            onChange={(operatingHours) => setFormData({ ...formData, operatingHours })}
+          />
+        );
+      case 3:
+        return (
+          <StepMenuRegistration
+            data={formData.menuItems}
+            onChange={(menuItems) => setFormData({ ...formData, menuItems })}
+          />
+        );
+      case 4:
+        return (
+          <StepRecipeInfo
+            menuItems={formData.menuItems}
+            recipes={formData.recipes}
+            onChange={(recipes) => setFormData({ ...formData, recipes })}
+          />
+        );
+      case 5:
+        return (
+          <StepKeyIngredients
+            data={formData.keyIngredients}
+            onChange={(keyIngredients) => setFormData({ ...formData, keyIngredients })}
+          />
+        );
+      case 6:
+        return (
+          <StepNotifications
+            data={formData.notificationSettings}
+            onChange={(notificationSettings) => setFormData({ ...formData, notificationSettings })}
+          />
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col bg-(--baro-ivory)/30">
+      {/* Header */}
+      <header className="flex items-center justify-between border-b border-gray-100 bg-white px-6 py-3.5">
+        <div className="flex items-center gap-2.5">
+          <img src={baroLogo} alt="BARO" className="h-7 w-auto" />
+          <span className="text-sm font-semibold text-foreground">초기 설정</span>
+        </div>
+        <button
+          type="button"
+          onClick={handleSkip}
+          className="text-sm text-muted-foreground underline underline-offset-2 transition-colors hover:text-foreground"
+        >
+          건너뛰기
+        </button>
+      </header>
+
+      {/* Main content */}
+      <main className="flex flex-1 justify-center px-4 py-8">
+        <div className="w-full max-w-xl space-y-6">
+          {/* Progress bar */}
+          <SetupProgressBar currentStep={currentStep} />
+
+          {/* Step card */}
+          <Card className="shadow-sm">
+            <CardHeader className="border-b border-gray-100">
+              <div className="flex items-center gap-2">
+                <span className="flex size-6 items-center justify-center rounded-full bg-baro-blue text-xs font-bold text-white">
+                  {currentStep}
+                </span>
+                <CardTitle className="text-base">{currentStepConfig.title}</CardTitle>
+              </div>
+              <CardDescription className="mt-0.5">{currentStepConfig.description}</CardDescription>
+            </CardHeader>
+            <CardContent className="pt-5">{renderStep()}</CardContent>
+          </Card>
+
+          {/* Navigation */}
+          <div className="flex items-center justify-between">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={handleBack}
+              disabled={currentStep === 1}
+              className="gap-1 rounded-full"
+            >
+              <ChevronLeft className="size-4" />
+              이전
+            </Button>
+
+            <span className="text-xs text-muted-foreground">
+              {currentStep} / {totalSteps}
+            </span>
+
+            <Button
+              type="button"
+              size="sm"
+              onClick={handleNext}
+              className="gap-1  rounded-full bg-baro-blue text-white hover:bg-baro-blue-dark"
+            >
+              {currentStep === totalSteps ? (
+                '설정 완료'
+              ) : (
+                <>
+                  다음
+                  <ChevronRight className="size-4" />
+                </>
+              )}
+            </Button>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default InitialSetupForm;

--- a/src/features/initial-setup/components/InitialSetupForm.tsx
+++ b/src/features/initial-setup/components/InitialSetupForm.tsx
@@ -117,9 +117,9 @@ const InitialSetupForm = () => {
   };
 
   return (
-    <div className="flex min-h-screen flex-col bg-(--baro-ivory)/30">
+    <div className="flex min-h-screen flex-col">
       {/* Header */}
-      <header className="flex items-center justify-between border-b border-gray-100 bg-white px-6 py-3.5">
+      <header className="flex items-center justify-between border-b border-gray-100 dark:border-gray-800 bg-background px-6 py-3.5">
         <div className="flex items-center gap-2.5">
           <img src={baroLogo} alt="BARO" className="h-7 w-auto" />
           <span className="text-sm font-semibold text-foreground">초기 설정</span>
@@ -141,7 +141,7 @@ const InitialSetupForm = () => {
 
           {/* Step card */}
           <Card className="shadow-sm">
-            <CardHeader className="border-b border-gray-100">
+            <CardHeader className="border-b">
               <div className="flex items-center gap-2">
                 <span className="flex size-6 items-center justify-center rounded-full bg-baro-blue text-xs font-bold text-white">
                   {currentStep}

--- a/src/features/initial-setup/components/SetupProgressBar.tsx
+++ b/src/features/initial-setup/components/SetupProgressBar.tsx
@@ -15,7 +15,7 @@ const SetupProgressBar = ({ currentStep }: SetupProgressBarProps) => {
     <div className="w-full px-1">
       <div className="relative flex items-start justify-between">
         {/* Background line */}
-        <div className="absolute left-4 right-4 top-4 h-0.5 -translate-y-1/2 bg-gray-200" />
+        <div className="absolute left-4 right-4 top-4 h-0.5 -translate-y-1/2 bg-gray-200 dark:bg-baro-black-muted" />
         {/* Progress line */}
         <div
           className="absolute left-4 top-4 h-0.5 -translate-y-1/2 bg-baro-blue transition-all duration-500"
@@ -35,8 +35,8 @@ const SetupProgressBar = ({ currentStep }: SetupProgressBarProps) => {
                   isCompleted
                     ? 'border-baro-blue bg-baro-blue text-white'
                     : isActive
-                      ? 'border-baro-blue bg-white text-baro-blue'
-                      : 'border-gray-200 bg-white text-gray-400',
+                      ? 'border-baro-blue bg-background text-baro-blue'
+                      : 'border-gray-200 dark:border-baro-black-muted bg-background text-gray-400 dark:text-baro-black-muted',
                 )}
               >
                 {isCompleted ? <Check className="size-3.5" strokeWidth={3} /> : step.id}
@@ -44,11 +44,7 @@ const SetupProgressBar = ({ currentStep }: SetupProgressBarProps) => {
               <span
                 className={cn(
                   'hidden text-center text-[10px] font-medium leading-tight sm:block',
-                  isActive
-                    ? 'text-baro-blue'
-                    : isCompleted
-                      ? 'text-(--baro-blue)/70'
-                      : 'text-gray-400',
+                  isActive ? 'text-baro-blue' : isCompleted ? 'text-baro-blue/70' : 'text-gray-400',
                 )}
               >
                 {step.title}

--- a/src/features/initial-setup/components/SetupProgressBar.tsx
+++ b/src/features/initial-setup/components/SetupProgressBar.tsx
@@ -1,0 +1,64 @@
+import { Check } from 'lucide-react';
+
+import { SETUP_STEPS } from '@/features/initial-setup/constants/initialSetup.constants';
+import { cn } from '@/lib/utils';
+
+interface SetupProgressBarProps {
+  currentStep: number;
+}
+
+const SetupProgressBar = ({ currentStep }: SetupProgressBarProps) => {
+  const totalSteps = SETUP_STEPS.length;
+  const progressPercent = ((currentStep - 1) / (totalSteps - 1)) * 100;
+
+  return (
+    <div className="w-full px-1">
+      <div className="relative flex items-start justify-between">
+        {/* Background line */}
+        <div className="absolute left-4 right-4 top-4 h-0.5 -translate-y-1/2 bg-gray-200" />
+        {/* Progress line */}
+        <div
+          className="absolute left-4 top-4 h-0.5 -translate-y-1/2 bg-baro-blue transition-all duration-500"
+          style={{ width: `calc(${progressPercent / 100} * (100% - 2rem))` }}
+        />
+
+        {/* Step circles */}
+        {SETUP_STEPS.map((step) => {
+          const isCompleted = step.id < currentStep;
+          const isActive = step.id === currentStep;
+
+          return (
+            <div key={step.id} className="relative z-10 flex flex-col items-center gap-1.5">
+              <div
+                className={cn(
+                  'flex size-8 items-center justify-center rounded-full border-2 text-xs font-semibold transition-all duration-300',
+                  isCompleted
+                    ? 'border-baro-blue bg-baro-blue text-white'
+                    : isActive
+                      ? 'border-baro-blue bg-white text-baro-blue'
+                      : 'border-gray-200 bg-white text-gray-400',
+                )}
+              >
+                {isCompleted ? <Check className="size-3.5" strokeWidth={3} /> : step.id}
+              </div>
+              <span
+                className={cn(
+                  'hidden text-center text-[10px] font-medium leading-tight sm:block',
+                  isActive
+                    ? 'text-baro-blue'
+                    : isCompleted
+                      ? 'text-(--baro-blue)/70'
+                      : 'text-gray-400',
+                )}
+              >
+                {step.title}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default SetupProgressBar;

--- a/src/features/initial-setup/components/steps/StepBasicInfo.tsx
+++ b/src/features/initial-setup/components/steps/StepBasicInfo.tsx
@@ -1,0 +1,79 @@
+import {
+  BUSINESS_TYPE_OPTIONS,
+  STORE_CATEGORY_OPTIONS,
+} from '@/features/initial-setup/constants/initialSetup.constants';
+import type { StoreBasicInfo } from '@/features/initial-setup/types/initialSetup.types';
+import { Input } from '@/shadcn/ui/input';
+import { Label } from '@/shadcn/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/shadcn/ui/select';
+
+interface StepBasicInfoProps {
+  data: StoreBasicInfo;
+  onChange: (data: StoreBasicInfo) => void;
+  errors: Partial<Record<keyof StoreBasicInfo, string>>;
+}
+
+const StepBasicInfo = ({ data, onChange, errors }: StepBasicInfoProps) => {
+  return (
+    <div className="space-y-5">
+      <div className="space-y-1.5">
+        <Label htmlFor="storeName">
+          가게 이름 <span className="text-red-500">*</span>
+        </Label>
+        <Input
+          id="storeName"
+          placeholder="예: 바로 카페 홍대점"
+          value={data.storeName}
+          onChange={(e) => onChange({ ...data, storeName: e.target.value })}
+          aria-invalid={!!errors.storeName}
+          className="h-10"
+        />
+        {errors.storeName && <p className="text-xs text-destructive">{errors.storeName}</p>}
+      </div>
+
+      <div className="space-y-1.5">
+        <Label>업종 타입</Label>
+        <Select
+          value={data.businessType}
+          onValueChange={(val) =>
+            val && onChange({ ...data, businessType: val as StoreBasicInfo['businessType'] })
+          }
+        >
+          <SelectTrigger className="h-10 w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {BUSINESS_TYPE_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label>가게 카테고리</Label>
+        <Select
+          value={data.category}
+          onValueChange={(val) =>
+            val && onChange({ ...data, category: val as StoreBasicInfo['category'] })
+          }
+        >
+          <SelectTrigger className="h-10 w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {STORE_CATEGORY_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+};
+
+export default StepBasicInfo;

--- a/src/features/initial-setup/components/steps/StepKeyIngredients.tsx
+++ b/src/features/initial-setup/components/steps/StepKeyIngredients.tsx
@@ -29,9 +29,9 @@ const StepKeyIngredients = ({ data, onChange }: StepKeyIngredientsProps) => {
 
   return (
     <div className="space-y-4">
-      <div className="flex items-start gap-2 rounded-lg bg-(--baro-blue)/8 p-3">
+      <div className="flex items-start gap-2 rounded-lg bg-baro-blue/8 p-3">
         <AlertCircle className="mt-0.5 size-4 shrink-0 text-baro-blue" />
-        <p className="text-xs leading-relaxed text-(--baro-blue)/80">
+        <p className="text-xs leading-relaxed text-baro-blue/80">
           최소 재고 기준을 설정하면 재고가 기준 이하로 떨어질 때 알림을 받을 수 있어요
         </p>
       </div>
@@ -53,7 +53,7 @@ const StepKeyIngredients = ({ data, onChange }: StepKeyIngredientsProps) => {
           {data.map((item) => (
             <div
               key={item.id}
-              className="grid grid-cols-[1fr_100px_88px_32px] items-center gap-2 rounded-lg border border-gray-100 bg-gray-50/50 px-2 py-1.5"
+              className="grid grid-cols-[1fr_100px_88px_32px] items-center gap-2 rounded-lg border px-2 py-1.5"
             >
               <Input
                 placeholder="예: 원두"

--- a/src/features/initial-setup/components/steps/StepKeyIngredients.tsx
+++ b/src/features/initial-setup/components/steps/StepKeyIngredients.tsx
@@ -16,7 +16,7 @@ const generateId = () => Math.random().toString(36).slice(2, 9);
 
 const StepKeyIngredients = ({ data, onChange }: StepKeyIngredientsProps) => {
   const addIngredient = () => {
-    onChange([...data, { id: generateId(), name: '', minStockAmount: 0, unit: 'g' }]);
+    onChange([...data, { id: generateId(), name: '', minStockAmount: 0, unit: '개' }]);
   };
 
   const removeIngredient = (id: string) => {

--- a/src/features/initial-setup/components/steps/StepKeyIngredients.tsx
+++ b/src/features/initial-setup/components/steps/StepKeyIngredients.tsx
@@ -1,0 +1,117 @@
+import { AlertCircle, Plus, Trash2 } from 'lucide-react';
+
+import { INGREDIENT_UNITS } from '@/features/initial-setup/constants/initialSetup.constants';
+import type { KeyIngredient } from '@/features/initial-setup/types/initialSetup.types';
+import { Button } from '@/shadcn/ui/button';
+import { Input } from '@/shadcn/ui/input';
+import { Label } from '@/shadcn/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/shadcn/ui/select';
+
+interface StepKeyIngredientsProps {
+  data: KeyIngredient[];
+  onChange: (data: KeyIngredient[]) => void;
+}
+
+const generateId = () => Math.random().toString(36).slice(2, 9);
+
+const StepKeyIngredients = ({ data, onChange }: StepKeyIngredientsProps) => {
+  const addIngredient = () => {
+    onChange([...data, { id: generateId(), name: '', minStockAmount: 0, unit: 'g' }]);
+  };
+
+  const removeIngredient = (id: string) => {
+    onChange(data.filter((item) => item.id !== id));
+  };
+
+  const updateIngredient = (id: string, updated: Partial<KeyIngredient>) => {
+    onChange(data.map((item) => (item.id === id ? { ...item, ...updated } : item)));
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-start gap-2 rounded-lg bg-(--baro-blue)/8 p-3">
+        <AlertCircle className="mt-0.5 size-4 shrink-0 text-baro-blue" />
+        <p className="text-xs leading-relaxed text-(--baro-blue)/80">
+          최소 재고 기준을 설정하면 재고가 기준 이하로 떨어질 때 알림을 받을 수 있어요
+        </p>
+      </div>
+
+      {data.length === 0 ? (
+        <div className="flex flex-col items-center gap-2 rounded-lg border-2 border-dashed border-gray-200 py-10 text-center">
+          <p className="text-sm text-muted-foreground">등록된 식자재가 없습니다</p>
+          <p className="text-xs text-muted-foreground">관리할 주요 식자재를 추가해주세요</p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          <div className="grid grid-cols-[1fr_100px_88px_32px] gap-2 px-2">
+            <Label className="text-xs text-muted-foreground">식자재 이름</Label>
+            <Label className="text-xs text-muted-foreground">최소 재고</Label>
+            <Label className="text-xs text-muted-foreground">단위</Label>
+            <span />
+          </div>
+
+          {data.map((item) => (
+            <div
+              key={item.id}
+              className="grid grid-cols-[1fr_100px_88px_32px] items-center gap-2 rounded-lg border border-gray-100 bg-gray-50/50 px-2 py-1.5"
+            >
+              <Input
+                placeholder="예: 원두"
+                value={item.name}
+                onChange={(e) => updateIngredient(item.id, { name: e.target.value })}
+                className="h-8 bg-white"
+              />
+              <Input
+                type="number"
+                placeholder="0"
+                min={0}
+                value={item.minStockAmount === 0 ? '' : item.minStockAmount}
+                onChange={(e) =>
+                  updateIngredient(item.id, { minStockAmount: parseFloat(e.target.value) || 0 })
+                }
+                className="h-8 bg-white"
+              />
+              <Select
+                value={item.unit}
+                onValueChange={(val) =>
+                  val && updateIngredient(item.id, { unit: val as KeyIngredient['unit'] })
+                }
+              >
+                <SelectTrigger className="h-8 w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {INGREDIENT_UNITS.map((unit) => (
+                    <SelectItem key={unit} value={unit}>
+                      {unit}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <button
+                type="button"
+                onClick={() => removeIngredient(item.id)}
+                className="flex items-center justify-center rounded p-1 text-gray-400 transition-colors hover:bg-red-50 hover:text-red-500"
+              >
+                <Trash2 className="size-4" />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={addIngredient}
+        className="w-full gap-1.5 border-dashed"
+      >
+        <Plus className="size-4" />
+        식자재 추가
+      </Button>
+    </div>
+  );
+};
+
+export default StepKeyIngredients;

--- a/src/features/initial-setup/components/steps/StepMenuRegistration.tsx
+++ b/src/features/initial-setup/components/steps/StepMenuRegistration.tsx
@@ -44,7 +44,7 @@ const StepMenuRegistration = ({ data, onChange }: StepMenuRegistrationProps) => 
           {data.map((item) => (
             <div
               key={item.id}
-              className="grid grid-cols-[1fr_110px_36px_36px] items-center gap-2 rounded-lg border border-gray-100 bg-gray-50/50 px-2 py-1.5"
+              className="grid grid-cols-[1fr_110px_36px_36px] items-center gap-2 rounded-lg border px-2 py-1.5"
             >
               <Input
                 placeholder="메뉴 이름"

--- a/src/features/initial-setup/components/steps/StepMenuRegistration.tsx
+++ b/src/features/initial-setup/components/steps/StepMenuRegistration.tsx
@@ -1,0 +1,103 @@
+import { Plus, Star, Trash2 } from 'lucide-react';
+
+import type { MenuItem } from '@/features/initial-setup/types/initialSetup.types';
+import { Button } from '@/shadcn/ui/button';
+import { Input } from '@/shadcn/ui/input';
+import { Label } from '@/shadcn/ui/label';
+
+interface StepMenuRegistrationProps {
+  data: MenuItem[];
+  onChange: (data: MenuItem[]) => void;
+}
+
+const generateId = () => Math.random().toString(36).slice(2, 9);
+
+const StepMenuRegistration = ({ data, onChange }: StepMenuRegistrationProps) => {
+  const addMenu = () => {
+    onChange([...data, { id: generateId(), name: '', price: 0, isFeatured: false }]);
+  };
+
+  const removeMenu = (id: string) => {
+    onChange(data.filter((item) => item.id !== id));
+  };
+
+  const updateMenu = (id: string, updated: Partial<MenuItem>) => {
+    onChange(data.map((item) => (item.id === id ? { ...item, ...updated } : item)));
+  };
+
+  return (
+    <div className="space-y-4">
+      {data.length === 0 ? (
+        <div className="flex flex-col items-center gap-2 rounded-lg border-2 border-dashed border-gray-200 py-10 text-center">
+          <p className="text-sm text-muted-foreground">등록된 메뉴가 없습니다</p>
+          <p className="text-xs text-muted-foreground">아래 버튼으로 메뉴를 추가해주세요</p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          <div className="grid grid-cols-[1fr_110px_36px_36px] items-center gap-2 px-2">
+            <Label className="text-xs text-muted-foreground">메뉴 이름</Label>
+            <Label className="text-xs text-muted-foreground">가격 (원)</Label>
+            <Label className="text-center text-xs text-muted-foreground">대표</Label>
+            <span />
+          </div>
+
+          {data.map((item) => (
+            <div
+              key={item.id}
+              className="grid grid-cols-[1fr_110px_36px_36px] items-center gap-2 rounded-lg border border-gray-100 bg-gray-50/50 px-2 py-1.5"
+            >
+              <Input
+                placeholder="메뉴 이름"
+                value={item.name}
+                onChange={(e) => updateMenu(item.id, { name: e.target.value })}
+                className="h-8 bg-white"
+              />
+              <Input
+                type="number"
+                placeholder="0"
+                min={0}
+                value={item.price === 0 ? '' : item.price}
+                onChange={(e) => updateMenu(item.id, { price: parseInt(e.target.value) || 0 })}
+                className="h-8 bg-white"
+              />
+              <button
+                type="button"
+                onClick={() => updateMenu(item.id, { isFeatured: !item.isFeatured })}
+                title={item.isFeatured ? '대표 메뉴 해제' : '대표 메뉴 설정'}
+                className="flex items-center justify-center"
+              >
+                <Star
+                  className={
+                    item.isFeatured
+                      ? 'size-5 fill-yellow-400 text-yellow-400'
+                      : 'size-5 text-gray-300 transition-colors hover:text-yellow-300'
+                  }
+                />
+              </button>
+              <button
+                type="button"
+                onClick={() => removeMenu(item.id)}
+                className="flex items-center justify-center rounded p-1 text-gray-400 transition-colors hover:bg-red-50 hover:text-red-500"
+              >
+                <Trash2 className="size-4" />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={addMenu}
+        className="w-full gap-1.5 border-dashed"
+      >
+        <Plus className="size-4" />
+        메뉴 추가
+      </Button>
+    </div>
+  );
+};
+
+export default StepMenuRegistration;

--- a/src/features/initial-setup/components/steps/StepNotifications.tsx
+++ b/src/features/initial-setup/components/steps/StepNotifications.tsx
@@ -1,0 +1,92 @@
+import { Bell } from 'lucide-react';
+
+import { NOTIFICATION_CHANNELS } from '@/features/initial-setup/constants/initialSetup.constants';
+import { ALERT_TYPE_CONFIG } from '@/features/initial-setup/constants/initialSetup.constants.ui';
+import type {
+  AlertKey,
+  ChannelKey,
+  NotificationSettings,
+} from '@/features/initial-setup/types/initialSetup.types';
+import { cn } from '@/lib/utils';
+import { Checkbox } from '@/shadcn/ui/checkbox';
+import { Separator } from '@/shadcn/ui/separator';
+import { Switch } from '@/shadcn/ui/switch';
+
+interface StepNotificationsProps {
+  data: NotificationSettings;
+  onChange: (data: NotificationSettings) => void;
+}
+
+const StepNotifications = ({ data, onChange }: StepNotificationsProps) => {
+  const updateAlert = (key: AlertKey, value: boolean) => {
+    onChange({ ...data, [key]: value });
+  };
+
+  const updateChannel = (key: ChannelKey, value: boolean) => {
+    onChange({ ...data, alertChannels: { ...data.alertChannels, [key]: value } });
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="mb-3 flex items-center gap-1.5 text-sm font-medium text-foreground">
+          <Bell className="size-4 text-baro-blue" />
+          알림 유형
+        </h3>
+        <div className="space-y-2.5">
+          {ALERT_TYPE_CONFIG.map(({ key, icon: Icon, title, description }) => (
+            <div
+              key={key}
+              className={cn(
+                'flex items-start justify-between gap-4 rounded-lg border p-3.5 transition-colors',
+                data[key]
+                  ? 'border-(--baro-blue)/25 bg-(--baro-blue)/5'
+                  : 'border-gray-100 bg-gray-50',
+              )}
+            >
+              <div className="flex items-start gap-3">
+                <div
+                  className={cn(
+                    'mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-lg transition-colors',
+                    data[key] ? 'bg-baro-blue text-white' : 'bg-gray-200 text-gray-400',
+                  )}
+                >
+                  <Icon className="size-4" />
+                </div>
+                <div>
+                  <p className="text-sm font-medium text-foreground">{title}</p>
+                  <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">
+                    {description}
+                  </p>
+                </div>
+              </div>
+              <Switch
+                checked={data[key]}
+                onCheckedChange={(checked) => updateAlert(key, checked)}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <Separator />
+
+      <div>
+        <h3 className="mb-3 text-sm font-medium text-foreground">알림 수단</h3>
+        <div className="flex flex-wrap gap-5">
+          {NOTIFICATION_CHANNELS.map(({ key, label }) => (
+            <label key={key} className="flex cursor-pointer items-center gap-2">
+              <Checkbox
+                checked={data.alertChannels[key]}
+                onCheckedChange={(checked) => updateChannel(key, !!checked)}
+              />
+              <span className="text-sm text-foreground">{label}</span>
+            </label>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default StepNotifications;

--- a/src/features/initial-setup/components/steps/StepNotifications.tsx
+++ b/src/features/initial-setup/components/steps/StepNotifications.tsx
@@ -40,15 +40,15 @@ const StepNotifications = ({ data, onChange }: StepNotificationsProps) => {
               className={cn(
                 'flex items-start justify-between gap-4 rounded-lg border p-3.5 transition-colors',
                 data[key]
-                  ? 'border-(--baro-blue)/25 bg-(--baro-blue)/5'
-                  : 'border-gray-100 bg-gray-50',
+                  ? 'border-baro-blue/25 bg-baro-blue/5'
+                  : 'border-gray-100 bg-gray-50 dark:bg-baro-black dark:border-baro-black/60',
               )}
             >
               <div className="flex items-start gap-3">
                 <div
                   className={cn(
                     'mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-lg transition-colors',
-                    data[key] ? 'bg-baro-blue text-white' : 'bg-gray-200 text-gray-400',
+                    data[key] ? 'bg-baro-blue text-white' : 'bg-gray-200  text-gray-400',
                   )}
                 >
                   <Icon className="size-4" />

--- a/src/features/initial-setup/components/steps/StepOperatingHours.tsx
+++ b/src/features/initial-setup/components/steps/StepOperatingHours.tsx
@@ -1,0 +1,88 @@
+import { Clock } from 'lucide-react';
+
+import { DAY_OF_WEEK_CONFIG } from '@/features/initial-setup/constants/initialSetup.constants';
+import type { OperatingHour } from '@/features/initial-setup/types/initialSetup.types';
+import { cn } from '@/lib/utils';
+import { Switch } from '@/shadcn/ui/switch';
+
+interface StepOperatingHoursProps {
+  data: OperatingHour[];
+  onChange: (data: OperatingHour[]) => void;
+}
+
+interface TimeInputProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const TimeInput = ({ value, onChange }: TimeInputProps) => (
+  <div className="relative flex items-center">
+    <Clock className="pointer-events-none absolute left-2.5 size-3.5 text-muted-foreground" />
+    <input
+      type="time"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className="h-8 w-36 rounded-lg border border-input bg-white pl-8 pr-3 text-sm outline-none transition-colors focus:border-baro-blue focus:ring-2 focus:ring-(--baro-blue)/20"
+    />
+  </div>
+);
+
+const StepOperatingHours = ({ data, onChange }: StepOperatingHoursProps) => {
+  const handleUpdate = (index: number, updated: Partial<OperatingHour>) => {
+    onChange(data.map((hour, i) => (i === index ? { ...hour, ...updated } : hour)));
+  };
+
+  return (
+    <div className="space-y-2">
+      {DAY_OF_WEEK_CONFIG.map((day, index) => {
+        const hour = data[index];
+        const isSat = day.value === 'saturday';
+        const isSun = day.value === 'sunday';
+
+        return (
+          <div
+            key={day.value}
+            className={cn(
+              'flex items-center gap-3 rounded-lg border px-3 py-2.5 transition-colors',
+              hour.isOpen
+                ? 'border-(--baro-blue)/25 bg-(--baro-blue)/5'
+                : 'border-gray-100 bg-gray-50/80',
+            )}
+          >
+            <span
+              className={cn(
+                'w-14 shrink-0 text-sm font-medium',
+                isSat ? 'text-blue-500' : isSun ? 'text-red-500' : 'text-foreground',
+              )}
+            >
+              {day.label}
+            </span>
+
+            <Switch
+              checked={hour.isOpen}
+              onCheckedChange={(checked) => handleUpdate(index, { isOpen: checked })}
+            />
+
+            {hour.isOpen ? (
+              <div className="flex flex-1 items-center gap-2">
+                <TimeInput
+                  value={hour.openTime}
+                  onChange={(v) => handleUpdate(index, { openTime: v })}
+                />
+                <span className="text-xs text-muted-foreground">~</span>
+                <TimeInput
+                  value={hour.closeTime}
+                  onChange={(v) => handleUpdate(index, { closeTime: v })}
+                />
+              </div>
+            ) : (
+              <span className="flex-1 text-sm text-muted-foreground">휴무</span>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default StepOperatingHours;

--- a/src/features/initial-setup/components/steps/StepOperatingHours.tsx
+++ b/src/features/initial-setup/components/steps/StepOperatingHours.tsx
@@ -22,7 +22,7 @@ const TimeInput = ({ value, onChange }: TimeInputProps) => (
       type="time"
       value={value}
       onChange={(e) => onChange(e.target.value)}
-      className="h-8 w-36 rounded-lg border border-input bg-white pl-8 pr-3 text-sm outline-none transition-colors focus:border-baro-blue focus:ring-2 focus:ring-(--baro-blue)/20"
+      className="h-8 w-36 rounded-lg border border-input pl-8 pr-3 text-sm outline-none transition-colors focus:border-baro-blue focus:ring-2 focus:ring-baro-blue/20"
     />
   </div>
 );
@@ -45,8 +45,8 @@ const StepOperatingHours = ({ data, onChange }: StepOperatingHoursProps) => {
             className={cn(
               'flex items-center gap-3 rounded-lg border px-3 py-2.5 transition-colors',
               hour.isOpen
-                ? 'border-(--baro-blue)/25 bg-(--baro-blue)/5'
-                : 'border-gray-100 bg-gray-50/80',
+                ? 'border-baro-blue/25 bg-baro-blue/5 dark:border-baro-blue-dark/15 dark:bg-baro-blue-dark/3'
+                : 'border-gray-100 bg-gray-50/80 dark:bg-baro-black/80 dark:border-baro-black',
             )}
           >
             <span

--- a/src/features/initial-setup/components/steps/StepRecipeInfo.tsx
+++ b/src/features/initial-setup/components/steps/StepRecipeInfo.tsx
@@ -38,7 +38,7 @@ const StepRecipeInfo = ({ menuItems, recipes, onChange }: StepRecipeInfoProps) =
       id: generateId(),
       ingredientName: '',
       amount: 0,
-      unit: 'g',
+      unit: '개',
     };
     updateRecipe({ ...recipe, ingredients: [...recipe.ingredients, newIngredient] });
   };

--- a/src/features/initial-setup/components/steps/StepRecipeInfo.tsx
+++ b/src/features/initial-setup/components/steps/StepRecipeInfo.tsx
@@ -1,0 +1,184 @@
+import { Plus, Trash2 } from 'lucide-react';
+
+import { INGREDIENT_UNITS } from '@/features/initial-setup/constants/initialSetup.constants';
+import type {
+  MenuItem,
+  Recipe,
+  RecipeIngredient,
+} from '@/features/initial-setup/types/initialSetup.types';
+import { Button } from '@/shadcn/ui/button';
+import { Input } from '@/shadcn/ui/input';
+import { Label } from '@/shadcn/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/shadcn/ui/select';
+
+interface StepRecipeInfoProps {
+  menuItems: MenuItem[];
+  recipes: Recipe[];
+  onChange: (recipes: Recipe[]) => void;
+}
+
+const generateId = () => Math.random().toString(36).slice(2, 9);
+
+const StepRecipeInfo = ({ menuItems, recipes, onChange }: StepRecipeInfoProps) => {
+  const getRecipe = (menuItemId: string): Recipe =>
+    recipes.find((r) => r.menuItemId === menuItemId) ?? { menuItemId, ingredients: [] };
+
+  const updateRecipe = (updatedRecipe: Recipe) => {
+    const exists = recipes.some((r) => r.menuItemId === updatedRecipe.menuItemId);
+    if (exists) {
+      onChange(recipes.map((r) => (r.menuItemId === updatedRecipe.menuItemId ? updatedRecipe : r)));
+    } else {
+      onChange([...recipes, updatedRecipe]);
+    }
+  };
+
+  const addIngredient = (menuItemId: string) => {
+    const recipe = getRecipe(menuItemId);
+    const newIngredient: RecipeIngredient = {
+      id: generateId(),
+      ingredientName: '',
+      amount: 0,
+      unit: 'g',
+    };
+    updateRecipe({ ...recipe, ingredients: [...recipe.ingredients, newIngredient] });
+  };
+
+  const removeIngredient = (menuItemId: string, ingredientId: string) => {
+    const recipe = getRecipe(menuItemId);
+    updateRecipe({
+      ...recipe,
+      ingredients: recipe.ingredients.filter((i) => i.id !== ingredientId),
+    });
+  };
+
+  const updateIngredient = (
+    menuItemId: string,
+    ingredientId: string,
+    updated: Partial<RecipeIngredient>,
+  ) => {
+    const recipe = getRecipe(menuItemId);
+    updateRecipe({
+      ...recipe,
+      ingredients: recipe.ingredients.map((i) =>
+        i.id === ingredientId ? { ...i, ...updated } : i,
+      ),
+    });
+  };
+
+  if (menuItems.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-2 rounded-lg border-2 border-dashed border-gray-200 py-10 text-center">
+        <p className="text-sm text-muted-foreground">등록된 메뉴가 없습니다</p>
+        <p className="text-xs text-muted-foreground">이전 단계에서 메뉴를 먼저 등록해주세요</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {menuItems.map((menu) => {
+        const recipe = getRecipe(menu.id);
+
+        return (
+          <div key={menu.id} className="overflow-hidden rounded-xl border border-gray-200">
+            <div className="flex items-center justify-between bg-gray-50 px-4 py-2.5">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium">{menu.name || '(이름 없음)'}</span>
+                {menu.isFeatured && (
+                  <span className="rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-700">
+                    대표
+                  </span>
+                )}
+              </div>
+              <span className="text-xs text-muted-foreground">
+                식자재 {recipe.ingredients.length}개
+              </span>
+            </div>
+
+            <div className="space-y-2 p-3">
+              {recipe.ingredients.length > 0 && (
+                <>
+                  <div className="grid grid-cols-[1fr_80px_88px_32px] gap-2 px-1">
+                    <Label className="text-xs text-muted-foreground">식자재 이름</Label>
+                    <Label className="text-xs text-muted-foreground">사용량</Label>
+                    <Label className="text-xs text-muted-foreground">단위</Label>
+                    <span />
+                  </div>
+                  {recipe.ingredients.map((ingredient) => (
+                    <div
+                      key={ingredient.id}
+                      className="grid grid-cols-[1fr_80px_88px_32px] items-center gap-2"
+                    >
+                      <Input
+                        placeholder="식자재 이름"
+                        value={ingredient.ingredientName}
+                        onChange={(e) =>
+                          updateIngredient(menu.id, ingredient.id, {
+                            ingredientName: e.target.value,
+                          })
+                        }
+                        className="h-8"
+                      />
+                      <Input
+                        type="number"
+                        placeholder="0"
+                        min={0}
+                        value={ingredient.amount === 0 ? '' : ingredient.amount}
+                        onChange={(e) =>
+                          updateIngredient(menu.id, ingredient.id, {
+                            amount: parseFloat(e.target.value) || 0,
+                          })
+                        }
+                        className="h-8"
+                      />
+                      <Select
+                        value={ingredient.unit}
+                        onValueChange={(val) =>
+                          val &&
+                          updateIngredient(menu.id, ingredient.id, {
+                            unit: val as RecipeIngredient['unit'],
+                          })
+                        }
+                      >
+                        <SelectTrigger className="h-8 w-full">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {INGREDIENT_UNITS.map((unit) => (
+                            <SelectItem key={unit} value={unit}>
+                              {unit}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <button
+                        type="button"
+                        onClick={() => removeIngredient(menu.id, ingredient.id)}
+                        className="flex items-center justify-center rounded p-1 text-gray-400 transition-colors hover:bg-red-50 hover:text-red-500"
+                      >
+                        <Trash2 className="size-4" />
+                      </button>
+                    </div>
+                  ))}
+                </>
+              )}
+
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => addIngredient(menu.id)}
+                className="w-full gap-1.5 border border-dashed text-xs text-muted-foreground"
+              >
+                <Plus className="size-3.5" />
+                식자재 추가
+              </Button>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default StepRecipeInfo;

--- a/src/features/initial-setup/components/steps/StepRecipeInfo.tsx
+++ b/src/features/initial-setup/components/steps/StepRecipeInfo.tsx
@@ -80,8 +80,8 @@ const StepRecipeInfo = ({ menuItems, recipes, onChange }: StepRecipeInfoProps) =
         const recipe = getRecipe(menu.id);
 
         return (
-          <div key={menu.id} className="overflow-hidden rounded-xl border border-gray-200">
-            <div className="flex items-center justify-between bg-gray-50 px-4 py-2.5">
+          <div key={menu.id} className="overflow-hidden rounded-xl border">
+            <div className="flex items-center justify-between px-4 py-2.5">
               <div className="flex items-center gap-2">
                 <span className="text-sm font-medium">{menu.name || '(이름 없음)'}</span>
                 {menu.isFeatured && (

--- a/src/features/initial-setup/constants/initialSetup.constants.ts
+++ b/src/features/initial-setup/constants/initialSetup.constants.ts
@@ -33,17 +33,7 @@ export const DAY_OF_WEEK_CONFIG: { value: DayOfWeek; label: string }[] = [
   { value: 'sunday', label: '일요일' },
 ];
 
-export const INGREDIENT_UNITS: IngredientUnit[] = [
-  'g',
-  'kg',
-  'ml',
-  'L',
-  '개',
-  '봉',
-  '팩',
-  '병',
-  '캔',
-];
+export const INGREDIENT_UNITS: IngredientUnit[] = ['개', '캔', '봉', '팩', '박스', '묶음'];
 
 export const NOTIFICATION_CHANNELS: { key: ChannelKey; label: string }[] = [
   { key: 'email', label: '이메일' },

--- a/src/features/initial-setup/constants/initialSetup.constants.ts
+++ b/src/features/initial-setup/constants/initialSetup.constants.ts
@@ -1,0 +1,61 @@
+import type {
+  BusinessType,
+  ChannelKey,
+  DayOfWeek,
+  IngredientUnit,
+  StoreCategory,
+} from '@/features/initial-setup/types/initialSetup.types';
+
+export const BUSINESS_TYPE_OPTIONS: { value: BusinessType; label: string }[] = [
+  { value: 'franchise', label: '프랜차이즈' },
+  { value: 'directly-operated', label: '직영' },
+  { value: 'individual', label: '개인' },
+];
+
+export const STORE_CATEGORY_OPTIONS: { value: StoreCategory; label: string }[] = [
+  { value: 'korean', label: '한식' },
+  { value: 'western', label: '양식' },
+  { value: 'cafe', label: '카페' },
+  { value: 'bunsik', label: '분식' },
+  { value: 'japanese', label: '일식' },
+  { value: 'chinese', label: '중식' },
+  { value: 'fastfood', label: '패스트푸드' },
+  { value: 'other', label: '기타' },
+];
+
+export const DAY_OF_WEEK_CONFIG: { value: DayOfWeek; label: string }[] = [
+  { value: 'monday', label: '월요일' },
+  { value: 'tuesday', label: '화요일' },
+  { value: 'wednesday', label: '수요일' },
+  { value: 'thursday', label: '목요일' },
+  { value: 'friday', label: '금요일' },
+  { value: 'saturday', label: '토요일' },
+  { value: 'sunday', label: '일요일' },
+];
+
+export const INGREDIENT_UNITS: IngredientUnit[] = [
+  'g',
+  'kg',
+  'ml',
+  'L',
+  '개',
+  '봉',
+  '팩',
+  '병',
+  '캔',
+];
+
+export const NOTIFICATION_CHANNELS: { key: ChannelKey; label: string }[] = [
+  { key: 'email', label: '이메일' },
+  { key: 'kakao', label: '카카오톡' },
+  { key: 'push', label: '앱 푸시' },
+];
+
+export const SETUP_STEPS = [
+  { id: 1, title: '가게 기본 정보', description: '가게 이름과 업종을 입력해주세요' },
+  { id: 2, title: '영업 시간', description: '영업 요일과 시간을 설정해주세요' },
+  { id: 3, title: '메뉴 등록', description: '대표 메뉴와 가격을 입력해주세요' },
+  { id: 4, title: '레시피 정보', description: '메뉴별 재료와 사용량을 입력해주세요' },
+  { id: 5, title: '주요 식자재', description: '주요 식자재와 최소 재고 기준을 설정해주세요' },
+  { id: 6, title: '알림 설정', description: '재고 및 발주 알림을 설정해주세요' },
+] as const;

--- a/src/features/initial-setup/constants/initialSetup.constants.ui.tsx
+++ b/src/features/initial-setup/constants/initialSetup.constants.ui.tsx
@@ -1,0 +1,29 @@
+import { Clock, Package, TrendingUp } from 'lucide-react';
+
+import type { AlertKey } from '@/features/initial-setup/types/initialSetup.types';
+
+export const ALERT_TYPE_CONFIG: {
+  key: AlertKey;
+  icon: React.ElementType;
+  title: string;
+  description: string;
+}[] = [
+  {
+    key: 'lowStockAlert',
+    icon: Package,
+    title: '재고 부족 알림',
+    description: '설정한 최소 재고 기준 이하로 떨어지면 알림을 보내드려요',
+  },
+  {
+    key: 'expiryAlert',
+    icon: Clock,
+    title: '유통기한 임박 알림',
+    description: '유통기한이 3일 이내로 남은 식자재가 있을 때 알림을 보내드려요',
+  },
+  {
+    key: 'orderRecommendationAlert',
+    icon: TrendingUp,
+    title: '발주 추천 알림',
+    description: 'AI가 분석한 소비 패턴을 기반으로 발주 시점을 알려드려요',
+  },
+];

--- a/src/features/initial-setup/data/initialSetup.mock.ts
+++ b/src/features/initial-setup/data/initialSetup.mock.ts
@@ -1,0 +1,36 @@
+import type {
+  InitialSetupData,
+  OperatingHour,
+} from '@/features/initial-setup/types/initialSetup.types';
+
+const DEFAULT_OPERATING_HOURS: OperatingHour[] = [
+  { dayOfWeek: 'monday', isOpen: true, openTime: '09:00', closeTime: '22:00' },
+  { dayOfWeek: 'tuesday', isOpen: true, openTime: '09:00', closeTime: '22:00' },
+  { dayOfWeek: 'wednesday', isOpen: true, openTime: '09:00', closeTime: '22:00' },
+  { dayOfWeek: 'thursday', isOpen: true, openTime: '09:00', closeTime: '22:00' },
+  { dayOfWeek: 'friday', isOpen: true, openTime: '09:00', closeTime: '22:00' },
+  { dayOfWeek: 'saturday', isOpen: true, openTime: '10:00', closeTime: '21:00' },
+  { dayOfWeek: 'sunday', isOpen: false, openTime: '10:00', closeTime: '21:00' },
+];
+
+export const DEFAULT_SETUP_DATA: InitialSetupData = {
+  basicInfo: {
+    storeName: '',
+    businessType: 'individual',
+    category: 'cafe',
+  },
+  operatingHours: DEFAULT_OPERATING_HOURS,
+  menuItems: [],
+  recipes: [],
+  keyIngredients: [],
+  notificationSettings: {
+    lowStockAlert: true,
+    expiryAlert: true,
+    orderRecommendationAlert: true,
+    alertChannels: {
+      email: false,
+      kakao: true,
+      push: true,
+    },
+  },
+};

--- a/src/features/initial-setup/types/initialSetup.types.ts
+++ b/src/features/initial-setup/types/initialSetup.types.ts
@@ -1,0 +1,85 @@
+export type BusinessType = 'franchise' | 'directly-operated' | 'individual';
+
+export type StoreCategory =
+  | 'korean'
+  | 'western'
+  | 'cafe'
+  | 'bunsik'
+  | 'japanese'
+  | 'chinese'
+  | 'fastfood'
+  | 'other';
+
+export type DayOfWeek =
+  | 'monday'
+  | 'tuesday'
+  | 'wednesday'
+  | 'thursday'
+  | 'friday'
+  | 'saturday'
+  | 'sunday';
+
+export type IngredientUnit = 'g' | 'kg' | 'ml' | 'L' | '개' | '봉' | '팩' | '병' | '캔';
+
+export interface StoreBasicInfo {
+  storeName: string;
+  businessType: BusinessType;
+  category: StoreCategory;
+}
+
+export interface OperatingHour {
+  dayOfWeek: DayOfWeek;
+  isOpen: boolean;
+  openTime: string;
+  closeTime: string;
+}
+
+export interface MenuItem {
+  id: string;
+  name: string;
+  price: number;
+  isFeatured: boolean;
+}
+
+export interface RecipeIngredient {
+  id: string;
+  ingredientName: string;
+  amount: number;
+  unit: IngredientUnit;
+}
+
+export interface Recipe {
+  menuItemId: string;
+  ingredients: RecipeIngredient[];
+}
+
+export interface KeyIngredient {
+  id: string;
+  name: string;
+  minStockAmount: number;
+  unit: IngredientUnit;
+}
+
+export interface NotificationSettings {
+  lowStockAlert: boolean;
+  expiryAlert: boolean;
+  orderRecommendationAlert: boolean;
+  alertChannels: {
+    email: boolean;
+    kakao: boolean;
+    push: boolean;
+  };
+}
+
+export type AlertKey = 'lowStockAlert' | 'expiryAlert' | 'orderRecommendationAlert';
+
+export type ChannelKey = keyof NotificationSettings['alertChannels'];
+
+export interface InitialSetupData {
+  basicInfo: StoreBasicInfo;
+  operatingHours: OperatingHour[];
+  menuItems: MenuItem[];
+  recipes: Recipe[];
+  keyIngredients: KeyIngredient[];
+  notificationSettings: NotificationSettings;
+}

--- a/src/features/initial-setup/types/initialSetup.types.ts
+++ b/src/features/initial-setup/types/initialSetup.types.ts
@@ -19,7 +19,7 @@ export type DayOfWeek =
   | 'saturday'
   | 'sunday';
 
-export type IngredientUnit = 'g' | 'kg' | 'ml' | 'L' | '개' | '봉' | '팩' | '병' | '캔';
+export type IngredientUnit = '개' | '봉' | '팩' | '병' | '캔' | '박스' | '묶음';
 
 export interface StoreBasicInfo {
   storeName: string;

--- a/src/pages/InitialSetupPage.tsx
+++ b/src/pages/InitialSetupPage.tsx
@@ -1,0 +1,7 @@
+import InitialSetupForm from '@/features/initial-setup/components/InitialSetupForm';
+
+const InitialSetupPage = () => {
+  return <InitialSetupForm />;
+};
+
+export default InitialSetupPage;

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -18,7 +18,7 @@ const LoginPage = () => {
   const navigate = useNavigate();
 
   const handleKakaoLoginClick = () => {
-    navigate(routePaths.dashboard);
+    navigate(routePaths.initialSetup);
   };
 
   const handleGoBackClick = () => {

--- a/src/shadcn/ui/checkbox.tsx
+++ b/src/shadcn/ui/checkbox.tsx
@@ -1,0 +1,26 @@
+import { Checkbox as CheckboxPrimitive } from '@base-ui/react/checkbox';
+
+import { cn } from '@/lib/utils';
+import { CheckIcon } from 'lucide-react';
+
+function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        'peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input transition-colors outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary',
+        className,
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none [&>svg]:size-3.5"
+      >
+        <CheckIcon />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
+}
+
+export { Checkbox };

--- a/src/shadcn/ui/checkbox.tsx
+++ b/src/shadcn/ui/checkbox.tsx
@@ -8,7 +8,7 @@ function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        'peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input transition-colors outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary',
+        'peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input transition-colors outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-baro-blue data-checked:bg-baro-blue data-checked:text-white dark:data-checked:bg-baro-blue',
         className,
       )}
       {...props}

--- a/src/shadcn/ui/dropdown-menu.tsx
+++ b/src/shadcn/ui/dropdown-menu.tsx
@@ -1,0 +1,266 @@
+import * as React from "react"
+import { Menu as MenuPrimitive } from "@base-ui/react/menu"
+
+import { cn } from "@/lib/utils"
+import { ChevronRightIcon, CheckIcon } from "lucide-react"
+
+function DropdownMenu({ ...props }: MenuPrimitive.Root.Props) {
+  return <MenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuPortal({ ...props }: MenuPrimitive.Portal.Props) {
+  return <MenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+}
+
+function DropdownMenuTrigger({ ...props }: MenuPrimitive.Trigger.Props) {
+  return <MenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />
+}
+
+function DropdownMenuContent({
+  align = "start",
+  alignOffset = 0,
+  side = "bottom",
+  sideOffset = 4,
+  className,
+  ...props
+}: MenuPrimitive.Popup.Props &
+  Pick<
+    MenuPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <MenuPrimitive.Portal>
+      <MenuPrimitive.Positioner
+        className="isolate z-50 outline-none"
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+      >
+        <MenuPrimitive.Popup
+          data-slot="dropdown-menu-content"
+          className={cn("z-50 max-h-(--available-height) w-(--anchor-width) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:overflow-hidden data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          {...props}
+        />
+      </MenuPrimitive.Positioner>
+    </MenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuGroup({ ...props }: MenuPrimitive.Group.Props) {
+  return <MenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: MenuPrimitive.GroupLabel.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.GroupLabel
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-1.5 py-1 text-xs font-medium text-muted-foreground data-inset:pl-7",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: MenuPrimitive.Item.Props & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <MenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "group/dropdown-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSub({ ...props }: MenuPrimitive.SubmenuRoot.Props) {
+  return <MenuPrimitive.SubmenuRoot data-slot="dropdown-menu-sub" {...props} />
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: MenuPrimitive.SubmenuTrigger.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.SubmenuTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-popup-open:bg-accent data-popup-open:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto" />
+    </MenuPrimitive.SubmenuTrigger>
+  )
+}
+
+function DropdownMenuSubContent({
+  align = "start",
+  alignOffset = -3,
+  side = "right",
+  sideOffset = 0,
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuContent>) {
+  return (
+    <DropdownMenuContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn("w-auto min-w-[96px] rounded-lg bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+      align={align}
+      alignOffset={alignOffset}
+      side={side}
+      sideOffset={sideOffset}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  inset,
+  ...props
+}: MenuPrimitive.CheckboxItem.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-checkbox-item-indicator"
+      >
+        <MenuPrimitive.CheckboxItemIndicator>
+          <CheckIcon
+          />
+        </MenuPrimitive.CheckboxItemIndicator>
+      </span>
+      {children}
+    </MenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuRadioGroup({ ...props }: MenuPrimitive.RadioGroup.Props) {
+  return (
+    <MenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  inset,
+  ...props
+}: MenuPrimitive.RadioItem.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-radio-item-indicator"
+      >
+        <MenuPrimitive.RadioItemIndicator>
+          <CheckIcon
+          />
+        </MenuPrimitive.RadioItemIndicator>
+      </span>
+      {children}
+    </MenuPrimitive.RadioItem>
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: MenuPrimitive.Separator.Props) {
+  return (
+    <MenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground group-focus/dropdown-menu-item:text-accent-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+}

--- a/src/shadcn/ui/input.tsx
+++ b/src/shadcn/ui/input.tsx
@@ -10,7 +10,7 @@ function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
       type={type}
       data-slot="input"
       className={cn(
-        'h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40',
+        'h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40',
         className,
       )}
       {...props}

--- a/src/shadcn/ui/select.tsx
+++ b/src/shadcn/ui/select.tsx
@@ -1,0 +1,188 @@
+import * as React from 'react';
+import { Select as SelectPrimitive } from '@base-ui/react/select';
+
+import { cn } from '@/lib/utils';
+import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from 'lucide-react';
+
+const Select = SelectPrimitive.Root;
+
+function SelectGroup({ className, ...props }: SelectPrimitive.Group.Props) {
+  return (
+    <SelectPrimitive.Group
+      data-slot="select-group"
+      className={cn('scroll-my-1 p-1', className)}
+      {...props}
+    />
+  );
+}
+
+function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
+  return (
+    <SelectPrimitive.Value
+      data-slot="select-value"
+      className={cn('flex flex-1 text-left', className)}
+      {...props}
+    />
+  );
+}
+
+function SelectTrigger({
+  className,
+  size = 'default',
+  children,
+  ...props
+}: SelectPrimitive.Trigger.Props & {
+  size?: 'sm' | 'default';
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon
+        render={<ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />}
+      />
+    </SelectPrimitive.Trigger>
+  );
+}
+
+function SelectContent({
+  className,
+  children,
+  side = 'bottom',
+  sideOffset = 4,
+  align = 'center',
+  alignOffset = 0,
+  alignItemWithTrigger = true,
+  ...props
+}: SelectPrimitive.Popup.Props &
+  Pick<
+    SelectPrimitive.Positioner.Props,
+    'align' | 'alignOffset' | 'side' | 'sideOffset' | 'alignItemWithTrigger'
+  >) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        alignItemWithTrigger={alignItemWithTrigger}
+        className="isolate z-50"
+      >
+        <SelectPrimitive.Popup
+          data-slot="select-content"
+          data-align-trigger={alignItemWithTrigger}
+          className={cn(
+            'relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+            className,
+          )}
+          {...props}
+        >
+          <SelectScrollUpButton />
+          <SelectPrimitive.List>{children}</SelectPrimitive.List>
+          <SelectScrollDownButton />
+        </SelectPrimitive.Popup>
+      </SelectPrimitive.Positioner>
+    </SelectPrimitive.Portal>
+  );
+}
+
+function SelectLabel({ className, ...props }: SelectPrimitive.GroupLabel.Props) {
+  return (
+    <SelectPrimitive.GroupLabel
+      data-slot="select-label"
+      className={cn('px-1.5 py-1 text-xs text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+function SelectItem({ className, children, ...props }: SelectPrimitive.Item.Props) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className,
+      )}
+      {...props}
+    >
+      <SelectPrimitive.ItemText className="flex flex-1 shrink-0 gap-2 whitespace-nowrap">
+        {children}
+      </SelectPrimitive.ItemText>
+      <SelectPrimitive.ItemIndicator
+        render={
+          <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />
+        }
+      >
+        <CheckIcon className="pointer-events-none" />
+      </SelectPrimitive.ItemIndicator>
+    </SelectPrimitive.Item>
+  );
+}
+
+function SelectSeparator({ className, ...props }: SelectPrimitive.Separator.Props) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn('pointer-events-none -mx-1 my-1 h-px bg-border', className)}
+      {...props}
+    />
+  );
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpArrow>) {
+  return (
+    <SelectPrimitive.ScrollUpArrow
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "top-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <ChevronUpIcon />
+    </SelectPrimitive.ScrollUpArrow>
+  );
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownArrow>) {
+  return (
+    <SelectPrimitive.ScrollDownArrow
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "bottom-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <ChevronDownIcon />
+    </SelectPrimitive.ScrollDownArrow>
+  );
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+};

--- a/src/shadcn/ui/switch.tsx
+++ b/src/shadcn/ui/switch.tsx
@@ -1,0 +1,30 @@
+import { Switch as SwitchPrimitive } from '@base-ui/react/switch';
+
+import { cn } from '@/lib/utils';
+
+function Switch({
+  className,
+  size = 'default',
+  ...props
+}: SwitchPrimitive.Root.Props & {
+  size?: 'sm' | 'default';
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        'peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 data-disabled:cursor-not-allowed data-disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className="pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] dark:data-checked:bg-primary-foreground group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 dark:data-unchecked:bg-foreground"
+      />
+    </SwitchPrimitive.Root>
+  );
+}
+
+export { Switch };

--- a/src/shadcn/ui/switch.tsx
+++ b/src/shadcn/ui/switch.tsx
@@ -14,7 +14,7 @@ function Switch({
       data-slot="switch"
       data-size={size}
       className={cn(
-        'peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 data-disabled:cursor-not-allowed data-disabled:opacity-50',
+        'peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-baro-blue data-unchecked:bg-input dark:data-unchecked:bg-input/80 data-disabled:cursor-not-allowed data-disabled:opacity-50',
         className,
       )}
       {...props}


### PR DESCRIPTION
## 📌 요약

- 가게 초기 세팅을 위한 6단계 스텝 폼 UI 구현 (`/initial-setup`)
- shadcn/ui 컴포넌트(checkbox, switch, select, dropdown-menu) 추가 설치 및 서비스 색상 적용
- 초기 세팅 페이지 다크모드 도입
- README 배너에 서비스 바로가기 및 테스트 서버 배지 추가

<br/>

## 🏷️ 관련 이슈

- Closes #27

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- `InitialSetupForm` 구현 — 가게 기본 정보 → 영업 시간 → 메뉴 등록 → 레시피 정보 → 주요 식자재 → 알림 설정 6단계 플로우
- `SetupProgressBar` 컴포넌트 — 현재 진행 단계 시각화
- 라우터에 `/initial-setup` 경로 추가, 로그인 시 해당 페이지로 임시 연결

<br/>

### 📂 세부 변경사항

- `features/initial-setup/components/` — `InitialSetupForm`, `SetupProgressBar`, 단계별 Step 컴포넌트 6개 추가
- `features/initial-setup/types/initialSetup.types.ts` — 초기 세팅 전체 타입 정의 (`InitialSetupData`, `StoreBasicInfo`, `OperatingHour`, `MenuItem`, `Recipe`, `KeyIngredient`, `NotificationSettings` 등)
- `features/initial-setup/constants/initialSetup.constants.ts` — 업종·카테고리·요일·단위·알림 채널 상수 및 `SETUP_STEPS` 정의
- `shadcn/ui/` — checkbox, switch, select, dropdown-menu 컴포넌트 추가; Input focus ring 제거; checkbox·switch 서비스 색상 적용
- `README.md` — 서비스 바로가기 및 테스트 서버 배지 추가

<br/>

## 📸 Screenshots

<!-- Before / After 비교 -->

| Before | After |
| ------ | ----- |
|        |       |

<br/>

## 🧪 테스트 방법

1. `/login` 접속 후 로그인 버튼 클릭 → `/initial-setup` 이동 확인
2. 각 단계별 입력 필드 동작 확인 (가게 정보, 영업 시간 토글, 메뉴 추가/삭제, 레시피 재료 입력, 식자재 최소 재고 설정, 알림 채널 선택)
3. 다크모드 전환 시 초기 세팅 페이지 스타일 깨짐 없음 확인
4. 6단계 완료 후 다음 단계 버튼 흐름 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [ ] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [x] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- 현재 로그인 후 `/initial-setup`으로 이동하는 로직은 임시 처리(`🤡`)이며, 실제 신규 사용자 판별 로직 구현 시 교체 필요
- OCR 연동 전 단계이므로 모든 입력은 수동 입력 기반