### PR TITLE
💄 (#57) ui: 대시보드 및 메인 헤더 다크모드 도입

### DIFF
--- a/src/features/dashboard/components/MemoCard.tsx
+++ b/src/features/dashboard/components/MemoCard.tsx
@@ -6,11 +6,13 @@ const MemoCard = () => {
   const [memo, setMemo] = useState('');
 
   return (
-    <div className="flex-1 flex flex-col bg-yellow-100 rounded-sm shadow-md relative overflow-hidden">
+    <div className="flex-1 flex flex-col bg-yellow-100 dark:bg-zinc-800 rounded-sm shadow-md relative overflow-hidden">
       {/* 포스트잇 상단 헤더 */}
-      <div className="shrink-0 bg-yellow-200 px-4 py-2.5 flex items-center gap-2 border-b border-yellow-300/60">
-        <PenLine className="w-3.5 h-3.5 text-yellow-700" />
-        <span className="text-xs font-semibold text-yellow-800 tracking-wide">메모</span>
+      <div className="shrink-0 bg-yellow-200 dark:bg-zinc-700 px-4 py-2.5 flex items-center gap-2 border-b border-yellow-300/60 dark:border-zinc-600">
+        <PenLine className="w-3.5 h-3.5 text-yellow-700 dark:text-zinc-300" />
+        <span className="text-xs font-semibold text-yellow-800 dark:text-zinc-300 tracking-wide">
+          메모
+        </span>
       </div>
 
       {/* 본문 */}
@@ -18,10 +20,11 @@ const MemoCard = () => {
         <textarea
           className="
             flex-1 w-full resize-none bg-transparent
-            text-sm leading-7 text-yellow-950
-            placeholder:text-yellow-700/40
+            text-sm leading-7 text-yellow-950 dark:text-zinc-100
+            placeholder:text-yellow-700/40 dark:placeholder:text-zinc-500
             focus:outline-none
             bg-[repeating-linear-gradient(transparent,transparent_calc(1.75rem-1px),#ca8a0428_calc(1.75rem-1px),#ca8a0428_1.75rem)]
+            dark:bg-[repeating-linear-gradient(transparent,transparent_calc(1.75rem-1px),rgba(113,113,122,0.2)_calc(1.75rem-1px),rgba(113,113,122,0.2)_1.75rem)]
           "
           placeholder={'오늘의 메모를 남겨보세요\n(예: 오후 2시 재고 실사)'}
           value={memo}
@@ -30,8 +33,8 @@ const MemoCard = () => {
       </div>
 
       {/* 접힌 모서리 효과 */}
-      <div className="absolute bottom-0 right-0 w-8 h-8 bg-yellow-300/80 [clip-path:polygon(100%_0,100%_100%,0_100%)] shadow-inner" />
-      <div className="absolute bottom-0 right-0 w-0 h-0 border-l-32 border-b-32 border-l-transparent border-b-yellow-50/60 pointer-events-none" />
+      <div className="absolute bottom-0 right-0 w-8 h-8 bg-yellow-300/80 dark:bg-zinc-600 [clip-path:polygon(100%_0,100%_100%,0_100%)] shadow-inner" />
+      <div className="absolute bottom-0 right-0 w-0 h-0 border-l-32 border-b-32 border-l-transparent border-b-yellow-50/60 dark:border-b-zinc-900 pointer-events-none" />
     </div>
   );
 };

--- a/src/features/dashboard/components/OcrUploadCard.tsx
+++ b/src/features/dashboard/components/OcrUploadCard.tsx
@@ -39,7 +39,7 @@ const OcrUploadCard = () => {
           onClick={() => fileInputRef.current?.click()}
           onDrop={handleDrop}
           onDragOver={(e) => e.preventDefault()}
-          className="border-2 border-dashed rounded-xl flex flex-col items-center justify-center gap-3 py-5 bg-blue-50/10 cursor-pointer hover:bg-blue-50 transition-colors group"
+          className="border-2 border-dashed rounded-xl flex flex-col items-center justify-center gap-3 py-5 bg-blue-50/10 cursor-pointer hover:bg-baro-blue/10 transition-colors group"
         >
           <div className="w-8 h-8 rounded-full bg-blue-100 flex items-center justify-center group-hover:bg-blue-200 transition-colors">
             <Upload className="w-4 h-4 text-baro-blue" />

--- a/src/features/dashboard/components/SalesConsumptionCard.tsx
+++ b/src/features/dashboard/components/SalesConsumptionCard.tsx
@@ -91,9 +91,7 @@ const SalesConsumptionCard = ({ data }: SalesConsumptionCardProps) => {
               <span className="size-2 rounded-full bg-baro-green shrink-0" />
               <span className="text-xs text-muted-foreground">소비</span>
             </div>
-            <p className="text-sm font-bold text-gray-900">
-              {(latest.consumption / 10000).toFixed(0)}만원
-            </p>
+            <p className="text-sm font-bold ">{(latest.consumption / 10000).toFixed(0)}만원</p>
             <p className="text-xs text-muted-foreground mt-0.5">
               {(consumptionRatio * 100).toFixed(1)}%
             </p>
@@ -104,7 +102,7 @@ const SalesConsumptionCard = ({ data }: SalesConsumptionCardProps) => {
               <span className="size-2 rounded-full bg-baro-blue shrink-0" />
               <span className="text-xs text-muted-foreground">순이익</span>
             </div>
-            <p className="text-sm font-bold text-gray-900">{(profit / 10000).toFixed(0)}만원</p>
+            <p className="text-sm font-bold">{(profit / 10000).toFixed(0)}만원</p>
             <p className="text-xs text-muted-foreground mt-0.5">
               {(profitRatio * 100).toFixed(1)}%
             </p>

--- a/src/features/ocr-inbound/components/IngredientLinkModal.tsx
+++ b/src/features/ocr-inbound/components/IngredientLinkModal.tsx
@@ -82,7 +82,7 @@ const IngredientLinkModal = ({
                       'inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-all select-none cursor-pointer',
                       selected?.id === ingredient.id
                         ? 'border-baro-blue bg-baro-blue/10 text-baro-blue'
-                        : 'border-gray-200 bg-white text-foreground hover:border-baro-blue/60 hover:bg-baro-blue/5',
+                        : 'text-foreground hover:border-baro-blue/60 hover:bg-baro-blue/5',
                     )}
                   >
                     {ingredient.name}

--- a/src/widgets/AppHeader.tsx
+++ b/src/widgets/AppHeader.tsx
@@ -15,7 +15,7 @@ const AppHeader = ({ userName, userRole, onClosingClick }: AppHeaderProps) => {
       <Button
         size="sm"
         onClick={onClosingClick}
-        className="bg-baro-blue text-xs rounded-full hover:bg-baro-blue/80"
+        className="bg-baro-blue text-xs rounded-full hover:bg-baro-blue/80 text-white"
       >
         마감하기
       </Button>


### PR DESCRIPTION
## 📌 요약

- 대시보드 OCR 카드, 그래프 카드, 메인 헤더 마감하기 버튼에 다크모드 스타일 적용

<br/>

## 🏷️ 관련 이슈

- Closes #57

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- 다크모드 지원 확대: 대시보드 주요 컴포넌트 및 메인 헤더에 다크모드 클래스 추가

<br/>

### 📂 세부 변경사항

- `OcrUploadCard.tsx`: 다크모드 스타일 적용
- `SalesConsumptionCard.tsx`: 다크모드 스타일 적용
- `AppHeader.tsx`: 마감하기 버튼 다크모드 스타일 적용

<br/>

## 📸 Screenshots

<!-- Before / After 비교 -->

| Before | After |
| ------ | ----- |
|        |       |

<br/>

## 🧪 테스트 방법

1. 다크모드 전환 후 대시보드 페이지 접속
2. OCR 카드, 그래프 카드 스타일 확인
3. 메인 헤더 마감하기 버튼 스타일 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [ ] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [ ] 빌드 정상 동작 확인
- [ ] 콘솔 에러 없음
- [ ] 불필요한 코드 제거
- [ ] 타입 에러 없음
- [ ] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

-