### PR TITLE
✨ (#59) feat: 로그아웃 및 회원탈퇴 API 연동

### DIFF
--- a/src/features/account-settings/api/accountSettings.api.ts
+++ b/src/features/account-settings/api/accountSettings.api.ts
@@ -1,0 +1,5 @@
+import axiosInstance from '@/shared/api/axiosInstance';
+
+export const withdrawUser = (): Promise<void> => {
+  return axiosInstance.delete('/users/me').then(() => undefined);
+};

--- a/src/features/account-settings/components/sections/AccountSection.tsx
+++ b/src/features/account-settings/components/sections/AccountSection.tsx
@@ -172,8 +172,8 @@ const AccountSection = () => {
           <DialogHeader>
             <DialogTitle>정말 탈퇴하시겠어요?</DialogTitle>
             <DialogDescription>
-              탈퇴하면 가게 정보, 재고, 메뉴, 레시피 등 모든 데이터가 영구적으로 삭제됩니다.
-              이 작업은 되돌릴 수 없습니다.
+              탈퇴하면 가게 정보, 재고, 메뉴, 레시피 등 모든 데이터가 영구적으로 삭제됩니다. 이
+              작업은 되돌릴 수 없습니다.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
@@ -184,11 +184,7 @@ const AccountSection = () => {
             >
               취소
             </Button>
-            <Button
-              variant="destructive"
-              onClick={handleWithdraw}
-              disabled={isWithdrawing}
-            >
+            <Button variant="destructive" onClick={handleWithdraw} disabled={isWithdrawing}>
               탈퇴하기
             </Button>
           </DialogFooter>

--- a/src/features/account-settings/components/sections/AccountSection.tsx
+++ b/src/features/account-settings/components/sections/AccountSection.tsx
@@ -1,9 +1,21 @@
 import { useRef, useState } from 'react';
 
 import { Check, LogOut, Pencil, Trash2, UserCircle, X } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 
+import { withdrawUser } from '@/features/account-settings/api/accountSettings.api';
 import { MOCK_ACCOUNT_SETTINGS } from '@/features/account-settings/data/account-settings.mock';
+import { logout } from '@/features/auth/api/authApi';
+import useAuthStore from '@/features/auth/store/authStore';
 import { Button } from '@/shadcn/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/shadcn/ui/dialog';
 import { Input } from '@/shadcn/ui/input';
 import { Separator } from '@/shadcn/ui/separator';
 import SettingRow from '@/shared/components/SettingRow';
@@ -13,7 +25,12 @@ const AccountSection = () => {
   const [isEditingName, setIsEditingName] = useState(false);
   const [name, setName] = useState(MOCK_ACCOUNT_SETTINGS.name);
   const [draftName, setDraftName] = useState(name);
+  const [isWithdrawDialogOpen, setIsWithdrawDialogOpen] = useState(false);
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
+  const [isWithdrawing, setIsWithdrawing] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const navigate = useNavigate();
+  const clearAuth = useAuthStore((s) => s.clearAuth);
 
   const handleEditStart = () => {
     setDraftName(name);
@@ -38,91 +55,146 @@ const AccountSection = () => {
     if (e.key === 'Escape') handleCancel();
   };
 
+  const handleLogout = async () => {
+    setIsLoggingOut(true);
+    try {
+      await logout();
+    } finally {
+      clearAuth();
+      navigate('/login');
+    }
+  };
+
+  const handleWithdraw = async () => {
+    setIsWithdrawing(true);
+    try {
+      await withdrawUser();
+      clearAuth();
+      navigate('/login');
+    } catch {
+      setIsWithdrawing(false);
+      setIsWithdrawDialogOpen(false);
+    }
+  };
+
   return (
-    <SettingsSection
-      title="계정"
-      description="계정 정보 및 보안 설정을 관리합니다."
-      icon={<UserCircle className="h-4 w-4" />}
-    >
-      <SettingRow
-        label="이름"
-        action={
-          isEditingName ? (
-            <div className="flex items-center gap-1.5">
-              <Input
-                ref={inputRef}
-                value={draftName}
-                onChange={(e) => setDraftName(e.target.value)}
-                onKeyDown={handleKeyDown}
-                className="h-8 w-36 text-sm"
-                maxLength={20}
-              />
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8 text-baro-green hover:bg-baro-green/10 hover:text-baro-green"
-                onClick={handleSave}
-                aria-label="저장"
-              >
-                <Check className="h-4 w-4" />
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8 text-muted-foreground hover:text-foreground"
-                onClick={handleCancel}
-                aria-label="취소"
-              >
-                <X className="h-4 w-4" />
-              </Button>
-            </div>
-          ) : (
-            <div className="flex items-center gap-1.5">
-              <span className="text-sm text-muted-foreground">{name}</span>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8 text-muted-foreground hover:text-foreground"
-                onClick={handleEditStart}
-                aria-label="이름 편집"
-              >
-                <Pencil className="h-3.5 w-3.5" />
-              </Button>
-            </div>
-          )
-        }
-      />
-      <Separator />
-      <SettingRow
-        label="로그아웃"
-        description="현재 기기에서 로그아웃합니다."
-        action={
-          <Button
-            variant="outline"
-            size="sm"
-            className="gap-1.5 border-baro-red text-baro-red hover:bg-baro-red/10 hover:text-baro-red"
-          >
-            <LogOut className="h-3.5 w-3.5" />
-            로그아웃
-          </Button>
-        }
-      />
-      <Separator />
-      <SettingRow
-        label="회원 탈퇴"
-        description="서비스에서 계정을 삭제합니다."
-        action={
-          <Button
-            variant="outline"
-            size="sm"
-            className="gap-1.5 border-baro-red text-baro-red hover:bg-baro-red/10 hover:text-baro-red"
-          >
-            <Trash2 className="h-3.5 w-3.5" />
-            회원 탈퇴
-          </Button>
-        }
-      />
-    </SettingsSection>
+    <>
+      <SettingsSection
+        title="계정"
+        description="계정 정보 및 보안 설정을 관리합니다."
+        icon={<UserCircle className="h-4 w-4" />}
+      >
+        <SettingRow
+          label="이름"
+          action={
+            isEditingName ? (
+              <div className="flex items-center gap-1.5">
+                <Input
+                  ref={inputRef}
+                  value={draftName}
+                  onChange={(e) => setDraftName(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  className="h-8 w-36 text-sm"
+                  maxLength={20}
+                />
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 text-baro-green hover:bg-baro-green/10 hover:text-baro-green"
+                  onClick={handleSave}
+                  aria-label="저장"
+                >
+                  <Check className="h-4 w-4" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                  onClick={handleCancel}
+                  aria-label="취소"
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              </div>
+            ) : (
+              <div className="flex items-center gap-1.5">
+                <span className="text-sm text-muted-foreground">{name}</span>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                  onClick={handleEditStart}
+                  aria-label="이름 편집"
+                >
+                  <Pencil className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+            )
+          }
+        />
+        <Separator />
+        <SettingRow
+          label="로그아웃"
+          description="현재 기기에서 로그아웃합니다."
+          action={
+            <Button
+              variant="outline"
+              size="sm"
+              className="gap-1.5 border-baro-red text-baro-red hover:bg-baro-red/10 hover:text-baro-red"
+              onClick={handleLogout}
+              disabled={isLoggingOut}
+            >
+              <LogOut className="h-3.5 w-3.5" />
+              로그아웃
+            </Button>
+          }
+        />
+        <Separator />
+        <SettingRow
+          label="회원 탈퇴"
+          description="서비스에서 계정을 삭제합니다."
+          action={
+            <Button
+              variant="outline"
+              size="sm"
+              className="gap-1.5 border-baro-red text-baro-red hover:bg-baro-red/10 hover:text-baro-red"
+              onClick={() => setIsWithdrawDialogOpen(true)}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+              회원 탈퇴
+            </Button>
+          }
+        />
+      </SettingsSection>
+
+      <Dialog open={isWithdrawDialogOpen} onOpenChange={setIsWithdrawDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>정말 탈퇴하시겠어요?</DialogTitle>
+            <DialogDescription>
+              탈퇴하면 가게 정보, 재고, 메뉴, 레시피 등 모든 데이터가 영구적으로 삭제됩니다.
+              이 작업은 되돌릴 수 없습니다.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setIsWithdrawDialogOpen(false)}
+              disabled={isWithdrawing}
+            >
+              취소
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleWithdraw}
+              disabled={isWithdrawing}
+            >
+              탈퇴하기
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 };
 

--- a/src/features/auth/api/authApi.ts
+++ b/src/features/auth/api/authApi.ts
@@ -1,4 +1,10 @@
+import axiosInstance from '@/shared/api/axiosInstance';
+
 export const getKakaoLoginUrl = (callbackUrl: string): string => {
   const base = `${import.meta.env.VITE_API_BASE_URL}/auth/kakao`;
-  return `${base}?state=${encodeURIComponent(callbackUrl)}`;
+  return `${base}?returnUrl=${encodeURIComponent(callbackUrl)}`;
+};
+
+export const logout = (): Promise<void> => {
+  return axiosInstance.post('/auth/logout').then(() => undefined);
 };


### PR DESCRIPTION
## 📌 요약

- 로그아웃 API 연동 (`POST /auth/logout`)
- 회원탈퇴 API 연동 (`DELETE /users/me`)
- `AccountSection` 버튼에 실제 API 호출 및 인증 상태 정리 로직 연결

<br/>

## 🏷️ 관련 이슈

- Closes #59

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- 로그아웃 버튼: `POST /auth/logout` → `clearAuth()` → `/login` 이동 (`finally` 처리로 서버 오류에도 클라이언트 인증 상태 정리 보장)
- 회원탈퇴 버튼: 확인 Dialog 추가 → `DELETE /users/me` → `clearAuth()` → `/login` 이동

<br/>

### 📂 세부 변경사항

- `src/features/auth/api/authApi.ts` — `logout()` 함수 추가
- `src/features/account-settings/api/accountSettings.api.ts` — 신규 생성, `withdrawUser()` 함수 추가
- `src/features/account-settings/components/sections/AccountSection.tsx` — API 연동 및 회원탈퇴 확인 Dialog 추가

<br/>

## 📸 Screenshots

| Before | After |
| ------ | ----- |
| 버튼 클릭 시 아무 동작 없음 | 로그아웃: 즉시 처리 / 회원탈퇴: 확인 다이얼로그 표시 후 처리 |

<br/>

## 🧪 테스트 방법

1. `/my-account` 페이지 접속
2. 로그아웃 버튼 클릭 → `/login`으로 이동, 로컬스토리지 토큰 삭제 확인
3. 다시 로그인 후 회원 탈퇴 버튼 클릭 → 확인 다이얼로그 표시 확인
4. 다이얼로그에서 탈퇴하기 클릭 → `/login`으로 이동, 계정 삭제 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [x] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- 로그아웃은 `finally` 블록에서 `clearAuth()`를 호출하므로, 서버 요청이 실패해도 클라이언트 인증 상태가 반드시 초기화됩니다.
- 회원탈퇴 실패 시 다이얼로그를 닫고 로딩 상태를 해제하여 재시도 가능하도록 처리했습니다.