### PR TITLE
✨ (#61) feat: OCR 이미지 업로드 API 연동

### DIFF
--- a/src/features/ocr-inbound/api/ocr.api.ts
+++ b/src/features/ocr-inbound/api/ocr.api.ts
@@ -1,0 +1,22 @@
+import type { OcrApiResponse } from '@/features/ocr-inbound/types/ocrInbound.api.types';
+import type { OcrInboundItem } from '@/features/ocr-inbound/types/ocrInbound.types';
+import axiosInstance from '@/shared/api/axiosInstance';
+
+export async function uploadOcrImage(storeId: string, file: File): Promise<OcrInboundItem[]> {
+  const formData = new FormData();
+  formData.append('file', file);
+
+  const res = await axiosInstance.post<{ success: boolean; data: OcrApiResponse }>(
+    `/stores/${storeId}/ocr/upload`,
+    formData,
+    { headers: { 'Content-Type': 'multipart/form-data' } },
+  );
+
+  return res.data.data.items.map((item, i) => ({
+    id: `ocr-${Date.now()}-${i}`,
+    name: item.name,
+    quantity: item.amount,
+    unit: item.unit,
+    isMatched: false,
+  }));
+}

--- a/src/features/ocr-inbound/types/ocrInbound.api.types.ts
+++ b/src/features/ocr-inbound/types/ocrInbound.api.types.ts
@@ -1,0 +1,13 @@
+import type { OcrUnit } from '@/features/ocr-inbound/types/ocrInbound.types';
+
+export interface OcrApiItem {
+  name: string;
+  amount: number;
+  unit: OcrUnit;
+  unitPrice: number | null;
+}
+
+export interface OcrApiResponse {
+  items: OcrApiItem[];
+  rawText: string;
+}

--- a/src/pages/OcrInboundPage.tsx
+++ b/src/pages/OcrInboundPage.tsx
@@ -1,14 +1,15 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import { ArrowLeft, ScanLine } from 'lucide-react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 
 import { routePaths } from '@/app/routes/routePaths';
+import useAuthStore from '@/features/auth/store/authStore';
 import { useInventoryStore } from '@/features/inventory/store/inventoryStore';
+import { uploadOcrImage } from '@/features/ocr-inbound/api/ocr.api';
 import OcrReviewStep from '@/features/ocr-inbound/components/OcrReviewStep';
 import OcrUploadStep from '@/features/ocr-inbound/components/OcrUploadStep';
-import { MOCK_OCR_RESULT } from '@/features/ocr-inbound/data/ocrInbound.mock';
 import type { OcrInboundItem } from '@/features/ocr-inbound/types/ocrInbound.types';
 
 type Step = 'upload' | 'analyzing' | 'review';
@@ -17,6 +18,7 @@ const OcrInboundPage = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const applyInbound = useInventoryStore((s) => s.applyInbound);
+  const storeId = useAuthStore((s) => s.storeId);
   const [imageUrl, setImageUrl] = useState<string | null>(
     () => (location.state as { imageUrl?: string } | null)?.imageUrl ?? null,
   );
@@ -26,20 +28,28 @@ const OcrInboundPage = () => {
   });
   const [items, setItems] = useState<OcrInboundItem[]>([]);
 
-  useEffect(() => {
-    if (step !== 'analyzing') return;
-    const timer = setTimeout(() => {
-      setItems([...MOCK_OCR_RESULT]);
-      setStep('review');
-    }, 1500);
-    return () => clearTimeout(timer);
-  }, [step]);
-
-  const handleFileSelect = useCallback((file: File) => {
-    const url = URL.createObjectURL(file);
-    setImageUrl(url);
-    setStep('analyzing');
-  }, []);
+  const handleFileSelect = useCallback(
+    async (file: File) => {
+      if (!storeId) {
+        toast.error('가게 정보를 불러올 수 없습니다.');
+        return;
+      }
+      const url = URL.createObjectURL(file);
+      setImageUrl(url);
+      setStep('analyzing');
+      try {
+        const result = await uploadOcrImage(storeId, file);
+        setItems(result);
+        setStep('review');
+      } catch {
+        toast.error('OCR 처리에 실패했습니다. 다시 시도해주세요.');
+        URL.revokeObjectURL(url);
+        setStep('upload');
+        setImageUrl(null);
+      }
+    },
+    [storeId],
+  );
 
   const handleReset = () => {
     if (imageUrl) URL.revokeObjectURL(imageUrl);


### PR DESCRIPTION
## 📌 요약

- OCR 이미지 업로드 API 연동 (`POST /stores/:storeId/ocr/upload`)
- 기존 목 데이터(타이머 방식) 제거 및 실제 API 응답으로 교체

<br/>

## 🏷️ 관련 이슈

- Closes #61

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- `MOCK_OCR_RESULT` + `useEffect` 타이머 방식 → 실제 API 호출로 전환
- `storeId` 미존재 시 토스트 에러 처리
- 업로드 실패 시 이미지 URL 해제 및 업로드 단계로 롤백

<br/>

### 📂 세부 변경사항

- `src/features/ocr-inbound/types/ocrInbound.api.types.ts` — 신규 생성, `OcrApiItem` / `OcrApiResponse` 타입 정의
- `src/features/ocr-inbound/api/ocr.api.ts` — 신규 생성, `uploadOcrImage(storeId, file)` 함수 추가
- `src/pages/OcrInboundPage.tsx` — 목 데이터 제거, 실제 API 연동

<br/>

## 📸 Screenshots

| Before | After |
| ------ | ----- |
| 1.5초 타이머 후 목 데이터 표시 | <img width="1918" height="977" alt="image" src="https://github.com/user-attachments/assets/279438b8-2f5f-4271-8ae6-6f6c9ed4f001" /> |

<br/>

## 🧪 테스트 방법

1. `/ocr-inbound` 페이지 접속
2. 거래명세서 이미지 업로드
3. 분석 중 화면 표시 확인
4. OCR 결과 항목이 리뷰 단계에 정상 표시되는지 확인
5. 네트워크 오류 시 업로드 단계로 롤백되는지 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [x] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- OCR API 응답의 `amount` 필드를 프론트 `quantity`로 매핑하며, 단위(`unit`)는 백엔드 `OcrUnit` 타입을 그대로 사용합니다.
- `isMatched` 필드는 초기값 `false`로 설정되며, 이후 리뷰 단계에서 재고 매칭 처리됩니다.