### PR TITLE
🐛 (#64) fix: 초기 세팅 메뉴 이미지 blob URL 저장 문제 수정

### DIFF
--- a/src/features/initial-setup/components/InitialSetupForm.tsx
+++ b/src/features/initial-setup/components/InitialSetupForm.tsx
@@ -6,7 +6,6 @@ import { useNavigate } from 'react-router-dom';
 import { routePaths } from '@/app/routes/routePaths';
 import useAuthStore from '@/features/auth/store/authStore';
 import { fetchMe, submitInitialSetup } from '@/features/initial-setup/api/initialSetup.api';
-import { fetchMenus, updateMenu, uploadMenuImage } from '@/features/store-settings/api/menus.api';
 import SetupProgressBar from '@/features/initial-setup/components/SetupProgressBar';
 import StepBasicInfo from '@/features/initial-setup/components/steps/StepBasicInfo';
 import StepIngredientsAndRecipes from '@/features/initial-setup/components/steps/StepIngredientsAndRecipes';
@@ -18,6 +17,7 @@ import type {
   InitialSetupData,
   StoreBasicInfo,
 } from '@/features/initial-setup/types/initialSetup.types';
+import { fetchMenus, updateMenu, uploadMenuImage } from '@/features/store-settings/api/menus.api';
 import { Button } from '@/shadcn/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shadcn/ui/card';
 import baroLogo from '@/shared/assets/images/baro-logo.png';

--- a/src/features/initial-setup/components/InitialSetupForm.tsx
+++ b/src/features/initial-setup/components/InitialSetupForm.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import { routePaths } from '@/app/routes/routePaths';
 import useAuthStore from '@/features/auth/store/authStore';
 import { fetchMe, submitInitialSetup } from '@/features/initial-setup/api/initialSetup.api';
+import { fetchMenus, updateMenu, uploadMenuImage } from '@/features/store-settings/api/menus.api';
 import SetupProgressBar from '@/features/initial-setup/components/SetupProgressBar';
 import StepBasicInfo from '@/features/initial-setup/components/steps/StepBasicInfo';
 import StepIngredientsAndRecipes from '@/features/initial-setup/components/steps/StepIngredientsAndRecipes';
@@ -70,8 +71,33 @@ const InitialSetupForm = () => {
 
   const handleComplete = async () => {
     try {
-      const { storeId } = await submitInitialSetup(formData);
+      // imageFile은 JSON 직렬화 제외, blob URL은 서버에 보내지 않음
+      const { storeId } = await submitInitialSetup({
+        ...formData,
+        menuItems: formData.menuItems.map(({ imageFile: _imageFile, imageUrl, ...rest }) => ({
+          ...rest,
+          imageUrl: imageUrl?.startsWith('blob:') ? undefined : imageUrl,
+        })),
+      });
       setStoreId(storeId);
+
+      const menusWithPendingImages = formData.menuItems.filter((m) => m.imageFile);
+      if (menusWithPendingImages.length > 0) {
+        const backendMenus = await fetchMenus(storeId);
+        await Promise.all(
+          menusWithPendingImages.map(async (localMenu) => {
+            const backendMenu = backendMenus.find((m) => m.name === localMenu.name);
+            if (!backendMenu || !localMenu.imageFile) return;
+            const imageUrl = await uploadMenuImage(storeId, localMenu.imageFile);
+            await updateMenu(storeId, backendMenu.id, { imageUrl });
+          }),
+        );
+      }
+
+      formData.menuItems.forEach((m) => {
+        if (m.imageUrl?.startsWith('blob:')) URL.revokeObjectURL(m.imageUrl);
+      });
+
       navigate(routePaths.dashboard);
     } catch {
       alert('초기 설정 저장에 실패했습니다. 잠시 후 다시 시도해 주세요.');

--- a/src/features/initial-setup/components/MenuRegistrationModal.tsx
+++ b/src/features/initial-setup/components/MenuRegistrationModal.tsx
@@ -23,6 +23,7 @@ const EMPTY_FORM = {
   price: '',
   isFeatured: false,
   imageUrl: undefined as string | undefined,
+  imageFile: undefined as File | undefined,
 };
 
 type FormState = typeof EMPTY_FORM;
@@ -48,6 +49,7 @@ const MenuRegistrationModal = ({
           price: editingMenu.price === 0 ? '' : String(editingMenu.price),
           isFeatured: editingMenu.isFeatured,
           imageUrl: editingMenu.imageUrl,
+          imageFile: editingMenu.imageFile,
         });
       } else {
         setForm(EMPTY_FORM);
@@ -68,13 +70,14 @@ const MenuRegistrationModal = ({
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
+    if (form.imageUrl?.startsWith('blob:')) URL.revokeObjectURL(form.imageUrl);
     const objectUrl = URL.createObjectURL(file);
-    setForm((prev) => ({ ...prev, imageUrl: objectUrl }));
+    setForm((prev) => ({ ...prev, imageUrl: objectUrl, imageFile: file }));
   };
 
   const handleRemoveImage = () => {
-    if (form.imageUrl) URL.revokeObjectURL(form.imageUrl);
-    setForm((prev) => ({ ...prev, imageUrl: undefined }));
+    if (form.imageUrl?.startsWith('blob:')) URL.revokeObjectURL(form.imageUrl);
+    setForm((prev) => ({ ...prev, imageUrl: undefined, imageFile: undefined }));
     if (fileInputRef.current) fileInputRef.current.value = '';
   };
 
@@ -87,6 +90,7 @@ const MenuRegistrationModal = ({
       price: Number(form.price),
       isFeatured: form.isFeatured,
       imageUrl: form.imageUrl,
+      imageFile: form.imageFile,
     });
   };
 

--- a/src/features/initial-setup/types/initialSetup.types.ts
+++ b/src/features/initial-setup/types/initialSetup.types.ts
@@ -41,6 +41,8 @@ export interface MenuItem {
   price: number;
   isFeatured: boolean;
   imageUrl?: string;
+  /** 초기 세팅 중 선택된 이미지 파일 (서버 미전송, setup 완료 후 업로드) */
+  imageFile?: File;
 }
 
 /** 태그 형태로 등록되는 식자재 종류 (재고 수량이 아닌 종류 등록) */


### PR DESCRIPTION
## 📌 요약

- 초기 세팅 메뉴 등록 시 이미지가 Supabase에 업로드되지 않고 임시 `blob:` URL이 DB에 저장되던 버그 수정
- setup 완료 후 storeId를 받아 이미지 업로드 → 메뉴 레코드 PATCH 처리

<br/>

## 🏷️ 관련 이슈

- Closes #64

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- `MenuRegistrationModal`: 이미지 선택 시 `File` 객체를 상태에 보관, blob URL은 미리보기 전용으로만 사용
- `InitialSetupForm.handleComplete()`: setup API 제출 전 blob URL 제거, 완료 후 `uploadMenuImage` → `updateMenu`로 영구 URL 저장
- `MenuItem` 타입에 `imageFile?: File` 추가 (프론트 전용, JSON 직렬화 시 제외)

<br/>

### 📂 세부 변경사항

- `src/features/initial-setup/types/initialSetup.types.ts`: `MenuItem` 인터페이스에 `imageFile?: File` 필드 추가
- `src/features/initial-setup/components/MenuRegistrationModal.tsx`: `handleImageChange`에서 File 객체 저장, `handleRemoveImage`에서 File 초기화
- `src/features/initial-setup/components/InitialSetupForm.tsx`: setup 완료 후 pending 이미지 일괄 업로드 로직 추가

<br/>

## 📸 Screenshots

| Before | After |
| ------ | ----- |
| `imageUrl: "blob:http://localhost:5173/..."` | `imageUrl: "https://...supabase.co/storage/..."` |

<br/>

## 🧪 테스트 방법

1. `/initial-setup` 접근 후 3단계 메뉴 등록에서 이미지 포함 메뉴 추가
2. 초기 설정 완료 제출
3. Supabase Storage `menu-images` 버킷에 이미지 업로드 확인
4. DB `menus` 테이블 `imageUrl` 컬럼이 Supabase 영구 URL인지 확인
5. 손님 주문 페이지(`/order/:storeId?table=1`)에서 메뉴 이미지 정상 표시 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [ ] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- 기존 DB에 저장된 blob URL 데이터는 이번 수정으로 자동 복구되지 않음 → `/settings` 메뉴 수정에서 이미지 재업로드 필요
- `imageFile` 필드는 `JSON.stringify` 시 직렬화 불가하므로 API 전송 전 명시적으로 제외 처리