### PR TITLE
✨ (#63) feat: 주문 시스템 실제 API 연동 (손님 주문 + 대시보드 실시간)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ jobs:
 
       - name: pnpm 설치
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Node.js 설정
         uses: actions/setup-node@v4
@@ -44,8 +42,6 @@ jobs:
 
       - name: pnpm 설치
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Node.js 설정
         uses: actions/setup-node@v4
@@ -70,8 +66,6 @@ jobs:
 
       - name: pnpm 설치
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Node.js 설정
         uses: actions/setup-node@v4

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,1 @@
-export PATH="$(cygpath -u "$APPDATA")/npm:$PATH"
 pnpm eslint . --fix

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
+export PATH="$(cygpath -u "$APPDATA")/npm:$PATH"
 pnpm eslint . --fix

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "packageManager": "pnpm@10.15.0",
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",

--- a/src/features/customer-order/api/menu.api.ts
+++ b/src/features/customer-order/api/menu.api.ts
@@ -1,0 +1,9 @@
+import type { ApiMenu } from '@/features/customer-order/types/customerOrder.api.types';
+import publicAxiosInstance from '@/shared/api/publicAxiosInstance';
+
+// ⚠️ GET /stores/:storeId/menus 는 현재 백엔드에서 인증 필수.
+// 손님(비회원) 접근을 위해 백엔드에 공개 엔드포인트 추가 필요.
+export const fetchStoreMenus = (storeId: string): Promise<ApiMenu[]> =>
+  publicAxiosInstance
+    .get<{ success: boolean; data: ApiMenu[] }>(`/stores/${storeId}/menus`)
+    .then((res) => res.data.data);

--- a/src/features/customer-order/api/order.api.ts
+++ b/src/features/customer-order/api/order.api.ts
@@ -1,0 +1,10 @@
+import type {
+  ApiOrder,
+  CreateOrderRequest,
+} from '@/features/customer-order/types/customerOrder.api.types';
+import publicAxiosInstance from '@/shared/api/publicAxiosInstance';
+
+export const createOrder = (storeId: string, data: CreateOrderRequest): Promise<ApiOrder> =>
+  publicAxiosInstance
+    .post<{ success: boolean; data: ApiOrder }>(`/stores/${storeId}/orders`, data)
+    .then((res) => res.data.data);

--- a/src/features/customer-order/components/CustomerOrderStatusCard.tsx
+++ b/src/features/customer-order/components/CustomerOrderStatusCard.tsx
@@ -3,10 +3,12 @@ import { useState } from 'react';
 import { Clock, ShoppingBag } from 'lucide-react';
 
 import OrderStatusBadge from '@/features/customer-order/components/CustomerOrderStatusBadge';
-import { useOrderStore } from '@/features/customer-order/store/customerOrderStore';
-import type { Order } from '@/features/customer-order/types/customerOrder.types';
+import type { ApiOrder } from '@/features/customer-order/types/customerOrder.api.types';
+import { useOrders, useUpdateOrderStatus } from '@/features/dashboard/hooks/useOrders';
+import { useOrderSSE } from '@/features/dashboard/hooks/useOrderSSE';
 import { Button } from '@/shadcn/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/shadcn/ui/card';
+import { Skeleton } from '@/shadcn/ui/skeleton';
 
 type TabKey = 'pending' | 'preparing' | 'completed';
 
@@ -31,20 +33,20 @@ const formatTimeAgo = (isoString: string): string => {
 
 /* ── 개별 주문 카드 ── */
 interface OrderCardProps {
-  order: Order;
+  order: ApiOrder;
+  storeId: string;
 }
 
-const OrderCard = ({ order }: OrderCardProps) => {
-  const updateOrderStatus = useOrderStore((s) => s.updateOrderStatus);
+const OrderCard = ({ order, storeId }: OrderCardProps) => {
+  const { mutate: changeStatus, isPending } = useUpdateOrderStatus(storeId);
+
+  const itemSummary = order.items?.map((i) => `${i.menu.name} x${i.quantity}`).join(' · ') ?? '';
 
   return (
     <div className="rounded-lg border bg-card p-3 space-y-2">
-      {/* 헤더: 테이블 + 상태 + 시간 */}
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-2 min-w-0">
-          <span className="text-sm font-medium truncate">
-            {order.tableNumber ?? '테이블 미지정'}
-          </span>
+          <span className="text-sm font-medium truncate">{order.tableNumber}번 테이블</span>
           <OrderStatusBadge status={order.status} />
         </div>
         <div className="flex items-center gap-1 text-xs text-muted-foreground shrink-0">
@@ -53,28 +55,18 @@ const OrderCard = ({ order }: OrderCardProps) => {
         </div>
       </div>
 
-      {/* 주문 내역 */}
-      <p className="text-xs text-muted-foreground line-clamp-2">
-        {order.items.map((i) => `${i.name} x${i.quantity}`).join(' · ')}
-      </p>
+      {itemSummary && <p className="text-xs text-muted-foreground line-clamp-2">{itemSummary}</p>}
 
-      {/* 요청사항 */}
-      {order.customerNote && (
-        <p className="text-xs text-amber-500/80 bg-amber-50/60 rounded px-2 py-1">
-          💬 {order.customerNote}
-        </p>
-      )}
-
-      {/* 금액 + 액션 버튼 */}
       <div className="flex items-center justify-between">
-        <span className="text-sm font-semibold">{order.totalAmount.toLocaleString()}원</span>
+        <span className="text-sm font-semibold">{order.totalPrice.toLocaleString()}원</span>
         <div className="flex gap-1.5">
           {order.status === 'pending' && (
             <>
               <Button
                 size="sm"
                 className="h-7 px-2.5 text-xs bg-baro-blue text-white hover:bg-baro-blue/80"
-                onClick={() => updateOrderStatus(order.id, 'preparing')}
+                disabled={isPending}
+                onClick={() => changeStatus({ orderId: order.id, status: 'preparing' })}
               >
                 수락
               </Button>
@@ -82,7 +74,8 @@ const OrderCard = ({ order }: OrderCardProps) => {
                 size="sm"
                 variant="outline"
                 className="h-7 px-2.5 text-xs"
-                onClick={() => updateOrderStatus(order.id, 'cancelled')}
+                disabled={isPending}
+                onClick={() => changeStatus({ orderId: order.id, status: 'cancelled' })}
               >
                 취소
               </Button>
@@ -92,7 +85,8 @@ const OrderCard = ({ order }: OrderCardProps) => {
             <Button
               size="sm"
               className="h-7 px-2.5 text-xs bg-slate-600 text-white hover:bg-slate-700"
-              onClick={() => updateOrderStatus(order.id, 'completed')}
+              disabled={isPending}
+              onClick={() => changeStatus({ orderId: order.id, status: 'completed' })}
             >
               완료처리
             </Button>
@@ -104,9 +98,15 @@ const OrderCard = ({ order }: OrderCardProps) => {
 };
 
 /* ── 주문 현황 카드 ── */
-const OrderStatusCard = () => {
+interface OrderStatusCardProps {
+  storeId: string | null;
+}
+
+const OrderStatusCard = ({ storeId }: OrderStatusCardProps) => {
   const [activeTab, setActiveTab] = useState<TabKey>('pending');
-  const orders = useOrderStore((s) => s.orders);
+  const { data: orders = [], isLoading } = useOrders(storeId);
+
+  useOrderSSE(storeId);
 
   const pendingCount = orders.filter((o) => o.status === 'pending').length;
   const filteredOrders = orders.filter((o) => o.status === activeTab);
@@ -125,7 +125,6 @@ const OrderStatusCard = () => {
         </CardTitle>
       </CardHeader>
 
-      {/* 탭 */}
       <div className="flex border-b shrink-0">
         {TABS.map((tab) => {
           const count = orders.filter((o) => o.status === tab.key).length;
@@ -155,15 +154,20 @@ const OrderStatusCard = () => {
         })}
       </div>
 
-      {/* 주문 목록 */}
       <CardContent className="flex-1 overflow-y-auto p-3 space-y-2">
-        {filteredOrders.length === 0 ? (
+        {isLoading ? (
+          Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-24 w-full rounded-lg" />
+          ))
+        ) : filteredOrders.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-32 text-muted-foreground">
             <ShoppingBag className="size-8 mb-2 opacity-25" />
             <p className="text-xs">{EMPTY_MESSAGE[activeTab]}</p>
           </div>
         ) : (
-          filteredOrders.map((order) => <OrderCard key={order.id} order={order} />)
+          filteredOrders.map((order) =>
+            storeId ? <OrderCard key={order.id} order={order} storeId={storeId} /> : null,
+          )
         )}
       </CardContent>
     </Card>

--- a/src/features/customer-order/types/customerOrder.api.types.ts
+++ b/src/features/customer-order/types/customerOrder.api.types.ts
@@ -1,0 +1,42 @@
+export interface ApiMenu {
+  id: string;
+  storeId: string;
+  name: string;
+  price: number;
+  description: string | null;
+  imageUrl: string | null;
+  isAvailable: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ApiOrderItem {
+  id: string;
+  orderId: string;
+  menuId: string;
+  quantity: number;
+  unitPrice: number;
+  menu: ApiMenu;
+}
+
+export type ApiOrderStatus = 'pending' | 'preparing' | 'completed' | 'cancelled';
+
+export interface ApiOrder {
+  id: string;
+  storeId: string;
+  tableNumber: number;
+  status: ApiOrderStatus;
+  totalPrice: number;
+  createdAt: string;
+  updatedAt: string;
+  items?: ApiOrderItem[];
+}
+
+export interface CreateOrderRequest {
+  tableNumber: number;
+  items: { menuId: string; quantity: number }[];
+}
+
+export interface UpdateOrderStatusRequest {
+  status: 'preparing' | 'completed' | 'cancelled';
+}

--- a/src/features/dashboard/api/order.api.ts
+++ b/src/features/dashboard/api/order.api.ts
@@ -1,0 +1,22 @@
+import type {
+  ApiOrder,
+  UpdateOrderStatusRequest,
+} from '@/features/customer-order/types/customerOrder.api.types';
+import axiosInstance from '@/shared/api/axiosInstance';
+
+export const fetchOrders = (storeId: string): Promise<ApiOrder[]> =>
+  axiosInstance
+    .get<{ success: boolean; data: ApiOrder[] }>(`/stores/${storeId}/orders`)
+    .then((res) => res.data.data);
+
+export const updateOrderStatus = (
+  storeId: string,
+  orderId: string,
+  status: UpdateOrderStatusRequest['status'],
+): Promise<ApiOrder> =>
+  axiosInstance
+    .patch<{
+      success: boolean;
+      data: ApiOrder;
+    }>(`/stores/${storeId}/orders/${orderId}/status`, { status })
+    .then((res) => res.data.data);

--- a/src/features/dashboard/components/StoreStatusCard.tsx
+++ b/src/features/dashboard/components/StoreStatusCard.tsx
@@ -1,13 +1,13 @@
 import { Store } from 'lucide-react';
 
-import { useOrderStore } from '@/features/customer-order/store/customerOrderStore';
+import { useOrders } from '@/features/dashboard/hooks/useOrders';
 import type { DashboardStats } from '@/features/dashboard/types/dashboard.types';
 
 interface StoreStatusCardProps {
   stats: DashboardStats;
+  storeId: string | null;
 }
 
-/* ── 개별 스탯 타일 ── */
 interface StatTileProps {
   label: string;
   value: string;
@@ -23,20 +23,19 @@ const StatTile = ({ label, value, comment, commentColor }: StatTileProps) => (
   </div>
 );
 
-const StoreStatusCard = ({ stats }: StoreStatusCardProps) => {
-  const orders = useOrderStore((s) => s.orders);
+const StoreStatusCard = ({ stats, storeId }: StoreStatusCardProps) => {
+  const { data: orders = [] } = useOrders(storeId);
 
   const today = new Date().toDateString();
   const todayRevenue = orders
     .filter((o) => o.status === 'completed' && new Date(o.createdAt).toDateString() === today)
-    .reduce((sum, o) => sum + o.totalAmount, 0);
+    .reduce((sum, o) => sum + o.totalPrice, 0);
   const todayOrderCount = orders.filter(
     (o) => new Date(o.createdAt).toDateString() === today,
   ).length;
 
   return (
     <div className="rounded-xl bg-card ring-1 ring-foreground/10 overflow-hidden">
-      {/* 헤더 */}
       <div className="border-b px-4 py-2.5">
         <p className="text-sm font-medium flex items-center gap-2">
           <Store className="w-4 h-4 text-muted-foreground" />
@@ -44,7 +43,6 @@ const StoreStatusCard = ({ stats }: StoreStatusCardProps) => {
         </p>
       </div>
 
-      {/* 스탯 타일 */}
       <div className="flex gap-3 px-4 py-3">
         <StatTile
           label="전체 재고"

--- a/src/features/dashboard/hooks/useOrderSSE.ts
+++ b/src/features/dashboard/hooks/useOrderSSE.ts
@@ -1,0 +1,64 @@
+import { useEffect } from 'react';
+
+import { useQueryClient } from '@tanstack/react-query';
+
+import useAuthStore from '@/features/auth/store/authStore';
+
+// EventSource는 커스텀 헤더를 지원하지 않으므로 fetch + ReadableStream으로 SSE 연결
+export const useOrderSSE = (storeId: string | null) => {
+  const queryClient = useQueryClient();
+  const accessToken = useAuthStore((s) => s.accessToken);
+
+  useEffect(() => {
+    if (!storeId || !accessToken) return;
+
+    const controller = new AbortController();
+
+    const connect = async () => {
+      try {
+        const response = await fetch(
+          `${import.meta.env.VITE_API_BASE_URL}/stores/${storeId}/orders/stream`,
+          {
+            headers: { Authorization: `Bearer ${accessToken}` },
+            signal: controller.signal,
+          },
+        );
+
+        if (!response.ok || !response.body) return;
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+        let eventType = '';
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split('\n');
+          buffer = lines.pop() ?? '';
+
+          for (const line of lines) {
+            if (line.startsWith('event: ')) {
+              eventType = line.slice(7).trim();
+            } else if (line.startsWith('data: ')) {
+              if (eventType === 'new-order' || eventType === 'order-status-changed') {
+                queryClient.invalidateQueries({ queryKey: ['orders', storeId] });
+              }
+              eventType = '';
+            }
+          }
+        }
+      } catch (err) {
+        if ((err as Error).name === 'AbortError') return;
+        // 연결 끊김 시 3초 후 재연결
+        setTimeout(connect, 3_000);
+      }
+    };
+
+    connect();
+
+    return () => controller.abort();
+  }, [storeId, accessToken, queryClient]);
+};

--- a/src/features/dashboard/hooks/useOrders.ts
+++ b/src/features/dashboard/hooks/useOrders.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import type { UpdateOrderStatusRequest } from '@/features/customer-order/types/customerOrder.api.types';
+import { fetchOrders, updateOrderStatus } from '@/features/dashboard/api/order.api';
+
+export const useOrders = (storeId: string | null) =>
+  useQuery({
+    queryKey: ['orders', storeId],
+    queryFn: () => fetchOrders(storeId!),
+    enabled: !!storeId,
+  });
+
+export const useUpdateOrderStatus = (storeId: string | null) => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      orderId,
+      status,
+    }: {
+      orderId: string;
+      status: UpdateOrderStatusRequest['status'];
+    }) => updateOrderStatus(storeId!, orderId, status),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['orders', storeId] }),
+  });
+};

--- a/src/features/initial-setup/components/MenuRegistrationModal.tsx
+++ b/src/features/initial-setup/components/MenuRegistrationModal.tsx
@@ -96,12 +96,12 @@ const MenuRegistrationModal = ({
 
   return (
     <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
-      <DialogContent className="max-w-md gap-0 p-0">
-        <DialogHeader className="border-b px-6 pt-4">
-          <DialogTitle className="text-base">{editingMenu ? '메뉴 수정' : '메뉴 등록'}</DialogTitle>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{editingMenu ? '메뉴 수정' : '메뉴 등록'}</DialogTitle>
         </DialogHeader>
 
-        <div className="space-y-5 px-6 py-5">
+        <div>
           {/* 사진 업로드 */}
           <div className="space-y-1.5">
             <Label>메뉴 사진</Label>

--- a/src/index.css
+++ b/src/index.css
@@ -98,35 +98,6 @@ body {
   margin: 0;
 }
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  font-family: var(--heading);
-  font-weight: 700;
-  color: var(--text-h);
-}
-
-h1 {
-  font-size: 56px;
-  letter-spacing: -1.68px;
-  margin: 32px 0;
-  @media (max-width: 1024px) {
-    font-size: 36px;
-    margin: 20px 0;
-  }
-}
-h2 {
-  font-size: 32px;
-  line-height: 118%;
-  letter-spacing: -0.24px;
-  margin: 0 0 16px;
-  @media (max-width: 1024px) {
-    font-size: 24px;
-  }
-}
 
 p {
   margin: 0;

--- a/src/pages/CustomerOrderPage.tsx
+++ b/src/pages/CustomerOrderPage.tsx
@@ -1,23 +1,25 @@
 import { useState } from 'react';
 
-import { CheckCircle, Minus, Plus, ShoppingCart } from 'lucide-react';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { AlertCircle, CheckCircle, Loader2, Minus, Plus, ShoppingCart } from 'lucide-react';
 import { useParams, useSearchParams } from 'react-router-dom';
 
-import { MOCK_SHOP_MENU } from '@/features/customer-order/data/customerOrder.mock';
-import { useOrderStore } from '@/features/customer-order/store/customerOrderStore';
+import { fetchStoreMenus } from '@/features/customer-order/api/menu.api';
+import { createOrder } from '@/features/customer-order/api/order.api';
+import type { ApiMenu } from '@/features/customer-order/types/customerOrder.api.types';
 import type { CartItem } from '@/features/customer-order/types/customerOrder.types';
-import type { MenuItem } from '@/features/initial-setup/types/initialSetup.types';
 import { Button } from '@/shadcn/ui/button';
 import { Card, CardContent } from '@/shadcn/ui/card';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/shadcn/ui/dialog';
 import { Input } from '@/shadcn/ui/input';
 import { Label } from '@/shadcn/ui/label';
+import { Skeleton } from '@/shadcn/ui/skeleton';
 
-type CategoryTab = 'all' | 'featured';
+type CategoryTab = 'all' | 'available';
 
 /* ── 메뉴 아이템 카드 ── */
 interface MenuItemCardProps {
-  item: MenuItem;
+  item: ApiMenu;
   quantity: number;
   onUpdate: (id: string, delta: number) => void;
 }
@@ -25,10 +27,13 @@ interface MenuItemCardProps {
 const MenuItemCard = ({ item, quantity, onUpdate }: MenuItemCardProps) => (
   <div
     className={`flex items-center gap-3 bg-white rounded-xl px-4 py-3 transition-all ${
-      quantity > 0 ? 'ring-2 ring-baro-blue/25' : 'border border-gray-100'
+      !item.isAvailable
+        ? 'opacity-50'
+        : quantity > 0
+          ? 'ring-2 ring-baro-blue/25'
+          : 'border border-gray-100'
     }`}
   >
-    {/* 썸네일 */}
     {item.imageUrl ? (
       <img
         src={item.imageUrl}
@@ -41,23 +46,23 @@ const MenuItemCard = ({ item, quantity, onUpdate }: MenuItemCardProps) => (
       </div>
     )}
 
-    {/* 텍스트 */}
     <div className="flex-1 min-w-0">
       <div className="flex items-center gap-1.5">
         <p className="text-sm font-semibold text-gray-900 truncate">{item.name}</p>
-        {item.isFeatured && (
-          <span className="text-xs text-amber-600 bg-amber-50 px-1.5 py-0.5 rounded font-medium shrink-0">
-            대표
+        {!item.isAvailable && (
+          <span className="text-xs text-gray-400 bg-gray-100 px-1.5 py-0.5 rounded shrink-0">
+            품절
           </span>
         )}
       </div>
-      <p className="text-xs text-gray-400 mt-0.5 truncate">{item.description}</p>
+      {item.description && (
+        <p className="text-xs text-gray-400 mt-0.5 truncate">{item.description}</p>
+      )}
       <p className="text-sm font-bold text-gray-900 mt-1.5">{item.price.toLocaleString()}원</p>
     </div>
 
-    {/* 수량 */}
     <div className="flex items-center gap-2 shrink-0">
-      {quantity > 0 ? (
+      {!item.isAvailable ? null : quantity > 0 ? (
         <>
           <button
             onClick={() => onUpdate(item.id, -1)}
@@ -113,13 +118,10 @@ const OrderSuccess = ({ orderId, totalAmount, items, onReorder }: OrderSuccessPr
 
       <Card className="w-full max-w-xs">
         <CardContent className="px-5 py-4 space-y-3">
-          {/* 주문번호 */}
           <div className="flex justify-between items-center text-sm">
             <span className="text-gray-400">주문번호</span>
             <span className="font-bold text-gray-900">#{orderId}</span>
           </div>
-
-          {/* 주문 항목 */}
           <div className="border-t pt-3 space-y-2">
             {visibleItems.map((item) => (
               <div key={item.menuItemId} className="flex justify-between items-center text-sm">
@@ -132,8 +134,6 @@ const OrderSuccess = ({ orderId, totalAmount, items, onReorder }: OrderSuccessPr
                 </span>
               </div>
             ))}
-
-            {/* 더보기 / 접기 */}
             {hasMore && (
               <button
                 onClick={() => setExpanded((v) => !v)}
@@ -143,8 +143,6 @@ const OrderSuccess = ({ orderId, totalAmount, items, onReorder }: OrderSuccessPr
               </button>
             )}
           </div>
-
-          {/* 합계 */}
           <div className="border-t pt-3 flex justify-between items-center text-sm">
             <span className="text-gray-500 font-medium">합계</span>
             <span className="font-bold text-baro-blue">{totalAmount.toLocaleString()}원</span>
@@ -164,10 +162,9 @@ const OrderSuccess = ({ orderId, totalAmount, items, onReorder }: OrderSuccessPr
 
 /* ── 메인 페이지 ── */
 const CustomerOrderPage = () => {
-  const { shopId } = useParams<{ shopId: string }>();
+  const { shopId: storeId } = useParams<{ shopId: string }>();
   const [searchParams] = useSearchParams();
   const tableNumber = searchParams.get('table');
-  const addOrder = useOrderStore((s) => s.addOrder);
 
   const [activeTab, setActiveTab] = useState<CategoryTab>('all');
   const [cart, setCart] = useState<Record<string, number>>({});
@@ -179,13 +176,44 @@ const CustomerOrderPage = () => {
     items: CartItem[];
   } | null>(null);
 
+  const {
+    data: menus = [],
+    isLoading: isMenuLoading,
+    isError: isMenuError,
+  } = useQuery({
+    queryKey: ['public-menus', storeId],
+    queryFn: () => fetchStoreMenus(storeId!),
+    enabled: !!storeId,
+  });
+
+  const orderMutation = useMutation({
+    mutationFn: (data: Parameters<typeof createOrder>[1]) => createOrder(storeId!, data),
+    onSuccess: (order) => {
+      const cartItems: CartItem[] = menus
+        .filter((item) => (cart[item.id] ?? 0) > 0)
+        .map((item) => ({
+          menuItemId: item.id,
+          name: item.name,
+          price: item.price,
+          quantity: cart[item.id]!,
+          imageUrl: item.imageUrl ?? undefined,
+        }));
+
+      setIsCheckoutOpen(false);
+      setSuccessInfo({
+        orderId: order.id.slice(-4).toUpperCase(),
+        totalAmount: order.totalPrice,
+        items: cartItems,
+      });
+      setCart({});
+      setCustomerNote('');
+    },
+  });
+
+  const visibleMenu = activeTab === 'available' ? menus.filter((m) => m.isAvailable) : menus;
+
   const totalItems = Object.values(cart).reduce((sum, qty) => sum + qty, 0);
-  const totalAmount = MOCK_SHOP_MENU.reduce(
-    (sum, item) => sum + (cart[item.id] ?? 0) * item.price,
-    0,
-  );
-  const visibleMenu =
-    activeTab === 'featured' ? MOCK_SHOP_MENU.filter((m) => m.isFeatured) : MOCK_SHOP_MENU;
+  const totalAmount = menus.reduce((sum, item) => sum + (cart[item.id] ?? 0) * item.price, 0);
 
   const updateCart = (itemId: string, delta: number) => {
     setCart((prev) => {
@@ -198,35 +226,12 @@ const CustomerOrderPage = () => {
   };
 
   const handleOrder = () => {
-    const cartItems: CartItem[] = MOCK_SHOP_MENU.filter((item) => (cart[item.id] ?? 0) > 0).map(
-      (item) => ({
-        menuItemId: item.id,
-        name: item.name,
-        price: item.price,
-        quantity: cart[item.id]!,
-        imageUrl: item.imageUrl,
-      }),
-    );
+    if (!tableNumber) return;
+    const items = menus
+      .filter((item) => (cart[item.id] ?? 0) > 0)
+      .map((item) => ({ menuId: item.id, quantity: cart[item.id]! }));
 
-    addOrder({
-      shopId: shopId ?? 'shop1',
-      items: cartItems,
-      totalAmount,
-      status: 'pending',
-      tableNumber: tableNumber ? `${tableNumber}번 테이블` : undefined,
-      customerNote: customerNote.trim() || undefined,
-    });
-
-    setIsCheckoutOpen(false);
-    // eslint-disable-next-line react-hooks/purity
-    const orderId = String(Date.now()).slice(-4);
-    setSuccessInfo({
-      orderId,
-      totalAmount,
-      items: cartItems,
-    });
-    setCart({});
-    setCustomerNote('');
+    orderMutation.mutate({ tableNumber: Number(tableNumber), items });
   };
 
   if (successInfo) {
@@ -249,8 +254,8 @@ const CustomerOrderPage = () => {
             🍽️
           </div>
           <div>
-            <p className="text-sm font-bold text-white leading-none">임포트 감자 식당</p>
-            <p className="text-xs text-white/60 mt-1">한식 · 춘천</p>
+            <p className="text-sm font-bold text-white leading-none">주문하기</p>
+            <p className="text-xs text-white/60 mt-1">메뉴를 선택해 주세요</p>
           </div>
         </div>
         {tableNumber && (
@@ -267,7 +272,7 @@ const CustomerOrderPage = () => {
           {(
             [
               { key: 'all', label: '전체' },
-              { key: 'featured', label: '대표 메뉴' },
+              { key: 'available', label: '주문 가능' },
             ] as { key: CategoryTab; label: string }[]
           ).map((tab) => (
             <button
@@ -287,14 +292,30 @@ const CustomerOrderPage = () => {
 
       {/* 메뉴 목록 */}
       <div className="px-4 pt-3 pb-28 space-y-2">
-        {visibleMenu.map((item) => (
-          <MenuItemCard
-            key={item.id}
-            item={item}
-            quantity={cart[item.id] ?? 0}
-            onUpdate={updateCart}
-          />
-        ))}
+        {isMenuLoading ? (
+          Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-24 w-full rounded-xl" />
+          ))
+        ) : isMenuError ? (
+          <div className="flex flex-col items-center justify-center py-16 gap-3 text-gray-400">
+            <AlertCircle className="size-10 opacity-40" />
+            <p className="text-sm">메뉴를 불러오지 못했어요.</p>
+            <p className="text-xs">잠시 후 다시 시도해 주세요.</p>
+          </div>
+        ) : visibleMenu.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-16 text-gray-400">
+            <p className="text-sm">주문 가능한 메뉴가 없어요.</p>
+          </div>
+        ) : (
+          visibleMenu.map((item) => (
+            <MenuItemCard
+              key={item.id}
+              item={item}
+              quantity={cart[item.id] ?? 0}
+              onUpdate={updateCart}
+            />
+          ))
+        )}
       </div>
 
       {/* 장바구니 바 */}
@@ -324,25 +345,25 @@ const CustomerOrderPage = () => {
           </DialogHeader>
 
           <div className="space-y-4">
-            {/* 주문 내역 */}
             <div className="rounded-xl bg-gray-50 px-4 py-3 space-y-2">
-              {MOCK_SHOP_MENU.filter((item) => (cart[item.id] ?? 0) > 0).map((item) => (
-                <div key={item.id} className="flex justify-between text-sm">
-                  <span className="text-gray-500">
-                    {item.name} <span className="text-gray-400">× {cart[item.id]}</span>
-                  </span>
-                  <span className="font-medium text-gray-900">
-                    {((cart[item.id] ?? 0) * item.price).toLocaleString()}원
-                  </span>
-                </div>
-              ))}
+              {menus
+                .filter((item) => (cart[item.id] ?? 0) > 0)
+                .map((item) => (
+                  <div key={item.id} className="flex justify-between text-sm">
+                    <span className="text-gray-500">
+                      {item.name} <span className="text-gray-400">× {cart[item.id]}</span>
+                    </span>
+                    <span className="font-medium text-gray-900">
+                      {((cart[item.id] ?? 0) * item.price).toLocaleString()}원
+                    </span>
+                  </div>
+                ))}
               <div className="border-t border-gray-200 pt-2 flex justify-between text-sm font-bold">
                 <span className="text-gray-900">합계</span>
                 <span className="text-baro-blue">{totalAmount.toLocaleString()}원</span>
               </div>
             </div>
 
-            {/* 테이블 번호 */}
             {tableNumber && (
               <div className="flex items-center justify-between rounded-xl bg-baro-blue/8 px-4 py-2.5">
                 <span className="text-sm text-gray-500">테이블 번호</span>
@@ -350,7 +371,6 @@ const CustomerOrderPage = () => {
               </div>
             )}
 
-            {/* 요청사항 */}
             <div className="space-y-1.5">
               <Label htmlFor="customer-note" className="text-sm text-gray-700">
                 요청사항 <span className="text-gray-400 font-normal">(선택)</span>
@@ -367,8 +387,13 @@ const CustomerOrderPage = () => {
             <Button
               className="w-full bg-baro-blue text-white hover:bg-baro-blue/90 rounded-xl h-11 text-sm font-semibold"
               onClick={handleOrder}
+              disabled={orderMutation.isPending}
             >
-              주문하기 · {totalAmount.toLocaleString()}원
+              {orderMutation.isPending ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                `주문하기 · ${totalAmount.toLocaleString()}원`
+              )}
             </Button>
           </div>
         </DialogContent>

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,3 +1,4 @@
+import useAuthStore from '@/features/auth/store/authStore';
 import OrderStatusCard from '@/features/customer-order/components/CustomerOrderStatusCard';
 import MemoCard from '@/features/dashboard/components/MemoCard';
 import OcrUploadCard from '@/features/dashboard/components/OcrUploadCard';
@@ -6,17 +7,19 @@ import StoreStatusCard from '@/features/dashboard/components/StoreStatusCard';
 import { MOCK_SALES_DATA, MOCK_STATS } from '@/features/dashboard/data/dashboard.mock';
 
 const DashboardPage = () => {
+  const storeId = useAuthStore((s) => s.storeId);
+
   return (
     <main className="flex-1 min-h-0 overflow-hidden p-4 flex gap-4">
       {/* 왼쪽: 주문 현황 */}
       <div className="flex-1 min-w-0">
-        <OrderStatusCard />
+        <OrderStatusCard storeId={storeId} />
       </div>
 
       {/* 오른쪽: 가게 현황 */}
       <div className="flex-1 min-w-0 flex flex-col gap-4">
         {/* 상단: 오늘의 가게 현황 요약 */}
-        <StoreStatusCard stats={MOCK_STATS} />
+        <StoreStatusCard stats={MOCK_STATS} storeId={storeId} />
 
         {/* 하단: 좌(이번달 현황 + OCR) / 우(메모) */}
         <div className="flex gap-5 flex-1 min-h-0">

--- a/src/pages/SettingsMenusPage.tsx
+++ b/src/pages/SettingsMenusPage.tsx
@@ -95,12 +95,12 @@ const MenuModal = ({
 
   return (
     <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
-      <DialogContent className="max-w-md gap-0 p-0" showCloseButton={false}>
-        <DialogHeader className="border-b px-6 pt-4">
-          <DialogTitle className="text-base">{editing ? '메뉴 수정' : '메뉴 등록'}</DialogTitle>
+      <DialogContent showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>{editing ? '메뉴 수정' : '메뉴 등록'}</DialogTitle>
         </DialogHeader>
 
-        <div className="space-y-5 px-6 py-5">
+        <div className="flex gap-4 flex-col">
           {/* 사진 업로드 */}
           <div className="space-y-1.5">
             <Label>메뉴 사진</Label>
@@ -191,16 +191,15 @@ const MenuModal = ({
           </div>
         </div>
 
-        <DialogFooter className="mx-0 mb-0 border-t p-4">
-          <Button type="button" variant="outline" size="sm" onClick={onClose}>
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={onClose}>
             취소
           </Button>
           <Button
             type="button"
-            size="sm"
             onClick={handleSave}
             disabled={isSaving || isUploading}
-            className="bg-baro-blue text-white hover:bg-baro-blue/80"
+            className="bg-baro-blue hover:bg-baro-blue/80"
           >
             {editing ? '수정 완료' : '등록하기'}
           </Button>

--- a/src/pages/SettingsRecipesPage.tsx
+++ b/src/pages/SettingsRecipesPage.tsx
@@ -1,6 +1,15 @@
 import { useState } from 'react';
 
-import { ArrowLeft, ChevronDown, ChevronUp, GripVertical, Plus, Trash2, X } from 'lucide-react';
+import {
+  ArrowLeft,
+  CheckCircle2,
+  ChevronDown,
+  ChevronUp,
+  Loader2,
+  Plus,
+  Trash2,
+  X,
+} from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
 import { routePaths } from '@/app/routes/routePaths';
@@ -15,7 +24,14 @@ import {
 } from '@/features/store-settings/hooks/useRecipes';
 import { cn } from '@/lib/utils';
 import { Button } from '@/shadcn/ui/button';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/shadcn/ui/dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/shadcn/ui/dialog';
 import { Input } from '@/shadcn/ui/input';
 import { Label } from '@/shadcn/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/shadcn/ui/select';
@@ -29,21 +45,28 @@ const IngredientTag = ({
 }: {
   ingredient: IngredientDto;
   added: boolean;
-  onClick?: () => void;
+  onClick: () => void;
 }) => (
-  <div
+  <button
+    type="button"
     onClick={onClick}
     className={cn(
-      'inline-flex cursor-pointer items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-all select-none',
+      'inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium transition-all select-none',
       added
-        ? 'border-baro-blue bg-baro-blue/10 text-baro-blue cursor-default'
-        : 'border-gray-200 bg-white text-foreground hover:border-baro-blue/60 hover:bg-baro-blue/5 dark:border-gray-700 dark:bg-gray-800',
+        ? 'bg-baro-blue text-white hover:bg-baro-blue/80'
+        : 'border border-gray-200 bg-white text-gray-600 hover:border-baro-blue/60 hover:bg-baro-blue/5 hover:text-baro-blue',
     )}
   >
-    {!added && <GripVertical className="size-3 text-muted-foreground" />}
-    <span>{ingredient.name}</span>
-    <span className="text-muted-foreground">({ingredient.unit})</span>
-  </div>
+    {added ? (
+      <CheckCircle2 className="size-3 shrink-0" />
+    ) : (
+      <Plus className="size-3 shrink-0 text-gray-400" />
+    )}
+    {ingredient.name}
+    <span className={cn('font-normal', added ? 'text-white/70' : 'text-gray-400')}>
+      ({ingredient.unit})
+    </span>
+  </button>
 );
 
 /* ── 메뉴별 아코디언 패널 ── */
@@ -130,14 +153,18 @@ const SettingsRecipesPage = () => {
   const [pendingItems, setPendingItems] = useState<{ ingredientId: string; amount: string }[]>([]);
 
   const existingForMenu = recipes?.filter((r) => r.menuId === selectedMenuId) ?? [];
-  const addedIds = [
-    ...existingForMenu.map((r) => r.ingredientId),
-    ...pendingItems.map((p) => p.ingredientId),
-  ];
+  const existingIngredientIds = existingForMenu.map((r) => r.ingredientId);
+  const addedIds = [...existingIngredientIds, ...pendingItems.map((p) => p.ingredientId)];
 
   const handleTagClick = (ingredientId: string) => {
-    if (addedIds.includes(ingredientId)) return;
-    setPendingItems((prev) => [...prev, { ingredientId, amount: '' }]);
+    if (pendingItems.some((p) => p.ingredientId === ingredientId)) {
+      setPendingItems((prev) => prev.filter((p) => p.ingredientId !== ingredientId));
+    } else if (existingIngredientIds.includes(ingredientId)) {
+      const recipe = existingForMenu.find((r) => r.ingredientId === ingredientId);
+      if (recipe) deleteRecipe(recipe.id);
+    } else {
+      setPendingItems((prev) => [...prev, { ingredientId, amount: '' }]);
+    }
   };
 
   const handleRemovePending = (ingredientId: string) => {
@@ -150,6 +177,12 @@ const SettingsRecipesPage = () => {
     );
   };
 
+  const closeModal = () => {
+    setOpen(false);
+    setSelectedMenuId('');
+    setPendingItems([]);
+  };
+
   const handleSave = () => {
     const valid = pendingItems.filter((p) => p.amount && Number(p.amount) > 0);
     if (!valid.length) return;
@@ -160,11 +193,7 @@ const SettingsRecipesPage = () => {
         {
           onSuccess: () => {
             remaining--;
-            if (remaining === 0) {
-              setOpen(false);
-              setSelectedMenuId('');
-              setPendingItems([]);
-            }
+            if (remaining === 0) closeModal();
           },
         },
       );
@@ -178,6 +207,9 @@ const SettingsRecipesPage = () => {
       recipes: recipes?.filter((r) => r.menuId === menu.id) ?? [],
     }))
     .filter((g) => g.recipes.length > 0 || menus.length > 0);
+
+  const selectedMenuName = menus?.find((m) => m.id === selectedMenuId)?.name;
+  const hasListItems = existingForMenu.length > 0 || pendingItems.length > 0;
 
   return (
     <div className="min-h-screen bg-background">
@@ -223,22 +255,24 @@ const SettingsRecipesPage = () => {
       <Dialog
         open={open}
         onOpenChange={(v) => {
-          setOpen(v);
-          if (!v) {
-            setSelectedMenuId('');
-            setPendingItems([]);
-          }
+          if (!v) closeModal();
+          else setOpen(true);
         }}
       >
-        <DialogContent className="max-w-lg">
+        <DialogContent className="flex max-h-[60vh] max-w-xl flex-col overflow-hidden">
+          {/* 헤더 — 고정 */}
           <DialogHeader>
             <DialogTitle>레시피 추가</DialogTitle>
+            <DialogDescription>메뉴별 식자재 사용량을 설정합니다</DialogDescription>
           </DialogHeader>
 
-          <div className="space-y-4">
+          {/* 본문 — 스크롤 */}
+          <div className="flex-1 overflow-y-auto pb-2">
             {/* 메뉴 선택 */}
             <div className="space-y-1.5">
-              <Label>메뉴 선택 *</Label>
+              <Label className="text-sm">
+                메뉴 <span className="text-baro-red">*</span>
+              </Label>
               <Select
                 value={selectedMenuId}
                 onValueChange={(v) => {
@@ -246,8 +280,10 @@ const SettingsRecipesPage = () => {
                   setPendingItems([]);
                 }}
               >
-                <SelectTrigger>
-                  <SelectValue placeholder="메뉴를 선택하세요" />
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="레시피를 추가할 메뉴를 선택하세요">
+                    {selectedMenuName}
+                  </SelectValue>
                 </SelectTrigger>
                 <SelectContent>
                   {menus?.map((m) => (
@@ -260,18 +296,22 @@ const SettingsRecipesPage = () => {
             </div>
 
             {selectedMenuId && (
-              <>
-                {/* 식자재 태그 팔레트 */}
-                <div className="space-y-2">
-                  <p className="text-xs font-medium text-muted-foreground">
-                    식자재를 클릭해서 추가하세요
+              <div className="space-y-4 py-2">
+                {/* 구분선 */}
+                <div className="flex items-center gap-3">
+                  <div className="h-px flex-1 bg-border" />
+                  <span className="text-xs font-medium text-muted-foreground">식자재 선택</span>
+                  <div className="h-px flex-1 bg-border" />
+                </div>
+
+                {/* 식자재 팔레트 */}
+                {!ingredients?.length ? (
+                  <p className="py-4 text-center text-xs text-muted-foreground">
+                    등록된 식자재가 없습니다. 먼저 식자재를 등록해주세요.
                   </p>
-                  {!ingredients?.length ? (
-                    <p className="text-xs text-muted-foreground italic">
-                      등록된 식자재가 없습니다.
-                    </p>
-                  ) : (
-                    <div className="flex flex-wrap gap-1.5 rounded-xl border border-dashed p-3">
+                ) : (
+                  <div className="rounded-xl border bg-gray-50/60 p-3 dark:bg-muted/20">
+                    <div className="flex flex-wrap gap-2">
                       {ingredients.map((ing) => (
                         <IngredientTag
                           key={ing.id}
@@ -281,59 +321,115 @@ const SettingsRecipesPage = () => {
                         />
                       ))}
                     </div>
-                  )}
-                </div>
-
-                {/* 추가된 식자재 + 사용량 입력 */}
-                {pendingItems.length > 0 && (
-                  <div className="space-y-2">
-                    <div className="grid grid-cols-[1fr_90px_auto_28px] items-center gap-2 px-1">
-                      <Label className="text-xs text-muted-foreground">식자재</Label>
-                      <Label className="text-xs text-muted-foreground">사용량</Label>
-                      <Label className="text-xs text-muted-foreground">단위</Label>
-                      <span />
-                    </div>
-                    {pendingItems.map((item) => {
-                      const ing = ingredients?.find((i) => i.id === item.ingredientId);
-                      if (!ing) return null;
-                      return (
-                        <div
-                          key={item.ingredientId}
-                          className="grid grid-cols-[1fr_90px_auto_28px] items-center gap-2 rounded-lg border bg-background px-2 py-1.5"
-                        >
-                          <span className="truncate text-sm">{ing.name}</span>
-                          <Input
-                            type="number"
-                            placeholder="0"
-                            min={0}
-                            value={item.amount}
-                            onChange={(e) => handleAmountChange(item.ingredientId, e.target.value)}
-                            className="h-8"
-                          />
-                          <span className="text-xs text-muted-foreground">{ing.unit}</span>
-                          <button
-                            type="button"
-                            onClick={() => handleRemovePending(item.ingredientId)}
-                            className="flex items-center justify-center rounded p-1 text-gray-400 hover:bg-red-50 hover:text-red-500"
-                          >
-                            <X className="size-3.5" />
-                          </button>
-                        </div>
-                      );
-                    })}
                   </div>
                 )}
 
-                <Button
-                  className="w-full bg-baro-blue hover:bg-baro-blue/80 text-white"
-                  onClick={handleSave}
-                  disabled={isCreating || pendingItems.every((p) => !p.amount)}
-                >
-                  저장하기
-                </Button>
-              </>
+                {/* 재료 목록 (기존 저장 + 새로 추가) */}
+                {hasListItems && (
+                  <div className="space-y-1.5">
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs font-medium text-muted-foreground">사용량</span>
+                      {pendingItems.length > 0 && (
+                        <span className="text-xs font-medium text-baro-blue">
+                          +{pendingItems.length}개 추가 예정
+                        </span>
+                      )}
+                    </div>
+                    <div className="overflow-hidden rounded-xl border">
+                      <div className="grid grid-cols-[1fr_96px_40px_32px] items-center gap-2 border-b bg-muted/40 px-3.5 py-2 text-xs font-medium text-muted-foreground">
+                        <span>식자재</span>
+                        <span>사용량</span>
+                        <span>단위</span>
+                        <span />
+                      </div>
+                      <div className="divide-y">
+                        {/* 기존 저장된 항목 — 읽기 전용 */}
+                        {existingForMenu.map((recipe) => (
+                          <div
+                            key={recipe.id}
+                            className="grid grid-cols-[1fr_96px_40px_32px] items-center gap-2 bg-muted/10 px-3.5 py-2.5"
+                          >
+                            <div className="flex min-w-0 items-center gap-2">
+                              <span className="size-1.5 shrink-0 rounded-full bg-gray-300" />
+                              <span className="truncate text-sm text-muted-foreground">
+                                {recipe.ingredientName}
+                              </span>
+                            </div>
+                            <span className="pr-1 text-right text-sm text-muted-foreground">
+                              {Number(recipe.amount).toLocaleString()}
+                            </span>
+                            <span className="text-xs text-muted-foreground">
+                              {recipe.ingredientUnit}
+                            </span>
+                            <button
+                              type="button"
+                              onClick={() => deleteRecipe(recipe.id)}
+                              className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-red-50 hover:text-baro-red"
+                            >
+                              <X className="size-3.5" />
+                            </button>
+                          </div>
+                        ))}
+
+                        {/* 새로 추가 중인 항목 — 사용량 입력 가능 */}
+                        {pendingItems.map((item) => {
+                          const ing = ingredients?.find((i) => i.id === item.ingredientId);
+                          if (!ing) return null;
+                          return (
+                            <div
+                              key={item.ingredientId}
+                              className="grid grid-cols-[1fr_96px_40px_32px] items-center gap-2 px-3.5 py-2.5"
+                            >
+                              <div className="flex min-w-0 items-center gap-2">
+                                <span className="size-1.5 shrink-0 rounded-full bg-baro-blue" />
+                                <span className="truncate text-sm">{ing.name}</span>
+                              </div>
+                              <Input
+                                type="number"
+                                placeholder="0"
+                                min={0}
+                                value={item.amount}
+                                onChange={(e) =>
+                                  handleAmountChange(item.ingredientId, e.target.value)
+                                }
+                                className="h-8 px-2 text-right text-sm"
+                              />
+                              <span className="text-xs text-muted-foreground">{ing.unit}</span>
+                              <button
+                                type="button"
+                                onClick={() => handleRemovePending(item.ingredientId)}
+                                className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-red-50 hover:text-baro-red"
+                              >
+                                <X className="size-3.5" />
+                              </button>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </div>
             )}
           </div>
+
+          {/* 푸터 — 고정 */}
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={closeModal}>
+              취소
+            </Button>
+            <Button
+              className="bg-baro-blue text-white hover:bg-baro-blue/80"
+              onClick={handleSave}
+              disabled={
+                isCreating ||
+                !selectedMenuId ||
+                pendingItems.every((p) => !p.amount || Number(p.amount) <= 0)
+              }
+            >
+              {isCreating ? <Loader2 className="size-4 animate-spin" /> : '저장하기'}
+            </Button>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
     </div>

--- a/src/shadcn/ui/dialog.tsx
+++ b/src/shadcn/ui/dialog.tsx
@@ -1,40 +1,37 @@
-import * as React from "react"
-import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
+import * as React from 'react';
+import { Dialog as DialogPrimitive } from '@base-ui/react/dialog';
 
-import { cn } from "@/lib/utils"
-import { Button } from "@/shadcn/ui/button"
-import { XIcon } from "lucide-react"
+import { cn } from '@/lib/utils';
+import { Button } from '@/shadcn/ui/button';
+import { XIcon } from 'lucide-react';
 
 function Dialog({ ...props }: DialogPrimitive.Root.Props) {
-  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
 }
 
 function DialogTrigger({ ...props }: DialogPrimitive.Trigger.Props) {
-  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
 }
 
 function DialogPortal({ ...props }: DialogPrimitive.Portal.Props) {
-  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
 }
 
 function DialogClose({ ...props }: DialogPrimitive.Close.Props) {
-  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
 }
 
-function DialogOverlay({
-  className,
-  ...props
-}: DialogPrimitive.Backdrop.Props) {
+function DialogOverlay({ className, ...props }: DialogPrimitive.Backdrop.Props) {
   return (
     <DialogPrimitive.Backdrop
       data-slot="dialog-overlay"
       className={cn(
-        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
-        className
+        'fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function DialogContent({
@@ -43,7 +40,7 @@ function DialogContent({
   showCloseButton = true,
   ...props
 }: DialogPrimitive.Popup.Props & {
-  showCloseButton?: boolean
+  showCloseButton?: boolean;
 }) {
   return (
     <DialogPortal>
@@ -51,8 +48,8 @@ function DialogContent({
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
-          className
+          'fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+          className,
         )}
         {...props}
       >
@@ -60,32 +57,21 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            render={
-              <Button
-                variant="ghost"
-                className="absolute top-2 right-2"
-                size="icon-sm"
-              />
-            }
+            render={<Button variant="ghost" className="absolute top-2 right-2" size="icon-sm" />}
           >
-            <XIcon
-            />
+            <XIcon />
             <span className="sr-only">Close</span>
           </DialogPrimitive.Close>
         )}
       </DialogPrimitive.Popup>
     </DialogPortal>
-  )
+  );
 }
 
-function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
-    <div
-      data-slot="dialog-header"
-      className={cn("flex flex-col gap-2", className)}
-      {...props}
-    />
-  )
+    <div data-slot="dialog-header" className={cn('flex flex-col gap-2', className)} {...props} />
+  );
 }
 
 function DialogFooter({
@@ -93,55 +79,47 @@ function DialogFooter({
   showCloseButton = false,
   children,
   ...props
-}: React.ComponentProps<"div"> & {
-  showCloseButton?: boolean
+}: React.ComponentProps<'div'> & {
+  showCloseButton?: boolean;
 }) {
   return (
     <div
       data-slot="dialog-footer"
       className={cn(
-        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
-        className
+        '-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end',
+        className,
       )}
       {...props}
     >
       {children}
       {showCloseButton && (
-        <DialogPrimitive.Close render={<Button variant="outline" />}>
-          Close
-        </DialogPrimitive.Close>
+        <DialogPrimitive.Close render={<Button variant="outline" />}>Close</DialogPrimitive.Close>
       )}
     </div>
-  )
+  );
 }
 
 function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn(
-        "font-heading text-base leading-none font-medium",
-        className
-      )}
+      className={cn('font-heading text-base leading-none font-medium', className)}
       {...props}
     />
-  )
+  );
 }
 
-function DialogDescription({
-  className,
-  ...props
-}: DialogPrimitive.Description.Props) {
+function DialogDescription({ className, ...props }: DialogPrimitive.Description.Props) {
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
       className={cn(
-        "text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
-        className
+        'text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -155,4 +133,4 @@ export {
   DialogPortal,
   DialogTitle,
   DialogTrigger,
-}
+};

--- a/src/shared/api/publicAxiosInstance.ts
+++ b/src/shared/api/publicAxiosInstance.ts
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+// 비회원(손님) 요청용 — 인증 인터셉터 없음
+const publicAxiosInstance = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL,
+});
+
+export default publicAxiosInstance;


### PR DESCRIPTION
## 📌 요약

- 손님 주문 페이지에서 실제 가게 메뉴를 조회하고 주문 제출이 가능하도록 API 연동
- 대시보드 주문 현황 카드에 실제 주문 데이터 연동 및 SSE 실시간 수신 적용
- 모든 목(mock) 데이터 제거

<br/>

## 🏷️ 관련 이슈

- Closes #63

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- `CustomerOrderPage`: 목 데이터 제거, `useParams`로 storeId 추출, React Query로 메뉴 조회 및 주문 제출
- `CustomerOrderStatusCard`: 실제 주문 데이터 표시, 상태 변경(수락/취소/완료) API 연동
- `StoreStatusCard`: 실제 주문 데이터 기반 오늘 매출 집계
- `useOrderSSE`: fetch + ReadableStream 방식으로 SSE 구현 (Authorization 헤더 전송을 위해 EventSource 미사용), 연결 끊기면 3초 후 재연결
- `publicAxiosInstance`: 손님(비인증) 요청용 Axios 인스턴스 추가

<br/>

### 📂 세부 변경사항

- `src/shared/api/publicAxiosInstance.ts`: 인증 없는 공개 API용 Axios 인스턴스
- `src/features/customer-order/types/customerOrder.api.types.ts`: 주문 관련 API 응답 타입 정의
- `src/features/customer-order/api/menu.api.ts`: 공개 메뉴 조회 (`publicAxiosInstance`)
- `src/features/customer-order/api/order.api.ts`: 손님 주문 생성 (`publicAxiosInstance`)
- `src/features/dashboard/api/order.api.ts`: 주문 목록 조회 및 상태 변경 (`axiosInstance`)
- `src/features/dashboard/hooks/useOrders.ts`: 주문 조회/상태변경 React Query 훅
- `src/features/dashboard/hooks/useOrderSSE.ts`: SSE 실시간 주문 수신 훅

<br/>

## 📸 Screenshots

| 손님 주문 페이지 | 대시보드 주문 현황 |
| ------ | ----- |
| <img width="655" height="977" alt="image" src="https://github.com/user-attachments/assets/30a077c8-716f-4391-b320-f4dfe54fcbc3" /> | <img width="1918" height="978" alt="image" src="https://github.com/user-attachments/assets/17995467-7898-436a-bc83-8ca24b7237bb" /> |

<br/>

## 🧪 테스트 방법

1. `/order/:storeId?table=1` 접근 → 등록된 메뉴 목록 표시 확인
2. 메뉴 선택 후 주문하기 → 주문 접수 완료 화면 확인
3. 대시보드(`/dashboard`) → 신규주문 탭에서 방금 주문 표시 확인 (SSE 실시간)
4. 수락/취소/완료처리 버튼 동작 확인
5. 품절 메뉴(`isAvailable: false`) 주문 불가 처리 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [x] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- SSE는 `EventSource` 미사용 — Authorization 헤더를 보낼 수 없어 `fetch` + `ReadableStream`으로 직접 구현
- 손님 주문 페이지는 비인증 요청이므로 `publicAxiosInstance` 사용 (authStore 접근 없음)
- QR 코드 URL 형태: `/order/:storeId?table={n}`