### PR TITLE
✨ (#72) feat: 대시보드 실제 API 연동

### DIFF
--- a/src/features/dashboard/api/dashboard.api.ts
+++ b/src/features/dashboard/api/dashboard.api.ts
@@ -1,7 +1,4 @@
-import type {
-  DashboardStats,
-  MonthlySalesData,
-} from '@/features/dashboard/types/dashboard.types';
+import type { DashboardStats, MonthlySalesData } from '@/features/dashboard/types/dashboard.types';
 import axiosInstance from '@/shared/api/axiosInstance';
 
 export const fetchDashboardStats = (storeId: string): Promise<DashboardStats> =>

--- a/src/features/dashboard/api/dashboard.api.ts
+++ b/src/features/dashboard/api/dashboard.api.ts
@@ -1,0 +1,15 @@
+import type {
+  DashboardStats,
+  MonthlySalesData,
+} from '@/features/dashboard/types/dashboard.types';
+import axiosInstance from '@/shared/api/axiosInstance';
+
+export const fetchDashboardStats = (storeId: string): Promise<DashboardStats> =>
+  axiosInstance
+    .get<{ success: boolean; data: DashboardStats }>(`/stores/${storeId}/dashboard/stats`)
+    .then((res) => res.data.data);
+
+export const fetchDashboardSales = (storeId: string): Promise<MonthlySalesData[]> =>
+  axiosInstance
+    .get<{ success: boolean; data: MonthlySalesData[] }>(`/stores/${storeId}/dashboard/sales`)
+    .then((res) => res.data.data);

--- a/src/features/dashboard/components/OcrUploadCard.tsx
+++ b/src/features/dashboard/components/OcrUploadCard.tsx
@@ -12,8 +12,7 @@ const OcrUploadCard = () => {
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
-    const imageUrl = URL.createObjectURL(file);
-    navigate(routePaths.ocrInbound, { state: { imageUrl } });
+    navigate(routePaths.ocrInbound, { state: { file } });
     e.target.value = '';
   };
 
@@ -21,8 +20,7 @@ const OcrUploadCard = () => {
     e.preventDefault();
     const file = e.dataTransfer.files?.[0];
     if (!file?.type.startsWith('image/')) return;
-    const imageUrl = URL.createObjectURL(file);
-    navigate(routePaths.ocrInbound, { state: { imageUrl } });
+    navigate(routePaths.ocrInbound, { state: { file } });
   };
 
   return (

--- a/src/features/dashboard/components/SalesConsumptionCard.tsx
+++ b/src/features/dashboard/components/SalesConsumptionCard.tsx
@@ -61,8 +61,8 @@ const DonutChart = ({ consumptionRatio }: DonutChartProps) => {
 const SalesConsumptionCard = ({ data }: SalesConsumptionCardProps) => {
   const latest = data[data.length - 1];
   const profit = Math.max(0, latest.sales - latest.consumption);
-  const consumptionRatio = latest.consumption / latest.sales;
-  const profitRatio = profit / latest.sales;
+  const consumptionRatio = latest.sales > 0 ? latest.consumption / latest.sales : 0;
+  const profitRatio = latest.sales > 0 ? profit / latest.sales : 0;
 
   return (
     <Card size="sm" className="h-full">

--- a/src/features/dashboard/components/StoreStatusCard.tsx
+++ b/src/features/dashboard/components/StoreStatusCard.tsx
@@ -52,13 +52,13 @@ const StoreStatusCard = ({ stats, storeId }: StoreStatusCardProps) => {
               ? `발주 추천 ${stats.aiOrderRecommendations}개 있어요`
               : '발주 추천 없어요'
           }
-          commentColor={stats.aiOrderRecommendations > 0 ? 'text-amber-500' : 'text-green-500'}
+          commentColor={stats.aiOrderRecommendations > 0 ? 'text-amber-500' : 'text-baro-green'}
         />
         <StatTile
           label="유통기한 임박"
           value={`${stats.expiringItems}개`}
           comment={stats.expiringItems > 0 ? '빠른 소진 및 발주 필요' : '임박 상품이 없어요'}
-          commentColor={stats.expiringItems > 0 ? 'text-red-500' : 'text-green-500'}
+          commentColor={stats.expiringItems > 0 ? 'text-red-500' : 'text-baro-green'}
         />
         <StatTile
           label="오늘 매출"

--- a/src/features/dashboard/hooks/useDashboardSales.ts
+++ b/src/features/dashboard/hooks/useDashboardSales.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchDashboardSales } from '@/features/dashboard/api/dashboard.api';
+
+export const useDashboardSales = (storeId: string | null) =>
+  useQuery({
+    queryKey: ['dashboard', 'sales', storeId],
+    queryFn: () => fetchDashboardSales(storeId!),
+    enabled: !!storeId,
+  });

--- a/src/features/dashboard/hooks/useDashboardStats.ts
+++ b/src/features/dashboard/hooks/useDashboardStats.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchDashboardStats } from '@/features/dashboard/api/dashboard.api';
+
+export const useDashboardStats = (storeId: string | null) =>
+  useQuery({
+    queryKey: ['dashboard', 'stats', storeId],
+    queryFn: () => fetchDashboardStats(storeId!),
+    enabled: !!storeId,
+  });

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -4,10 +4,15 @@ import MemoCard from '@/features/dashboard/components/MemoCard';
 import OcrUploadCard from '@/features/dashboard/components/OcrUploadCard';
 import SalesConsumptionCard from '@/features/dashboard/components/SalesConsumptionCard';
 import StoreStatusCard from '@/features/dashboard/components/StoreStatusCard';
-import { MOCK_SALES_DATA, MOCK_STATS } from '@/features/dashboard/data/dashboard.mock';
+import { useDashboardSales } from '@/features/dashboard/hooks/useDashboardSales';
+import { useDashboardStats } from '@/features/dashboard/hooks/useDashboardStats';
+import { Skeleton } from '@/shadcn/ui/skeleton';
 
 const DashboardPage = () => {
   const storeId = useAuthStore((s) => s.storeId);
+
+  const { data: stats, isLoading: statsLoading } = useDashboardStats(storeId);
+  const { data: salesData, isLoading: salesLoading } = useDashboardSales(storeId);
 
   return (
     <main className="flex-1 min-h-0 overflow-hidden p-4 flex gap-4">
@@ -19,14 +24,22 @@ const DashboardPage = () => {
       {/* 오른쪽: 가게 현황 */}
       <div className="flex-1 min-w-0 flex flex-col gap-4">
         {/* 상단: 오늘의 가게 현황 요약 */}
-        <StoreStatusCard stats={MOCK_STATS} storeId={storeId} />
+        {statsLoading || !stats ? (
+          <Skeleton className="h-[92px] w-full rounded-xl" />
+        ) : (
+          <StoreStatusCard stats={stats} storeId={storeId} />
+        )}
 
         {/* 하단: 좌(이번달 현황 + OCR) / 우(메모) */}
         <div className="flex gap-5 flex-1 min-h-0">
           {/* 좌: 이번달 현황 + OCR 빠른 입고 처리 */}
           <div className="flex-1 min-w-0 flex flex-col gap-4 min-h-0">
             <div className="flex-1 min-h-0">
-              <SalesConsumptionCard data={MOCK_SALES_DATA} />
+              {salesLoading || !salesData || salesData.length === 0 ? (
+                <Skeleton className="h-full w-full rounded-xl" />
+              ) : (
+                <SalesConsumptionCard data={salesData} />
+              )}
             </div>
             <div className="shrink-0">
               <OcrUploadCard />

--- a/src/pages/OcrInboundPage.tsx
+++ b/src/pages/OcrInboundPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { ArrowLeft, ScanLine } from 'lucide-react';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -19,14 +19,11 @@ const OcrInboundPage = () => {
   const location = useLocation();
   const applyInbound = useInventoryStore((s) => s.applyInbound);
   const storeId = useAuthStore((s) => s.storeId);
-  const [imageUrl, setImageUrl] = useState<string | null>(
-    () => (location.state as { imageUrl?: string } | null)?.imageUrl ?? null,
-  );
-  const [step, setStep] = useState<Step>(() => {
-    const incoming = (location.state as { imageUrl?: string } | null)?.imageUrl;
-    return incoming ? 'analyzing' : 'upload';
-  });
+  const locationState = location.state as { file?: File } | null;
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const [step, setStep] = useState<Step>('upload');
   const [items, setItems] = useState<OcrInboundItem[]>([]);
+  const handledInitialFile = useRef(false);
 
   const handleFileSelect = useCallback(
     async (file: File) => {
@@ -50,6 +47,13 @@ const OcrInboundPage = () => {
     },
     [storeId],
   );
+
+  useEffect(() => {
+    if (locationState?.file && !handledInitialFile.current && storeId) {
+      handledInitialFile.current = true;
+      handleFileSelect(locationState.file);
+    }
+  }, [locationState, handleFileSelect, storeId]);
 
   const handleReset = () => {
     if (imageUrl) URL.revokeObjectURL(imageUrl);


### PR DESCRIPTION
## 📌 요약

- 대시보드 가게 현황 요약 및 이번 달 매출 차트를 mock 데이터에서 실제 API로 교체
- 대시보드 OCR 빠른 입고처리에서 이미지 업로드 시 OCR API가 호출되지 않던 버그 수정
- 가게 현황 카드 정상 상태 문구 색상을 baro-green으로 통일

<br/>

## 🏷️ 관련 이슈

- Closes #72

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- `dashboard.api.ts` 생성: `/dashboard/stats`, `/dashboard/sales` 엔드포인트 호출 함수 추가
- `useDashboardStats`, `useDashboardSales` React Query 훅 생성
- `DashboardPage`: MOCK_STATS, MOCK_SALES_DATA 제거 후 실제 API 훅으로 교체, 로딩 중 Skeleton UI 처리

<br/>

### 📂 세부 변경사항

- `OcrUploadCard`: imageUrl(blob URL) 대신 File 객체를 navigation state로 전달
- `OcrInboundPage`: state.file 수신 시 useEffect로 handleFileSelect 자동 호출 (OCR API 미호출 버그 수정)
- `SalesConsumptionCard`: sales가 0일 때 NaN 방지 방어 처리
- `StoreStatusCard`: 정상 상태 안내 문구 색상 text-green-500 → text-baro-green 통일

<br/>

## 📸 Screenshots

| Before | After |
| ------ | ----- |
| mock 데이터 표시 | 실제 API 데이터 표시 |

<br/>

## 🧪 테스트 방법

1. 대시보드 접속 후 가게 현황 카드(전체 재고, 유통기한 임박, 발주 추천)가 실제 데이터로 표시되는지 확인
2. 이번 달 현황 차트가 실제 매출 데이터로 표시되는지 확인
3. 대시보드 OCR 카드에서 이미지 업로드 시 OCR 분석 페이지로 이동 후 API 호출이 정상 동작하는지 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [x] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- 백엔드에서 `consumption` 필드가 현재 0으로 고정이라 이번 달 현황 차트의 소비 항목은 0으로 표시됨 (백엔드 구현 완료 시 자동 반영)
