### PR TITLE
🐛 (#75) fix: OCR 신규 식자재 등록 및 입고 확정 API 연동

### DIFF
--- a/src/features/ocr-inbound/components/IngredientRegisterModal.tsx
+++ b/src/features/ocr-inbound/components/IngredientRegisterModal.tsx
@@ -1,7 +1,10 @@
 import { useState } from 'react';
 
 import { PackagePlus } from 'lucide-react';
+import { toast } from 'sonner';
 
+import useAuthStore from '@/features/auth/store/authStore';
+import { createIngredient } from '@/features/store-settings/api/ingredients.api';
 import type { OcrUnit } from '@/features/ocr-inbound/types/ocrInbound.types';
 import { Button } from '@/shadcn/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/shadcn/ui/dialog';
@@ -22,7 +25,7 @@ interface IngredientRegisterModalProps {
   initialName: string;
   initialUnit: OcrUnit;
   onClose: () => void;
-  onConfirm: () => void;
+  onConfirm: (ingredientId: string) => void;
 }
 
 const IngredientRegisterModal = ({
@@ -32,16 +35,30 @@ const IngredientRegisterModal = ({
   onClose,
   onConfirm,
 }: IngredientRegisterModalProps) => {
+  const storeId = useAuthStore((s) => s.storeId);
   const [form, setForm] = useState<IngredientForm>({
     name: initialName,
     unit: initialUnit,
     safetyStock: '',
   });
+  const [isPending, setIsPending] = useState(false);
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    // TODO: API 연동
-    onConfirm();
+    if (!storeId) return;
+    setIsPending(true);
+    try {
+      const created = await createIngredient(storeId, {
+        name: form.name,
+        unit: form.unit,
+        safetyStock: form.safetyStock ? Number(form.safetyStock) : undefined,
+      });
+      onConfirm(created.id);
+    } catch {
+      toast.error('식자재 등록에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+    } finally {
+      setIsPending(false);
+    }
   };
 
   return (
@@ -115,10 +132,10 @@ const IngredientRegisterModal = ({
             </Button>
             <Button
               type="submit"
-              disabled={!form.name.trim()}
+              disabled={!form.name.trim() || isPending}
               className="flex-1 bg-baro-blue hover:bg-baro-blue/90 text-white"
             >
-              등록
+              {isPending ? '등록 중...' : '등록'}
             </Button>
           </div>
         </form>

--- a/src/features/ocr-inbound/components/IngredientRegisterModal.tsx
+++ b/src/features/ocr-inbound/components/IngredientRegisterModal.tsx
@@ -4,8 +4,8 @@ import { PackagePlus } from 'lucide-react';
 import { toast } from 'sonner';
 
 import useAuthStore from '@/features/auth/store/authStore';
-import { createIngredient } from '@/features/store-settings/api/ingredients.api';
 import type { OcrUnit } from '@/features/ocr-inbound/types/ocrInbound.types';
+import { createIngredient } from '@/features/store-settings/api/ingredients.api';
 import { Button } from '@/shadcn/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/shadcn/ui/dialog';
 import { Input } from '@/shadcn/ui/input';

--- a/src/features/ocr-inbound/components/OcrReviewStep.tsx
+++ b/src/features/ocr-inbound/components/OcrReviewStep.tsx
@@ -13,12 +13,12 @@ import {
 
 import IngredientLinkModal from '@/features/ocr-inbound/components/IngredientLinkModal';
 import IngredientRegisterModal from '@/features/ocr-inbound/components/IngredientRegisterModal';
-import { MOCK_EXISTING_INGREDIENTS } from '@/features/ocr-inbound/data/ocrInbound.mock';
 import type {
   ExistingIngredient,
   OcrInboundItem,
   OcrUnit,
 } from '@/features/ocr-inbound/types/ocrInbound.types';
+import { useIngredients } from '@/features/store-settings/hooks/useIngredients';
 import { cn } from '@/lib/utils';
 import { Button } from '@/shadcn/ui/button';
 import { Input } from '@/shadcn/ui/input';
@@ -32,6 +32,7 @@ interface OcrReviewStepProps {
   onItemsChange: (items: OcrInboundItem[]) => void;
   onConfirm: () => void;
   onReset: () => void;
+  isConfirming?: boolean;
 }
 
 const OcrReviewStep = ({
@@ -40,7 +41,14 @@ const OcrReviewStep = ({
   onItemsChange,
   onConfirm,
   onReset,
+  isConfirming = false,
 }: OcrReviewStepProps) => {
+  const { data: ingredientList = [] } = useIngredients();
+  const existingIngredients: ExistingIngredient[] = ingredientList.map((ing) => ({
+    id: ing.id,
+    name: ing.name,
+    unit: ing.unit,
+  }));
   const [scale, setScale] = useState(1);
   const [pos, setPos] = useState({ x: 0, y: 0 });
   const [registerModal, setRegisterModal] = useState<{
@@ -319,10 +327,10 @@ const OcrReviewStep = ({
           </p>
           <Button
             onClick={onConfirm}
-            disabled={items.length === 0}
+            disabled={items.length === 0 || isConfirming}
             className="bg-baro-blue hover:bg-baro-blue/90 text-white"
           >
-            입고 확정
+            {isConfirming ? '처리 중...' : '입고 확정'}
           </Button>
         </div>
       </div>
@@ -333,10 +341,12 @@ const OcrReviewStep = ({
           initialName={registerModal.name}
           initialUnit={registerModal.unit}
           onClose={() => setRegisterModal(null)}
-          onConfirm={() => {
+          onConfirm={(ingredientId) => {
             onItemsChange(
               items.map((item) =>
-                item.id === registerModal.itemId ? { ...item, isMatched: true } : item,
+                item.id === registerModal.itemId
+                  ? { ...item, isMatched: true, newIngredientId: ingredientId }
+                  : item,
               ),
             );
             setRegisterModal(null);
@@ -348,7 +358,7 @@ const OcrReviewStep = ({
         <IngredientLinkModal
           open={linkModal.open}
           ocrName={linkModal.name}
-          ingredients={MOCK_EXISTING_INGREDIENTS}
+          ingredients={existingIngredients}
           onClose={() => setLinkModal(null)}
           onConfirm={(ingredient: ExistingIngredient) => {
             onItemsChange(

--- a/src/features/ocr-inbound/types/ocrInbound.types.ts
+++ b/src/features/ocr-inbound/types/ocrInbound.types.ts
@@ -7,6 +7,7 @@ export interface OcrInboundItem {
   unit: OcrUnit;
   isMatched: boolean;
   matchedInventoryId?: string;
+  newIngredientId?: string;
 }
 
 export interface ExistingIngredient {

--- a/src/features/store-settings/api/ingredients.api.ts
+++ b/src/features/store-settings/api/ingredients.api.ts
@@ -15,10 +15,17 @@ export async function fetchIngredients(storeId: string): Promise<IngredientDto[]
 
 export async function createIngredient(
   storeId: string,
-  data: Omit<IngredientDto, 'id' | 'currentStock' | 'safetyStock'>,
+  data: Omit<IngredientDto, 'id' | 'currentStock' | 'safetyStock'> & { safetyStock?: number },
 ): Promise<IngredientDto> {
   const res = await axiosInstance.post(`/stores/${storeId}/ingredients`, data);
   return res.data.data;
+}
+
+export async function confirmInbound(
+  storeId: string,
+  items: { ingredientId: string; amount: number }[],
+): Promise<void> {
+  await axiosInstance.post(`/stores/${storeId}/ingredients/inbound`, { items });
 }
 
 export async function updateIngredient(

--- a/src/pages/OcrInboundPage.tsx
+++ b/src/pages/OcrInboundPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { ArrowLeft, ScanLine } from 'lucide-react';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -6,27 +6,27 @@ import { toast } from 'sonner';
 
 import { routePaths } from '@/app/routes/routePaths';
 import useAuthStore from '@/features/auth/store/authStore';
-import { useInventoryStore } from '@/features/inventory/store/inventoryStore';
 import { uploadOcrImage } from '@/features/ocr-inbound/api/ocr.api';
 import OcrReviewStep from '@/features/ocr-inbound/components/OcrReviewStep';
 import OcrUploadStep from '@/features/ocr-inbound/components/OcrUploadStep';
 import type { OcrInboundItem } from '@/features/ocr-inbound/types/ocrInbound.types';
+import { confirmInbound } from '@/features/store-settings/api/ingredients.api';
+import { useQueryClient } from '@tanstack/react-query';
 
 type Step = 'upload' | 'analyzing' | 'review';
 
 const OcrInboundPage = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  const applyInbound = useInventoryStore((s) => s.applyInbound);
   const storeId = useAuthStore((s) => s.storeId);
-  const [imageUrl, setImageUrl] = useState<string | null>(
-    () => (location.state as { imageUrl?: string } | null)?.imageUrl ?? null,
-  );
-  const [step, setStep] = useState<Step>(() => {
-    const incoming = (location.state as { imageUrl?: string } | null)?.imageUrl;
-    return incoming ? 'analyzing' : 'upload';
-  });
+  const qc = useQueryClient();
+
+  const locationState = location.state as { file?: File } | null;
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const [step, setStep] = useState<Step>('upload');
   const [items, setItems] = useState<OcrInboundItem[]>([]);
+  const [isConfirming, setIsConfirming] = useState(false);
+  const handledInitialFile = useRef(false);
 
   const handleFileSelect = useCallback(
     async (file: File) => {
@@ -51,6 +51,13 @@ const OcrInboundPage = () => {
     [storeId],
   );
 
+  useEffect(() => {
+    if (locationState?.file && !handledInitialFile.current && storeId) {
+      handledInitialFile.current = true;
+      handleFileSelect(locationState.file);
+    }
+  }, [locationState, handleFileSelect, storeId]);
+
   const handleReset = () => {
     if (imageUrl) URL.revokeObjectURL(imageUrl);
     setStep('upload');
@@ -58,7 +65,7 @@ const OcrInboundPage = () => {
     setItems([]);
   };
 
-  const handleConfirm = () => {
+  const handleConfirm = async () => {
     const unmatched = items.filter((item) => !item.isMatched);
     if (unmatched.length > 0) {
       toast.warning(
@@ -66,9 +73,24 @@ const OcrInboundPage = () => {
       );
       return;
     }
-    applyInbound(items);
-    toast.success('재고 등록이 완료되었습니다.');
-    navigate(routePaths.inventory);
+    if (!storeId) return;
+
+    const inboundItems = items.map((item) => ({
+      ingredientId: (item.matchedInventoryId ?? item.newIngredientId)!,
+      amount: item.quantity,
+    }));
+
+    setIsConfirming(true);
+    try {
+      await confirmInbound(storeId, inboundItems);
+      qc.invalidateQueries({ queryKey: ['ingredients', storeId] });
+      toast.success('재고 등록이 완료되었습니다.');
+      navigate(routePaths.storeSettings);
+    } catch {
+      toast.error('입고 확정에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+    } finally {
+      setIsConfirming(false);
+    }
   };
 
   const handleBack = () => {
@@ -85,7 +107,7 @@ const OcrInboundPage = () => {
       <header className="shrink-0 h-14 border-b bg-card px-5 flex items-center gap-3">
         <button
           onClick={handleBack}
-          disabled={step === 'analyzing'}
+          disabled={step === 'analyzing' || isConfirming}
           className="flex items-center justify-center w-8 h-8 rounded-md hover:bg-muted transition-colors text-muted-foreground hover:text-foreground disabled:opacity-40 disabled:cursor-not-allowed"
           aria-label="뒤로 가기"
         >
@@ -122,6 +144,7 @@ const OcrInboundPage = () => {
             onItemsChange={setItems}
             onConfirm={handleConfirm}
             onReset={handleReset}
+            isConfirming={isConfirming}
           />
         )}
       </div>

--- a/src/pages/OcrInboundPage.tsx
+++ b/src/pages/OcrInboundPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { useQueryClient } from '@tanstack/react-query';
 import { ArrowLeft, ScanLine } from 'lucide-react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
@@ -11,7 +12,6 @@ import OcrReviewStep from '@/features/ocr-inbound/components/OcrReviewStep';
 import OcrUploadStep from '@/features/ocr-inbound/components/OcrUploadStep';
 import type { OcrInboundItem } from '@/features/ocr-inbound/types/ocrInbound.types';
 import { confirmInbound } from '@/features/store-settings/api/ingredients.api';
-import { useQueryClient } from '@tanstack/react-query';
 
 type Step = 'upload' | 'analyzing' | 'review';
 


### PR DESCRIPTION
## 📌 요약

- OCR 입고 처리에서 신규 식자재 등록 시 백엔드 API가 호출되지 않던 버그 수정
- 입고 확정 시 실제 inbound API 호출 및 설정 페이지 식자재 목록 자동 갱신 연동

<br/>

## 🏷️ 관련 이슈

- Closes #75

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- `IngredientRegisterModal`: `createIngredient` API 연동 — 신규 버튼 클릭 후 등록 시 백엔드에 식자재 실제 생성
- `OcrInboundPage.handleConfirm`: `applyInbound`(로컬 store) 제거, `POST /ingredients/inbound` API 호출로 교체
- 입고 확정 후 `['ingredients']` 쿼리 invalidate → 설정 페이지 식자재 목록 자동 갱신

<br/>

### 📂 세부 변경사항

- `ingredients.api.ts`: `confirmInbound` 함수 추가, `createIngredient`에 `safetyStock` 파라미터 지원
- `OcrInboundItem` 타입: 신규 등록 식자재 ID 저장용 `newIngredientId` 필드 추가
- `OcrReviewStep`: `MOCK_EXISTING_INGREDIENTS` 제거, `useIngredients()` 실제 API 데이터로 연결 모달 구성
- `OcrReviewStep`: `isConfirming` prop 추가, 입고 확정 버튼 로딩 처리

<br/>

## 📸 Screenshots

| Before | After |
| ------ | ----- |
| 신규 등록해도 설정 페이지에 미반영 | 등록 즉시 설정 페이지 식자재 목록에 반영 |

<br/>

## 🧪 테스트 방법

1. OCR 입고 처리 페이지에서 이미지 업로드
2. 인식된 항목 중 하나의 신규 버튼 클릭 → 식자재명·단위 입력 후 등록
3. 입고 확정 클릭
4. 설정 > 식자재 관리 페이지에서 등록한 식자재가 목록에 나타나는지 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [x] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- 연결 모달의 기존 식자재 목록도 MOCK에서 실제 API 데이터로 교체됨
