### PR TITLE
✨ (#77) feat: 대시보드 메모 카드 API 연동 (1초 디바운스 자동 저장)

### DIFF
--- a/src/features/dashboard/components/MemoCard.tsx
+++ b/src/features/dashboard/components/MemoCard.tsx
@@ -2,7 +2,10 @@ import { useEffect, useRef, useState } from 'react';
 
 import { PenLine } from 'lucide-react';
 
-import { useStoreSettings, useUpdateStoreSettings } from '@/features/store-settings/hooks/useStoreSettings';
+import {
+  useStoreSettings,
+  useUpdateStoreSettings,
+} from '@/features/store-settings/hooks/useStoreSettings';
 
 const DEBOUNCE_MS = 1000;
 

--- a/src/features/dashboard/components/MemoCard.tsx
+++ b/src/features/dashboard/components/MemoCard.tsx
@@ -1,9 +1,41 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { PenLine } from 'lucide-react';
 
+import { useStoreSettings, useUpdateStoreSettings } from '@/features/store-settings/hooks/useStoreSettings';
+
+const DEBOUNCE_MS = 1000;
+
 const MemoCard = () => {
+  const { data } = useStoreSettings();
+  const { mutate: updateStore } = useUpdateStoreSettings();
+
   const [memo, setMemo] = useState('');
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isInitialized = useRef(false);
+
+  useEffect(() => {
+    if (data && !isInitialized.current) {
+      setMemo(data.memo);
+      isInitialized.current = true;
+    }
+  }, [data]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const value = e.target.value;
+    setMemo(value);
+
+    if (debounceTimer.current) clearTimeout(debounceTimer.current);
+    debounceTimer.current = setTimeout(() => {
+      updateStore({ memo: value });
+    }, DEBOUNCE_MS);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (debounceTimer.current) clearTimeout(debounceTimer.current);
+    };
+  }, []);
 
   return (
     <div className="flex-1 flex flex-col bg-yellow-100 dark:bg-zinc-800 rounded-sm shadow-md relative overflow-hidden">
@@ -28,7 +60,7 @@ const MemoCard = () => {
           "
           placeholder={'오늘의 메모를 남겨보세요\n(예: 오후 2시 재고 실사)'}
           value={memo}
-          onChange={(e) => setMemo(e.target.value)}
+          onChange={handleChange}
         />
       </div>
 

--- a/src/features/store-settings/api/storeSettings.api.ts
+++ b/src/features/store-settings/api/storeSettings.api.ts
@@ -10,6 +10,7 @@ export async function fetchStoreSettings(storeId: string): Promise<StoreSettings
     ownerName: d.ownerName,
     businessType: d.businessType,
     category: d.category,
+    memo: d.memo ?? '',
   };
 }
 

--- a/src/features/store-settings/data/store-settings.mock.ts
+++ b/src/features/store-settings/data/store-settings.mock.ts
@@ -8,6 +8,7 @@ export const MOCK_STORE_SETTINGS: StoreSettings = {
   ownerName: '유다연',
   businessType: 'individual',
   category: 'cafe',
+  memo: '',
 };
 
 export const MOCK_STORE_STAFF: StoreStaff[] = [

--- a/src/features/store-settings/types/store-settings.types.ts
+++ b/src/features/store-settings/types/store-settings.types.ts
@@ -3,6 +3,7 @@ export interface StoreSettings {
   ownerName: string;
   businessType: 'franchise' | 'directly-operated' | 'individual';
   category: string;
+  memo: string;
 }
 
 export interface StoreStaff {


### PR DESCRIPTION
## 📌 요약

- 대시보드 MemoCard를 로컬 상태에서 실제 API 연동으로 교체
- 진입 시 저장된 메모 불러오기 + 입력 후 1초 디바운스 자동 저장

<br/>

## 🏷️ 관련 이슈

- Closes #77

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- `MemoCard`: `useStoreSettings`로 저장된 메모 초기값 로드, 입력 시 1초 디바운스 후 `PATCH /stores/:storeId` 자동 저장
- `StoreSettings` 타입에 `memo` 필드 추가
- `fetchStoreSettings`: `GET /stores/:storeId` 응답에서 `memo` 파싱

<br/>

### 📂 세부 변경사항

- 타이머 ref로 디바운스 관리, 언마운트 시 타이머 클리어
- 서버 데이터 최초 수신 시 1회만 초기화 (이후 사용자 입력값 유지)

<br/>

## 📸 Screenshots

| Before | After |
| ------ | ----- |
| 새로고침 시 메모 초기화 | 새로고침 후에도 메모 유지 |

<br/>

## 🧪 테스트 방법

1. 대시보드 메모 카드에 텍스트 입력
2. 1초 후 자동 저장 확인 (네트워크 탭에서 PATCH 요청 확인)
3. 새로고침 후 메모가 그대로 유지되는지 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [x] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- 백엔드 stores 테이블에 memo 컬럼 추가 필요 (백엔드 선행 작업 완료 기준으로 구현)
