### PR TITLE
✨ (#23) feat: OCR 입고 단가 저장 및 대시보드 월별 소비 집계 연동

### DIFF
--- a/src/features/ocr-inbound/api/ocr.api.ts
+++ b/src/features/ocr-inbound/api/ocr.api.ts
@@ -17,6 +17,7 @@ export async function uploadOcrImage(storeId: string, file: File): Promise<OcrIn
     name: item.name,
     quantity: item.amount,
     unit: item.unit,
+    unitPrice: item.unitPrice ?? null,
     isMatched: false,
   }));
 }

--- a/src/features/ocr-inbound/components/OcrReviewStep.tsx
+++ b/src/features/ocr-inbound/components/OcrReviewStep.tsx
@@ -113,7 +113,7 @@ const OcrReviewStep = ({
   const handleAdd = () => {
     onItemsChange([
       ...items,
-      { id: `new-${Date.now()}`, name: '', quantity: 0, unit: 'g', isMatched: false },
+      { id: `new-${Date.now()}`, name: '', quantity: 0, unit: 'g', unitPrice: null, isMatched: false },
     ]);
   };
 
@@ -214,11 +214,12 @@ const OcrReviewStep = ({
           </button>
         </div>
 
-        <div className="grid grid-cols-[24px_2fr_1.2fr_80px_1fr_36px] gap-3 px-4 py-2 bg-muted/40 border-b text-xs font-semibold text-muted-foreground uppercase tracking-wide shrink-0">
+        <div className="grid grid-cols-[24px_2fr_1.2fr_80px_1fr_1fr_36px] gap-3 px-4 py-2 bg-muted/40 border-b text-xs font-semibold text-muted-foreground uppercase tracking-wide shrink-0">
           <span />
           <span>식자재명</span>
           <span>수량</span>
           <span>단위</span>
+          <span>단가(원)</span>
           <span className="text-center">상태</span>
           <span />
         </div>
@@ -228,7 +229,7 @@ const OcrReviewStep = ({
             <div
               key={item.id}
               className={cn(
-                'grid grid-cols-[24px_2fr_1.2fr_80px_1fr_36px] gap-3 px-4 py-2.5 items-center border-b hover:bg-muted/10 transition-colors',
+                'grid grid-cols-[24px_2fr_1.2fr_80px_1fr_1fr_36px] gap-3 px-4 py-2.5 items-center border-b hover:bg-muted/10 transition-colors',
                 !item.isMatched && 'bg-green-50/20',
               )}
             >
@@ -268,6 +269,22 @@ const OcrReviewStep = ({
                   </SelectContent>
                 </Select>
               )}
+              <Input
+                type="number"
+                value={item.unitPrice ?? ''}
+                onChange={(e) =>
+                  onItemsChange(
+                    items.map((i) =>
+                      i.id === item.id
+                        ? { ...i, unitPrice: e.target.value === '' ? null : Number(e.target.value) }
+                        : i,
+                    ),
+                  )
+                }
+                className="h-8 text-sm"
+                min={0}
+                placeholder="미입력"
+              />
               <div className="flex items-center gap-1 justify-center flex-wrap">
                 {item.isMatched ? (
                   <span className="inline-flex items-center gap-1 text-xs text-baro-blue bg-blue-50 px-2 py-0.5 rounded-full border border-blue-200/60 whitespace-nowrap">

--- a/src/features/ocr-inbound/types/ocrInbound.types.ts
+++ b/src/features/ocr-inbound/types/ocrInbound.types.ts
@@ -5,6 +5,7 @@ export interface OcrInboundItem {
   name: string;
   quantity: number;
   unit: OcrUnit;
+  unitPrice: number | null;
   isMatched: boolean;
   matchedInventoryId?: string;
   newIngredientId?: string;

--- a/src/features/store-settings/api/ingredients.api.ts
+++ b/src/features/store-settings/api/ingredients.api.ts
@@ -23,7 +23,7 @@ export async function createIngredient(
 
 export async function confirmInbound(
   storeId: string,
-  items: { ingredientId: string; amount: number }[],
+  items: { ingredientId: string; amount: number; unitPrice?: number | null }[],
 ): Promise<void> {
   await axiosInstance.post(`/stores/${storeId}/ingredients/inbound`, { items });
 }

--- a/src/pages/OcrInboundPage.tsx
+++ b/src/pages/OcrInboundPage.tsx
@@ -78,6 +78,7 @@ const OcrInboundPage = () => {
     const inboundItems = items.map((item) => ({
       ingredientId: (item.matchedInventoryId ?? item.newIngredientId)!,
       amount: item.quantity,
+      unitPrice: item.unitPrice ?? null,
     }));
 
     setIsConfirming(true);


### PR DESCRIPTION
## 📌 요약

- OCR 입고 처리 시 단가(unitPrice)를 저장하도록 백엔드 변경에 맞춰 프론트엔드 연동
- 대시보드 월별 소비 차트가 `amount × unitPrice`로 계산된 실제 소비 금액을 표시

<br/>

## 🏷️ 관련 이슈

- Related to #23

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- `OcrReviewStep`: 단가(원) 컬럼 추가 — OCR 인식 단가를 표시하고 수정 가능
- `confirmInbound` API 호출 시 `unitPrice` 포함하여 전송
- 대시보드 `SalesConsumptionCard`는 백엔드가 실제 소비금액을 계산해 반환하므로 프론트 변경 없이 자동 반영

<br/>

### 📂 세부 변경사항

- `OcrInboundItem` 타입에 `unitPrice: number | null` 필드 추가
- `uploadOcrImage`: OCR 응답의 `unitPrice` 파싱하여 항목에 포함
- `confirmInbound`: `unitPrice` 파라미터 타입 추가
- `OcrInboundPage`: 입고 확정 시 `unitPrice` 전달

<br/>

## 📸 Screenshots

| Before | After |
| ------ | ----- |
| 단가 컬럼 없음, 소비 0원 표시 | 단가 입력 가능, 소비 실제 금액 표시 |

<br/>

## 🧪 테스트 방법

1. OCR 입고 처리 페이지에서 이미지 업로드
2. 인식 결과 테이블에 단가(원) 컬럼 표시 확인
3. 단가 수정 후 입고 확정
4. 대시보드 이번 달 현황 차트에서 소비 금액 반영 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [x] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- 백엔드 커밋 `902c7e3` (feat: 재고 입고 단가 저장 및 대시보드 월별 소비 집계) 기준으로 연동
