### PR TITLE
✨ (#82) feat: 전체 재고 현황 페이지 API 연동

### DIFF
--- a/src/features/inventory/components/InventoryTable.tsx
+++ b/src/features/inventory/components/InventoryTable.tsx
@@ -447,7 +447,7 @@ const InventoryTable = () => {
           <div className="flex-1 flex items-center justify-center py-16 text-center text-sm text-muted-foreground">
             {items.length === 0
               ? '등록된 재고가 없어요. OCR 입고처리로 재고를 등록해보세요.'
-              : showFavoritesOnly && favorites.size === 0
+              : showFavoritesOnly && favoriteCount === 0
                 ? '즐겨찾기한 항목이 없어요.'
                 : '검색 결과가 없어요.'}
           </div>

--- a/src/features/inventory/components/InventoryTable.tsx
+++ b/src/features/inventory/components/InventoryTable.tsx
@@ -283,7 +283,7 @@ const InventoryTable = () => {
   }
 
   return (
-    <Card>
+    <Card className="flex flex-col flex-1 min-h-0 overflow-hidden">
       {/* 카드 헤더 */}
       <CardHeader className="border-b pb-0">
         <div className="flex items-center justify-between gap-3 mb-3 flex-wrap">
@@ -412,7 +412,7 @@ const InventoryTable = () => {
         </div>
       </CardHeader>
 
-      <CardContent className="p-0">
+      <CardContent className="p-0 flex-1 min-h-0 flex flex-col overflow-hidden">
         {/* 컬럼 헤더 */}
         <div
           className={`hidden md:grid ${GRID} gap-4 px-5 py-2.5 bg-muted/40 border-b text-xs font-semibold text-muted-foreground uppercase tracking-wide`}
@@ -429,7 +429,7 @@ const InventoryTable = () => {
 
         {/* 행 목록 */}
         {isLoading ? (
-          <div className="divide-y">
+          <div className="divide-y flex-1 overflow-y-auto">
             {Array.from({ length: 5 }).map((_, i) => (
               <div key={i} className={`hidden md:grid ${GRID} gap-4 px-5 py-4 items-center`}>
                 <Skeleton className="w-4 h-4 rounded-full" />
@@ -444,7 +444,7 @@ const InventoryTable = () => {
             ))}
           </div>
         ) : sorted.length > 0 ? (
-          <div className="divide-y">
+          <div className="divide-y flex-1 overflow-y-auto">
             {sorted.map((item) => (
               <InventoryRow
                 key={item.id}
@@ -455,7 +455,7 @@ const InventoryTable = () => {
             ))}
           </div>
         ) : (
-          <div className="py-16 text-center text-sm text-muted-foreground">
+          <div className="flex-1 flex items-center justify-center py-16 text-center text-sm text-muted-foreground">
             {items.length === 0
               ? '등록된 재고가 없어요. OCR 입고처리로 재고를 등록해보세요.'
               : showFavoritesOnly && favorites.size === 0

--- a/src/features/inventory/components/InventoryTable.tsx
+++ b/src/features/inventory/components/InventoryTable.tsx
@@ -17,7 +17,7 @@ import { useNavigate } from 'react-router-dom';
 import { routePaths } from '@/app/routes/routePaths';
 import type { InventoryItem, InventoryStatus } from '@/features/inventory/types/inventory.types';
 import type { IngredientDto } from '@/features/store-settings/api/ingredients.api';
-import { useIngredients } from '@/features/store-settings/hooks/useIngredients';
+import { useIngredients, useToggleFavorite } from '@/features/store-settings/hooks/useIngredients';
 import { cn } from '@/lib/utils';
 import { Card, CardContent, CardHeader, CardTitle } from '@/shadcn/ui/card';
 import { Input } from '@/shadcn/ui/input';
@@ -48,6 +48,7 @@ function toInventoryItem(dto: IngredientDto): InventoryItem {
     recipeCount: dto.relatedMenus?.length ?? 0,
     inboundDate: dto.lastInboundDate ? dto.lastInboundDate.slice(0, 10) : '',
     expiryDate: dto.nearestExpiryDate ?? undefined,
+    isFavorite: dto.isFavorite ?? false,
     status,
   };
 }
@@ -114,11 +115,10 @@ const GRID = 'grid-cols-[32px_2fr_1.2fr_1.2fr_1.2fr_1.5fr_1fr_100px]';
 /* ── 행 컴포넌트 ── */
 interface InventoryRowProps {
   item: InventoryItem;
-  isFavorite: boolean;
-  onToggleFavorite: (id: string) => void;
+  onToggleFavorite: (id: string, current: boolean) => void;
 }
 
-const InventoryRow = ({ item, isFavorite, onToggleFavorite }: InventoryRowProps) => {
+const InventoryRow = ({ item, onToggleFavorite }: InventoryRowProps) => {
   const config = STATUS_CONFIG[item.status];
   const dday = getDday(item.expiryDate);
 
@@ -132,14 +132,14 @@ const InventoryRow = ({ item, isFavorite, onToggleFavorite }: InventoryRowProps)
     >
       {/* 즐겨찾기 버튼 */}
       <button
-        onClick={() => onToggleFavorite(item.id)}
+        onClick={() => onToggleFavorite(item.id, item.isFavorite)}
         className="flex items-center justify-center"
-        aria-label={isFavorite ? '즐겨찾기 해제' : '즐겨찾기 추가'}
+        aria-label={item.isFavorite ? '즐겨찾기 해제' : '즐겨찾기 추가'}
       >
         <Star
           className={cn(
             'w-4 h-4 transition-colors',
-            isFavorite
+            item.isFavorite
               ? 'fill-yellow-400 text-yellow-400'
               : 'text-muted-foreground/30 hover:text-yellow-400',
           )}
@@ -221,24 +221,16 @@ const InventoryRow = ({ item, isFavorite, onToggleFavorite }: InventoryRowProps)
 const InventoryTable = () => {
   const navigate = useNavigate();
   const { data: ingredientList = [], isLoading, isError } = useIngredients();
+  const toggleFavorite = useToggleFavorite();
   const items = ingredientList.map(toInventoryItem);
   const [search, setSearch] = useState('');
   const [activeTab, setActiveTab] = useState<FilterTab>('all');
-  const [favorites, setFavorites] = useState<Set<string>>(new Set());
   const [showFavoritesOnly, setShowFavoritesOnly] = useState(false);
   const [sortKey, setSortKey] = useState<SortKey>('default');
   const [sortDir, setSortDir] = useState<SortDir>('asc');
 
-  const handleToggleFavorite = (id: string) => {
-    setFavorites((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) {
-        next.delete(id);
-      } else {
-        next.add(id);
-      }
-      return next;
-    });
+  const handleToggleFavorite = (id: string, current: boolean) => {
+    toggleFavorite.mutate({ id, isFavorite: !current });
   };
 
   const handleSortClick = (key: SortKey) => {
@@ -250,13 +242,15 @@ const InventoryTable = () => {
     }
   };
 
+  const favoriteCount = items.filter((i) => i.isFavorite).length;
+
   const countByStatus = (status: InventoryStatus) =>
     items.filter((i) => i.status === status).length;
 
   const filtered = items.filter((item) => {
     const matchesSearch = item.name.toLowerCase().includes(search.toLowerCase());
     const matchesTab = activeTab === 'all' || item.status === activeTab;
-    const matchesFavorites = !showFavoritesOnly || favorites.has(item.id);
+    const matchesFavorites = !showFavoritesOnly || item.isFavorite;
     return matchesSearch && matchesTab && matchesFavorites;
   });
 
@@ -320,9 +314,9 @@ const InventoryTable = () => {
                 )}
               />
               즐겨찾기만
-              {showFavoritesOnly && favorites.size > 0 && (
+              {favoriteCount > 0 && (
                 <span className="ml-0.5 bg-yellow-400 text-white rounded-full w-4 h-4 inline-flex items-center justify-center text-[10px] font-bold">
-                  {favorites.size}
+                  {favoriteCount}
                 </span>
               )}
             </button>
@@ -446,12 +440,7 @@ const InventoryTable = () => {
         ) : sorted.length > 0 ? (
           <div className="divide-y flex-1 overflow-y-auto">
             {sorted.map((item) => (
-              <InventoryRow
-                key={item.id}
-                item={item}
-                isFavorite={favorites.has(item.id)}
-                onToggleFavorite={handleToggleFavorite}
-              />
+              <InventoryRow key={item.id} item={item} onToggleFavorite={handleToggleFavorite} />
             ))}
           </div>
         ) : (

--- a/src/features/inventory/components/InventoryTable.tsx
+++ b/src/features/inventory/components/InventoryTable.tsx
@@ -46,7 +46,7 @@ function toInventoryItem(dto: IngredientDto): InventoryItem {
     safetyStock: safety,
     safetyStockUnit: dto.unit,
     recipeCount: dto.relatedMenus?.length ?? 0,
-    inboundDate: dto.lastInboundDate ? dto.lastInboundDate.split('T')[0] : '',
+    inboundDate: dto.lastInboundDate ? dto.lastInboundDate.slice(0, 10) : '',
     expiryDate: dto.nearestExpiryDate ?? undefined,
     status,
   };
@@ -169,7 +169,11 @@ const InventoryRow = ({ item, isFavorite, onToggleFavorite }: InventoryRowProps)
 
       {/* 입고날짜 */}
       <div>
-        <span className="text-sm text-foreground">{item.inboundDate}</span>
+        {item.inboundDate ? (
+          <span className="text-sm text-foreground">{item.inboundDate}</span>
+        ) : (
+          <span className="text-sm text-muted-foreground/40">—</span>
+        )}
       </div>
 
       {/* 유통기한 */}

--- a/src/features/inventory/components/InventoryTable.tsx
+++ b/src/features/inventory/components/InventoryTable.tsx
@@ -15,11 +15,42 @@ import {
 import { useNavigate } from 'react-router-dom';
 
 import { routePaths } from '@/app/routes/routePaths';
-import { useInventoryStore } from '@/features/inventory/store/inventoryStore';
 import type { InventoryItem, InventoryStatus } from '@/features/inventory/types/inventory.types';
+import type { IngredientDto } from '@/features/store-settings/api/ingredients.api';
+import { useIngredients } from '@/features/store-settings/hooks/useIngredients';
 import { cn } from '@/lib/utils';
 import { Card, CardContent, CardHeader, CardTitle } from '@/shadcn/ui/card';
 import { Input } from '@/shadcn/ui/input';
+import { Skeleton } from '@/shadcn/ui/skeleton';
+
+/* ── API → UI 매퍼 ── */
+function toInventoryItem(dto: IngredientDto): InventoryItem {
+  const current = Number(dto.currentStock);
+  const safety = Number(dto.safetyStock);
+
+  let status: InventoryStatus;
+  if (current <= 0) status = 'depleted';
+  else if (safety === 0) status = 'normal';
+  else {
+    const ratio = current / safety;
+    if (ratio < 0.5) status = 'critical';
+    else if (ratio < 1.0) status = 'warning';
+    else status = 'normal';
+  }
+
+  return {
+    id: dto.id,
+    name: dto.name,
+    currentStock: current,
+    unit: dto.unit,
+    safetyStock: safety,
+    safetyStockUnit: dto.unit,
+    recipeCount: dto.relatedMenus?.length ?? 0,
+    inboundDate: dto.lastInboundDate ? dto.lastInboundDate.split('T')[0] : '',
+    expiryDate: dto.nearestExpiryDate ?? undefined,
+    status,
+  };
+}
 
 /* ── 상태 설정 ── */
 const STATUS_CONFIG: Record<
@@ -185,7 +216,8 @@ const InventoryRow = ({ item, isFavorite, onToggleFavorite }: InventoryRowProps)
 /* ── 메인 컴포넌트 ── */
 const InventoryTable = () => {
   const navigate = useNavigate();
-  const items = useInventoryStore((s) => s.items);
+  const { data: ingredientList = [], isLoading, isError } = useIngredients();
+  const items = ingredientList.map(toInventoryItem);
   const [search, setSearch] = useState('');
   const [activeTab, setActiveTab] = useState<FilterTab>('all');
   const [favorites, setFavorites] = useState<Set<string>>(new Set());
@@ -227,12 +259,24 @@ const InventoryTable = () => {
   const sorted = [...filtered].sort((a, b) => {
     if (sortKey === 'default') return 0;
 
-    const aVal = sortKey === 'expiryDate' ? (a.expiryDate ?? '9999-99-99') : a.inboundDate;
-    const bVal = sortKey === 'expiryDate' ? (b.expiryDate ?? '9999-99-99') : b.inboundDate;
+    const aVal =
+      sortKey === 'expiryDate' ? (a.expiryDate ?? '9999-99-99') : a.inboundDate || '0000-00-00';
+    const bVal =
+      sortKey === 'expiryDate' ? (b.expiryDate ?? '9999-99-99') : b.inboundDate || '0000-00-00';
 
     const cmp = aVal.localeCompare(bVal);
     return sortDir === 'asc' ? cmp : -cmp;
   });
+
+  if (isError) {
+    return (
+      <Card>
+        <CardContent className="py-16 text-center text-sm text-muted-foreground">
+          재고 목록을 불러오는 데 실패했습니다. 잠시 후 다시 시도해 주세요.
+        </CardContent>
+      </Card>
+    );
+  }
 
   return (
     <Card>
@@ -380,7 +424,22 @@ const InventoryTable = () => {
         </div>
 
         {/* 행 목록 */}
-        {sorted.length > 0 ? (
+        {isLoading ? (
+          <div className="divide-y">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} className={`hidden md:grid ${GRID} gap-4 px-5 py-4 items-center`}>
+                <Skeleton className="w-4 h-4 rounded-full" />
+                <Skeleton className="h-4 w-3/4" />
+                <Skeleton className="h-4 w-16" />
+                <Skeleton className="h-4 w-16" />
+                <Skeleton className="h-4 w-20" />
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-4 w-12" />
+                <Skeleton className="h-6 w-16 rounded-full mx-auto" />
+              </div>
+            ))}
+          </div>
+        ) : sorted.length > 0 ? (
           <div className="divide-y">
             {sorted.map((item) => (
               <InventoryRow
@@ -393,9 +452,11 @@ const InventoryTable = () => {
           </div>
         ) : (
           <div className="py-16 text-center text-sm text-muted-foreground">
-            {showFavoritesOnly && favorites.size === 0
-              ? '즐겨찾기한 항목이 없어요.'
-              : '검색 결과가 없어요.'}
+            {items.length === 0
+              ? '등록된 재고가 없어요. OCR 입고처리로 재고를 등록해보세요.'
+              : showFavoritesOnly && favorites.size === 0
+                ? '즐겨찾기한 항목이 없어요.'
+                : '검색 결과가 없어요.'}
           </div>
         )}
       </CardContent>

--- a/src/features/inventory/data/inventory.mock.ts
+++ b/src/features/inventory/data/inventory.mock.ts
@@ -11,6 +11,7 @@ export const MOCK_INVENTORY_ITEMS: InventoryItem[] = [
     safetyStockUnit: 'kg',
     recipeCount: 3,
     inboundDate: '2026-05-19',
+    isFavorite: false,
     status: 'critical',
   },
   {
@@ -23,6 +24,7 @@ export const MOCK_INVENTORY_ITEMS: InventoryItem[] = [
     safetyStockUnit: 'kg',
     recipeCount: 2,
     inboundDate: '2026-05-18',
+    isFavorite: false,
     status: 'normal',
   },
   {
@@ -36,6 +38,7 @@ export const MOCK_INVENTORY_ITEMS: InventoryItem[] = [
     recipeCount: 8,
     inboundDate: '2026-05-20',
     expiryDate: '2026-05-22',
+    isFavorite: false,
     status: 'critical',
   },
   {
@@ -49,6 +52,7 @@ export const MOCK_INVENTORY_ITEMS: InventoryItem[] = [
     recipeCount: 4,
     inboundDate: '2026-05-18',
     expiryDate: '2026-05-28',
+    isFavorite: false,
     status: 'normal',
   },
   {
@@ -62,6 +66,7 @@ export const MOCK_INVENTORY_ITEMS: InventoryItem[] = [
     recipeCount: 5,
     inboundDate: '2026-05-17',
     expiryDate: '2026-05-24',
+    isFavorite: false,
     status: 'critical',
   },
   {
@@ -75,6 +80,7 @@ export const MOCK_INVENTORY_ITEMS: InventoryItem[] = [
     recipeCount: 3,
     inboundDate: '2026-05-15',
     expiryDate: '2026-05-24',
+    isFavorite: false,
     status: 'warning',
   },
   {
@@ -87,6 +93,7 @@ export const MOCK_INVENTORY_ITEMS: InventoryItem[] = [
     safetyStockUnit: 'ml',
     recipeCount: 2,
     inboundDate: '2026-05-14',
+    isFavorite: false,
     status: 'normal',
   },
   {
@@ -99,6 +106,7 @@ export const MOCK_INVENTORY_ITEMS: InventoryItem[] = [
     safetyStockUnit: 'ml',
     recipeCount: 1,
     inboundDate: '2026-05-12',
+    isFavorite: false,
     status: 'normal',
   },
   {
@@ -111,6 +119,7 @@ export const MOCK_INVENTORY_ITEMS: InventoryItem[] = [
     safetyStockUnit: 'g',
     recipeCount: 2,
     inboundDate: '2026-05-16',
+    isFavorite: false,
     status: 'normal',
   },
   {
@@ -123,6 +132,7 @@ export const MOCK_INVENTORY_ITEMS: InventoryItem[] = [
     safetyStockUnit: 'g',
     recipeCount: 2,
     inboundDate: '2026-05-15',
+    isFavorite: false,
     status: 'normal',
   },
   {
@@ -136,6 +146,7 @@ export const MOCK_INVENTORY_ITEMS: InventoryItem[] = [
     recipeCount: 2,
     inboundDate: '2026-05-10',
     expiryDate: '2026-06-10',
+    isFavorite: false,
     status: 'normal',
   },
   {
@@ -149,6 +160,7 @@ export const MOCK_INVENTORY_ITEMS: InventoryItem[] = [
     recipeCount: 1,
     inboundDate: '2026-05-08',
     expiryDate: '2026-06-20',
+    isFavorite: false,
     status: 'normal',
   },
   {
@@ -161,6 +173,7 @@ export const MOCK_INVENTORY_ITEMS: InventoryItem[] = [
     safetyStockUnit: 'kg',
     recipeCount: 6,
     inboundDate: '2026-05-18',
+    isFavorite: false,
     status: 'warning',
   },
   {
@@ -174,6 +187,7 @@ export const MOCK_INVENTORY_ITEMS: InventoryItem[] = [
     recipeCount: 3,
     inboundDate: '2026-05-13',
     expiryDate: '2026-06-01',
+    isFavorite: false,
     status: 'normal',
   },
   {
@@ -186,6 +200,7 @@ export const MOCK_INVENTORY_ITEMS: InventoryItem[] = [
     safetyStockUnit: '개',
     recipeCount: 0,
     inboundDate: '2026-05-10',
+    isFavorite: false,
     status: 'normal',
   },
   {
@@ -198,6 +213,7 @@ export const MOCK_INVENTORY_ITEMS: InventoryItem[] = [
     safetyStockUnit: '개',
     recipeCount: 0,
     inboundDate: '2026-05-19',
+    isFavorite: false,
     status: 'warning',
   },
 ];

--- a/src/features/inventory/types/inventory.types.ts
+++ b/src/features/inventory/types/inventory.types.ts
@@ -3,7 +3,7 @@ export type InventoryStatus = 'normal' | 'warning' | 'critical' | 'depleted';
 export interface InventoryItem {
   id: string;
   name: string;
-  category: string;
+  category?: string;
   currentStock: number;
   unit: string;
   safetyStock: number;

--- a/src/features/inventory/types/inventory.types.ts
+++ b/src/features/inventory/types/inventory.types.ts
@@ -12,4 +12,5 @@ export interface InventoryItem {
   inboundDate: string; // 'YYYY-MM-DD' 입고날짜
   expiryDate?: string; // 'YYYY-MM-DD' 유통기한
   status: InventoryStatus;
+  isFavorite: boolean;
 }

--- a/src/features/store-settings/api/ingredients.api.ts
+++ b/src/features/store-settings/api/ingredients.api.ts
@@ -9,6 +9,7 @@ export interface IngredientDto {
   nearestExpiryDate: string | null;
   lastInboundDate: string | null;
   relatedMenus: string[];
+  isFavorite: boolean;
 }
 
 export async function fetchIngredients(storeId: string): Promise<IngredientDto[]> {

--- a/src/features/store-settings/api/ingredients.api.ts
+++ b/src/features/store-settings/api/ingredients.api.ts
@@ -19,7 +19,7 @@ export async function fetchIngredients(storeId: string): Promise<IngredientDto[]
 
 export async function createIngredient(
   storeId: string,
-  data: Omit<IngredientDto, 'id' | 'currentStock' | 'safetyStock'> & { safetyStock?: number },
+  data: { name: string; unit: 'g' | 'ml' | '개'; safetyStock?: number },
 ): Promise<IngredientDto> {
   const res = await axiosInstance.post(`/stores/${storeId}/ingredients`, data);
   return res.data.data;

--- a/src/features/store-settings/api/ingredients.api.ts
+++ b/src/features/store-settings/api/ingredients.api.ts
@@ -6,6 +6,9 @@ export interface IngredientDto {
   unit: 'g' | 'ml' | '개';
   currentStock: string;
   safetyStock: string;
+  nearestExpiryDate: string | null;
+  lastInboundDate: string | null;
+  relatedMenus: string[];
 }
 
 export async function fetchIngredients(storeId: string): Promise<IngredientDto[]> {

--- a/src/features/store-settings/hooks/useIngredients.ts
+++ b/src/features/store-settings/hooks/useIngredients.ts
@@ -5,6 +5,7 @@ import {
   fetchIngredients,
   createIngredient,
   deleteIngredient,
+  updateIngredient,
   type IngredientDto,
 } from '@/features/store-settings/api/ingredients.api';
 
@@ -32,5 +33,28 @@ export function useDeleteIngredient() {
   return useMutation({
     mutationFn: (id: string) => deleteIngredient(storeId!, id),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['ingredients', storeId] }),
+  });
+}
+
+export function useToggleFavorite() {
+  const storeId = useAuthStore((s) => s.storeId);
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, isFavorite }: { id: string; isFavorite: boolean }) =>
+      updateIngredient(storeId!, id, { isFavorite }),
+    onMutate: async ({ id, isFavorite }) => {
+      await qc.cancelQueries({ queryKey: ['ingredients', storeId] });
+      const previous = qc.getQueryData<IngredientDto[]>(['ingredients', storeId]);
+      qc.setQueryData<IngredientDto[]>(['ingredients', storeId], (old) =>
+        old?.map((item) => (item.id === id ? { ...item, isFavorite } : item)),
+      );
+      return { previous };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.previous) {
+        qc.setQueryData(['ingredients', storeId], ctx.previous);
+      }
+    },
+    onSettled: () => qc.invalidateQueries({ queryKey: ['ingredients', storeId] }),
   });
 }

--- a/src/pages/InventoryPage.tsx
+++ b/src/pages/InventoryPage.tsx
@@ -2,7 +2,7 @@ import InventoryTable from '@/features/inventory/components/InventoryTable';
 
 const InventoryPage = () => {
   return (
-    <div className="flex flex-col gap-6 p-6">
+    <div className="flex flex-col h-full min-h-0 overflow-hidden p-6">
       <InventoryTable />
     </div>
   );


### PR DESCRIPTION
## 📌 요약

- 전체 재고 현황 페이지 목 데이터 제거 및 실제 API 연동
- 식자재 즐겨찾기 기능 API 연동 (낙관적 업데이트)
- 행 영역 내부 스크롤 적용
- 입고날짜 타임스탬프 → 날짜만 표시 수정

<br/>

## 🏷️ 관련 이슈

- Closes #82

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- \useInventoryStore\ (Zustand 목 스토어) 제거 → \useIngredients()\ 실제 API 연동
- 즐겨찾기 별 클릭 시 \PATCH /stores/:storeId/ingredients/:id\ 호출, 낙관적 업데이트 적용
- 카드 헤더·컬럼 헤더 고정, 식자재 행 영역만 내부 스크롤
- 입고날짜 \2026-06-13 07:44:47.822612\ → \2026-06-13\ 형태로 표시

<br/>

### 📂 세부 변경사항

- \IngredientDto\에 \lastInboundDate\, \elatedMenus\, \
earestExpiryDate\, \isFavorite\ 필드 추가
- \InventoryItem\ 타입에 \isFavorite\ 추가, \category\ 옵셔널로 변경
- \	oInventoryItem\ 매퍼 함수 추가 (상태 자동 계산: normal/warning/critical/depleted)
- \useToggleFavorite\ 뮤테이션 훅 추가 (onMutate 낙관적 업데이트 + 실패 시 롤백)
- Skeleton 로딩 5행, 에러 상태, 빈 재고 안내 문구 처리
- 백엔드 GET \/ingredients\ 응답에 \isFavorite\ 누락 버그 수정 (백엔드 직접 수정)

<br/>

## 🧪 테스트 방법

1. 전체 재고 현황 페이지 접속 후 식자재 목록 로딩 확인
2. 별 아이콘 클릭 → 즉시 노란색으로 변경되는지 확인 (낙관적 업데이트)
3. 새로고침 후 즐겨찾기 상태 유지 확인
4. 즐겨찾기만 필터 버튼 클릭 → 즐겨찾기 항목만 표시 확인
5. 식자재 행이 많을 때 행 영역만 스크롤되는지 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [x] Backend
- [x] API

<br/>

## 🔎 체크리스트

- [ ] 빌드 정상 동작 확인
- [ ] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음

<br/>

## 💬 Additional Notes

- 백엔드 GET \/ingredients\ 쿼리에서 \isFavorite\ 셀렉트 누락으로 즐겨찾기가 동작하지 않던 버그를 함께 수정함