### PR TITLE
✨ (#86) feat: 손님 메뉴판 카테고리 탭·테마·배너 포지션 및 메뉴판 설정 페이지 분리

### DIFF
--- a/src/app/routes/Router.tsx
+++ b/src/app/routes/Router.tsx
@@ -14,6 +14,7 @@ import NotFoundPage from '@/pages/NotFoundPage';
 import OcrInboundPage from '@/pages/OcrInboundPage';
 import OrderGuidePage from '@/pages/OrderGuidePage';
 import SettingsIngredientsPage from '@/pages/SettingsIngredientsPage';
+import SettingsMenuBoardPage from '@/pages/SettingsMenuBoardPage';
 import SettingsMenusPage from '@/pages/SettingsMenusPage';
 import SettingsRecipesPage from '@/pages/SettingsRecipesPage';
 import StoreSelectionPage from '@/pages/StoreSelectionPage';
@@ -41,6 +42,7 @@ export default function Router() {
         {/* 가게 설정 */}
         <Route path={routePaths.storeSettings} element={<StoreSettingsPage />} />
         <Route path={routePaths.storeSettingsMenus} element={<SettingsMenusPage />} />
+        <Route path={routePaths.storeSettingsMenuBoard} element={<SettingsMenuBoardPage />} />
         <Route path={routePaths.storeSettingsRecipes} element={<SettingsRecipesPage />} />
         <Route path={routePaths.storeSettingsIngredients} element={<SettingsIngredientsPage />} />
         {/* 회원 설정 */}

--- a/src/app/routes/routePaths.ts
+++ b/src/app/routes/routePaths.ts
@@ -10,6 +10,7 @@ export const routePaths = {
   notifications: '/notifications',
   storeSettings: '/store-settings',
   storeSettingsMenus: '/store-settings/menus',
+  storeSettingsMenuBoard: '/store-settings/menu-board',
   storeSettingsRecipes: '/store-settings/recipes',
   storeSettingsIngredients: '/store-settings/ingredients',
   settings: '/settings',

--- a/src/features/customer-order/api/menu.api.ts
+++ b/src/features/customer-order/api/menu.api.ts
@@ -1,4 +1,8 @@
-import type { ApiMenu } from '@/features/customer-order/types/customerOrder.api.types';
+import type {
+  ApiMenu,
+  ApiMenuCategory,
+  ApiStoreTheme,
+} from '@/features/customer-order/types/customerOrder.api.types';
 import publicAxiosInstance from '@/shared/api/publicAxiosInstance';
 
 // ⚠️ GET /stores/:storeId/menus 는 현재 백엔드에서 인증 필수.
@@ -6,4 +10,14 @@ import publicAxiosInstance from '@/shared/api/publicAxiosInstance';
 export const fetchStoreMenus = (storeId: string): Promise<ApiMenu[]> =>
   publicAxiosInstance
     .get<{ success: boolean; data: ApiMenu[] }>(`/stores/${storeId}/menus`)
+    .then((res) => res.data.data);
+
+export const fetchStoreMenuCategories = (storeId: string): Promise<ApiMenuCategory[]> =>
+  publicAxiosInstance
+    .get<{ success: boolean; data: ApiMenuCategory[] }>(`/stores/${storeId}/menu-categories`)
+    .then((res) => res.data.data);
+
+export const fetchStoreTheme = (storeId: string): Promise<ApiStoreTheme> =>
+  publicAxiosInstance
+    .get<{ success: boolean; data: ApiStoreTheme }>(`/stores/${storeId}/theme`)
     .then((res) => res.data.data);

--- a/src/features/customer-order/types/customerOrder.api.types.ts
+++ b/src/features/customer-order/types/customerOrder.api.types.ts
@@ -1,3 +1,28 @@
+export interface ApiMenuCategory {
+  id: string;
+  name: string;
+  order: number;
+}
+
+export interface ApiStoreTheme {
+  themeColor:
+    | 'navy'
+    | 'slate'
+    | 'teal'
+    | 'charcoal'
+    | 'mauve'
+    | 'sage'
+    | 'lavender'
+    | 'terra'
+    | 'warmgray'
+    | 'coolgray'
+    | 'blue'
+    | 'green';
+  layout: 'list' | 'grid';
+  bannerImageUrl: string | null;
+  bannerPosition: string;
+}
+
 export interface ApiMenu {
   id: string;
   storeId: string;
@@ -6,6 +31,7 @@ export interface ApiMenu {
   description: string | null;
   imageUrl: string | null;
   isAvailable: boolean;
+  categoryId: string | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/src/features/store-settings/api/menuCategories.api.ts
+++ b/src/features/store-settings/api/menuCategories.api.ts
@@ -1,0 +1,36 @@
+import axiosInstance from '@/shared/api/axiosInstance';
+
+export interface MenuCategoryDto {
+  id: string;
+  name: string;
+  order: number;
+}
+
+export async function fetchMenuCategories(storeId: string): Promise<MenuCategoryDto[]> {
+  const res = await axiosInstance.get(`/stores/${storeId}/menu-categories`);
+  return res.data.data;
+}
+
+export async function createMenuCategory(storeId: string, name: string): Promise<MenuCategoryDto> {
+  const res = await axiosInstance.post(`/stores/${storeId}/menu-categories`, { name });
+  return res.data.data;
+}
+
+export async function updateMenuCategory(
+  storeId: string,
+  categoryId: string,
+  name: string,
+): Promise<MenuCategoryDto> {
+  const res = await axiosInstance.patch(`/stores/${storeId}/menu-categories/${categoryId}`, {
+    name,
+  });
+  return res.data.data;
+}
+
+export async function deleteMenuCategory(storeId: string, categoryId: string): Promise<void> {
+  await axiosInstance.delete(`/stores/${storeId}/menu-categories/${categoryId}`);
+}
+
+export async function reorderMenuCategories(storeId: string, categoryIds: string[]): Promise<void> {
+  await axiosInstance.patch(`/stores/${storeId}/menu-categories/reorder`, { categoryIds });
+}

--- a/src/features/store-settings/api/menus.api.ts
+++ b/src/features/store-settings/api/menus.api.ts
@@ -7,6 +7,7 @@ export interface MenuDto {
   description: string | null;
   imageUrl: string | null;
   isAvailable: boolean;
+  categoryId: string | null;
 }
 
 export async function fetchMenus(storeId: string): Promise<MenuDto[]> {

--- a/src/features/store-settings/api/storeTheme.api.ts
+++ b/src/features/store-settings/api/storeTheme.api.ts
@@ -1,0 +1,106 @@
+import axiosInstance from '@/shared/api/axiosInstance';
+
+export type ThemeColor =
+  | 'navy'
+  | 'slate'
+  | 'teal'
+  | 'charcoal'
+  | 'mauve'
+  | 'sage'
+  | 'lavender'
+  | 'terra'
+  | 'warmgray'
+  | 'coolgray'
+  | 'blue'
+  | 'green';
+
+export type MenuLayout = 'list' | 'grid';
+
+export interface StoreThemeDto {
+  themeColor: ThemeColor;
+  layout: MenuLayout;
+  bannerImageUrl: string | null;
+  bannerPosition: string;
+}
+
+export const THEME_COLOR_GROUPS: {
+  label: string;
+  colors: { key: ThemeColor; label: string; hex: string }[];
+}[] = [
+  {
+    label: '모던',
+    colors: [
+      { key: 'navy', label: '네이비', hex: '#1B3A5C' },
+      { key: 'slate', label: '슬레이트', hex: '#3D5166' },
+      { key: 'teal', label: '딥틸', hex: '#1B4547' },
+      { key: 'charcoal', label: '차콜', hex: '#3A3F47' },
+    ],
+  },
+  {
+    label: '파스텔',
+    colors: [
+      { key: 'mauve', label: '모브', hex: '#9E7A84' },
+      { key: 'sage', label: '세이지', hex: '#6A9E78' },
+      { key: 'lavender', label: '라벤더', hex: '#8A80B4' },
+      { key: 'terra', label: '테라코타', hex: '#B07868' },
+    ],
+  },
+  {
+    label: '심플',
+    colors: [
+      { key: 'warmgray', label: '웜그레이', hex: '#867B72' },
+      { key: 'coolgray', label: '쿨그레이', hex: '#5F6C78' },
+    ],
+  },
+  {
+    label: '바로',
+    colors: [
+      { key: 'blue', label: '바로블루', hex: '#449CD4' },
+      { key: 'green', label: '바로그린', hex: '#679436' },
+    ],
+  },
+];
+
+export const THEME_HEX: Record<ThemeColor, string> = {
+  navy: '#1B3A5C',
+  slate: '#3D5166',
+  teal: '#1B4547',
+  charcoal: '#3A3F47',
+  mauve: '#9E7A84',
+  sage: '#6A9E78',
+  lavender: '#8A80B4',
+  terra: '#B07868',
+  warmgray: '#867B72',
+  coolgray: '#5F6C78',
+  blue: '#449CD4',
+  green: '#679436',
+};
+
+export const DEFAULT_THEME: StoreThemeDto = {
+  themeColor: 'blue',
+  layout: 'list',
+  bannerImageUrl: null,
+  bannerPosition: '50% 50%',
+};
+
+export async function fetchStoreTheme(storeId: string): Promise<StoreThemeDto> {
+  const res = await axiosInstance.get(`/stores/${storeId}/theme`);
+  return res.data.data;
+}
+
+export async function updateStoreTheme(
+  storeId: string,
+  data: StoreThemeDto,
+): Promise<StoreThemeDto> {
+  const res = await axiosInstance.patch(`/stores/${storeId}/theme`, data);
+  return res.data.data;
+}
+
+export async function uploadBannerImage(storeId: string, file: File): Promise<string> {
+  const formData = new FormData();
+  formData.append('file', file);
+  const res = await axiosInstance.post(`/stores/${storeId}/theme/banner`, formData, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  });
+  return res.data.data.url;
+}

--- a/src/features/store-settings/components/sections/StoreOperationSection.tsx
+++ b/src/features/store-settings/components/sections/StoreOperationSection.tsx
@@ -1,4 +1,4 @@
-import { ChevronRight, ClipboardList, Layers, Salad, UtensilsCrossed } from 'lucide-react';
+import { ChevronRight, ClipboardList, Layers, Palette, Salad, UtensilsCrossed } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
 import { routePaths } from '@/app/routes/routePaths';
@@ -42,6 +42,12 @@ const StoreOperationSection = () => {
           label="메뉴 관리"
           description="판매 중인 메뉴 목록을 추가·수정·삭제합니다."
           onClick={() => navigate(routePaths.storeSettingsMenus)}
+        />
+        <NavRow
+          icon={<Palette className="h-4 w-4" />}
+          label="메뉴판 설정"
+          description="손님 메뉴판의 테마 색상, 레이아웃, 배너 이미지를 설정합니다."
+          onClick={() => navigate(routePaths.storeSettingsMenuBoard)}
         />
         <NavRow
           icon={<UtensilsCrossed className="h-4 w-4" />}

--- a/src/features/store-settings/hooks/useMenuCategories.ts
+++ b/src/features/store-settings/hooks/useMenuCategories.ts
@@ -1,0 +1,59 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+
+import useAuthStore from '@/features/auth/store/authStore';
+import {
+  fetchMenuCategories,
+  createMenuCategory,
+  updateMenuCategory,
+  deleteMenuCategory,
+  reorderMenuCategories,
+} from '@/features/store-settings/api/menuCategories.api';
+
+export function useMenuCategories() {
+  const storeId = useAuthStore((s) => s.storeId);
+  return useQuery({
+    queryKey: ['menu-categories', storeId],
+    queryFn: () => fetchMenuCategories(storeId!),
+    enabled: !!storeId,
+  });
+}
+
+export function useCreateMenuCategory() {
+  const storeId = useAuthStore((s) => s.storeId);
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (name: string) => createMenuCategory(storeId!, name),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['menu-categories', storeId] }),
+  });
+}
+
+export function useUpdateMenuCategory() {
+  const storeId = useAuthStore((s) => s.storeId);
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ categoryId, name }: { categoryId: string; name: string }) =>
+      updateMenuCategory(storeId!, categoryId, name),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['menu-categories', storeId] }),
+  });
+}
+
+export function useDeleteMenuCategory() {
+  const storeId = useAuthStore((s) => s.storeId);
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (categoryId: string) => deleteMenuCategory(storeId!, categoryId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['menu-categories', storeId] });
+      qc.invalidateQueries({ queryKey: ['menus', storeId] });
+    },
+  });
+}
+
+export function useReorderMenuCategories() {
+  const storeId = useAuthStore((s) => s.storeId);
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (categoryIds: string[]) => reorderMenuCategories(storeId!, categoryIds),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['menu-categories', storeId] }),
+  });
+}

--- a/src/features/store-settings/hooks/useStoreTheme.ts
+++ b/src/features/store-settings/hooks/useStoreTheme.ts
@@ -1,0 +1,26 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+
+import useAuthStore from '@/features/auth/store/authStore';
+import {
+  fetchStoreTheme,
+  updateStoreTheme,
+  type StoreThemeDto,
+} from '@/features/store-settings/api/storeTheme.api';
+
+export function useStoreTheme() {
+  const storeId = useAuthStore((s) => s.storeId);
+  return useQuery({
+    queryKey: ['store-theme', storeId],
+    queryFn: () => fetchStoreTheme(storeId!),
+    enabled: !!storeId,
+  });
+}
+
+export function useUpdateStoreTheme() {
+  const storeId = useAuthStore((s) => s.storeId);
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: StoreThemeDto) => updateStoreTheme(storeId!, data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['store-theme', storeId] }),
+  });
+}

--- a/src/pages/CustomerOrderPage.tsx
+++ b/src/pages/CustomerOrderPage.tsx
@@ -163,17 +163,18 @@ interface OrderSuccessProps {
   orderId: string;
   totalAmount: number;
   items: CartItem[];
+  themeHex: string;
   onReorder: () => void;
 }
 
-const OrderSuccess = ({ orderId, totalAmount, items, onReorder }: OrderSuccessProps) => {
+const OrderSuccess = ({ orderId, totalAmount, items, themeHex, onReorder }: OrderSuccessProps) => {
   const [expanded, setExpanded] = useState(false);
   const hasMore = items.length > PREVIEW_COUNT;
   const visibleItems = expanded ? items : items.slice(0, PREVIEW_COUNT);
 
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col items-center justify-center px-6 gap-4">
-      <div className="size-14 rounded-full bg-baro-blue flex items-center justify-center">
+      <div className="size-14 rounded-full flex items-center justify-center" style={{ backgroundColor: themeHex }}>
         <CheckCircle className="size-7 text-white" strokeWidth={2.5} />
       </div>
       <div className="text-center">
@@ -209,12 +210,13 @@ const OrderSuccess = ({ orderId, totalAmount, items, onReorder }: OrderSuccessPr
           </div>
           <div className="border-t pt-3 flex justify-between items-center text-sm">
             <span className="text-gray-500 font-medium">합계</span>
-            <span className="font-bold text-baro-blue">{totalAmount.toLocaleString()}원</span>
+            <span className="font-bold" style={{ color: themeHex }}>{totalAmount.toLocaleString()}원</span>
           </div>
         </CardContent>
       </Card>
       <Button
-        className="w-full max-w-xs bg-baro-blue text-white hover:bg-baro-blue/90 rounded-xl h-11 text-sm font-semibold"
+        className="w-full max-w-xs text-white rounded-xl h-11 text-sm font-semibold"
+        style={{ backgroundColor: themeHex }}
         onClick={onReorder}
       >
         다시 주문하기
@@ -325,6 +327,7 @@ const CustomerOrderPage = () => {
         orderId={successInfo.orderId}
         totalAmount={successInfo.totalAmount}
         items={successInfo.items}
+        themeHex={themeHex}
         onReorder={() => setSuccessInfo(null)}
       />
     );

--- a/src/pages/CustomerOrderPage.tsx
+++ b/src/pages/CustomerOrderPage.tsx
@@ -174,7 +174,10 @@ const OrderSuccess = ({ orderId, totalAmount, items, themeHex, onReorder }: Orde
 
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col items-center justify-center px-6 gap-4">
-      <div className="size-14 rounded-full flex items-center justify-center" style={{ backgroundColor: themeHex }}>
+      <div
+        className="size-14 rounded-full flex items-center justify-center"
+        style={{ backgroundColor: themeHex }}
+      >
         <CheckCircle className="size-7 text-white" strokeWidth={2.5} />
       </div>
       <div className="text-center">
@@ -210,7 +213,9 @@ const OrderSuccess = ({ orderId, totalAmount, items, themeHex, onReorder }: Orde
           </div>
           <div className="border-t pt-3 flex justify-between items-center text-sm">
             <span className="text-gray-500 font-medium">합계</span>
-            <span className="font-bold" style={{ color: themeHex }}>{totalAmount.toLocaleString()}원</span>
+            <span className="font-bold" style={{ color: themeHex }}>
+              {totalAmount.toLocaleString()}원
+            </span>
           </div>
         </CardContent>
       </Card>

--- a/src/pages/CustomerOrderPage.tsx
+++ b/src/pages/CustomerOrderPage.tsx
@@ -1,13 +1,22 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { AlertCircle, CheckCircle, Loader2, Minus, Plus, ShoppingCart } from 'lucide-react';
 import { useParams, useSearchParams } from 'react-router-dom';
 
-import { fetchStoreMenus } from '@/features/customer-order/api/menu.api';
+import {
+  fetchStoreMenuCategories,
+  fetchStoreMenus,
+  fetchStoreTheme,
+} from '@/features/customer-order/api/menu.api';
 import { createOrder } from '@/features/customer-order/api/order.api';
-import type { ApiMenu } from '@/features/customer-order/types/customerOrder.api.types';
+import type {
+  ApiMenu,
+  ApiStoreTheme,
+} from '@/features/customer-order/types/customerOrder.api.types';
 import type { CartItem } from '@/features/customer-order/types/customerOrder.types';
+import { THEME_HEX } from '@/features/store-settings/api/storeTheme.api';
+import { cn } from '@/lib/utils';
 import { Button } from '@/shadcn/ui/button';
 import { Card, CardContent } from '@/shadcn/ui/card';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/shadcn/ui/dialog';
@@ -15,24 +24,32 @@ import { Input } from '@/shadcn/ui/input';
 import { Label } from '@/shadcn/ui/label';
 import { Skeleton } from '@/shadcn/ui/skeleton';
 
-type CategoryTab = 'all' | 'available';
+const DEFAULT_THEME: ApiStoreTheme = {
+  themeColor: 'blue',
+  layout: 'list',
+  bannerImageUrl: null,
+  bannerPosition: '50% 50%',
+};
 
-/* ── 메뉴 아이템 카드 ── */
+/* ── 메뉴 아이템 카드 (리스트) ── */
 interface MenuItemCardProps {
   item: ApiMenu;
   quantity: number;
+  themeHex: string;
   onUpdate: (id: string, delta: number) => void;
 }
 
-const MenuItemCard = ({ item, quantity, onUpdate }: MenuItemCardProps) => (
+const MenuItemListCard = ({ item, quantity, themeHex, onUpdate }: MenuItemCardProps) => (
   <div
-    className={`flex items-center gap-3 bg-white rounded-xl px-4 py-3 transition-all ${
+    className={cn(
+      'flex items-center gap-3 bg-white rounded-xl px-4 py-3 transition-all',
       !item.isAvailable
         ? 'opacity-50'
         : quantity > 0
-          ? 'ring-2 ring-baro-blue/25'
-          : 'border border-gray-100'
-    }`}
+          ? 'ring-2 ring-offset-0'
+          : 'border border-gray-100',
+    )}
+    style={quantity > 0 ? ({ '--tw-ring-color': `${themeHex}40` } as React.CSSProperties) : {}}
   >
     {item.imageUrl ? (
       <img
@@ -45,7 +62,6 @@ const MenuItemCard = ({ item, quantity, onUpdate }: MenuItemCardProps) => (
         ☕
       </div>
     )}
-
     <div className="flex-1 min-w-0">
       <div className="flex items-center gap-1.5">
         <p className="text-sm font-semibold text-gray-900 truncate">{item.name}</p>
@@ -60,9 +76,57 @@ const MenuItemCard = ({ item, quantity, onUpdate }: MenuItemCardProps) => (
       )}
       <p className="text-sm font-bold text-gray-900 mt-1.5">{item.price.toLocaleString()}원</p>
     </div>
+    <MenuQuantityControl item={item} quantity={quantity} themeHex={themeHex} onUpdate={onUpdate} />
+  </div>
+);
 
+/* ── 메뉴 아이템 카드 (그리드) ── */
+const MenuItemGridCard = ({ item, quantity, themeHex, onUpdate }: MenuItemCardProps) => (
+  <div
+    className={cn(
+      'overflow-hidden rounded-xl bg-white shadow-xs transition-all',
+      !item.isAvailable ? 'opacity-50' : quantity > 0 ? 'ring-2' : 'border border-gray-100',
+    )}
+    style={quantity > 0 ? ({ '--tw-ring-color': `${themeHex}60` } as React.CSSProperties) : {}}
+  >
+    <div className="relative h-32 bg-orange-50">
+      {item.imageUrl ? (
+        <img src={item.imageUrl} alt={item.name} className="h-full w-full object-cover" />
+      ) : (
+        <div className="flex h-full items-center justify-center text-3xl select-none">☕</div>
+      )}
+      {!item.isAvailable && (
+        <div className="absolute inset-0 flex items-center justify-center bg-black/20">
+          <span className="rounded-full bg-white/90 px-2 py-0.5 text-xs font-medium text-gray-500">
+            품절
+          </span>
+        </div>
+      )}
+    </div>
+    <div className="p-3">
+      <p className="text-sm font-semibold text-gray-900 truncate">{item.name}</p>
+      {item.description && (
+        <p className="mt-0.5 text-xs text-gray-400 line-clamp-1">{item.description}</p>
+      )}
+      <div className="mt-2 flex items-center justify-between">
+        <p className="text-sm font-bold text-gray-900">{item.price.toLocaleString()}원</p>
+        <MenuQuantityControl
+          item={item}
+          quantity={quantity}
+          themeHex={themeHex}
+          onUpdate={onUpdate}
+        />
+      </div>
+    </div>
+  </div>
+);
+
+/* ── 수량 조절 버튼 (리스트·그리드 공용) ── */
+const MenuQuantityControl = ({ item, quantity, themeHex, onUpdate }: MenuItemCardProps) => {
+  if (!item.isAvailable) return null;
+  return (
     <div className="flex items-center gap-2 shrink-0">
-      {!item.isAvailable ? null : quantity > 0 ? (
+      {quantity > 0 ? (
         <>
           <button
             onClick={() => onUpdate(item.id, -1)}
@@ -73,7 +137,8 @@ const MenuItemCard = ({ item, quantity, onUpdate }: MenuItemCardProps) => (
           <span className="w-4 text-center text-sm font-bold text-gray-900">{quantity}</span>
           <button
             onClick={() => onUpdate(item.id, 1)}
-            className="size-8 flex items-center justify-center rounded-full bg-baro-blue text-white active:scale-90 transition-transform"
+            className="size-8 flex items-center justify-center rounded-full text-white active:scale-90 transition-transform"
+            style={{ backgroundColor: themeHex }}
           >
             <Plus className="size-3.5" />
           </button>
@@ -81,14 +146,15 @@ const MenuItemCard = ({ item, quantity, onUpdate }: MenuItemCardProps) => (
       ) : (
         <button
           onClick={() => onUpdate(item.id, 1)}
-          className="size-8 flex items-center justify-center rounded-full bg-baro-blue text-white active:scale-90 transition-transform"
+          className="size-8 flex items-center justify-center rounded-full text-white active:scale-90 transition-transform"
+          style={{ backgroundColor: themeHex }}
         >
           <Plus className="size-3.5" />
         </button>
       )}
     </div>
-  </div>
-);
+  );
+};
 
 const PREVIEW_COUNT = 2;
 
@@ -110,12 +176,10 @@ const OrderSuccess = ({ orderId, totalAmount, items, onReorder }: OrderSuccessPr
       <div className="size-14 rounded-full bg-baro-blue flex items-center justify-center">
         <CheckCircle className="size-7 text-white" strokeWidth={2.5} />
       </div>
-
       <div className="text-center">
         <h1 className="text-lg font-bold text-gray-900">주문 접수 완료</h1>
         <p className="text-sm text-gray-400 mt-1">사장님이 곧 준비를 시작할 거예요</p>
       </div>
-
       <Card className="w-full max-w-xs">
         <CardContent className="px-5 py-4 space-y-3">
           <div className="flex justify-between items-center text-sm">
@@ -149,7 +213,6 @@ const OrderSuccess = ({ orderId, totalAmount, items, onReorder }: OrderSuccessPr
           </div>
         </CardContent>
       </Card>
-
       <Button
         className="w-full max-w-xs bg-baro-blue text-white hover:bg-baro-blue/90 rounded-xl h-11 text-sm font-semibold"
         onClick={onReorder}
@@ -166,7 +229,7 @@ const CustomerOrderPage = () => {
   const [searchParams] = useSearchParams();
   const tableNumber = searchParams.get('table');
 
-  const [activeTab, setActiveTab] = useState<CategoryTab>('all');
+  const [activeTab, setActiveTab] = useState<string>('all');
   const [cart, setCart] = useState<Record<string, number>>({});
   const [isCheckoutOpen, setIsCheckoutOpen] = useState(false);
   const [customerNote, setCustomerNote] = useState('');
@@ -186,6 +249,20 @@ const CustomerOrderPage = () => {
     enabled: !!storeId,
   });
 
+  const { data: categories = [], isLoading: isCategoriesLoading } = useQuery({
+    queryKey: ['public-menu-categories', storeId],
+    queryFn: () => fetchStoreMenuCategories(storeId!),
+    enabled: !!storeId,
+  });
+
+  const { data: theme = DEFAULT_THEME } = useQuery({
+    queryKey: ['public-store-theme', storeId],
+    queryFn: () => fetchStoreTheme(storeId!),
+    enabled: !!storeId,
+  });
+
+  const themeHex = THEME_HEX[theme.themeColor];
+
   const orderMutation = useMutation({
     mutationFn: (data: Parameters<typeof createOrder>[1]) => createOrder(storeId!, data),
     onSuccess: (order) => {
@@ -198,7 +275,6 @@ const CustomerOrderPage = () => {
           quantity: cart[item.id]!,
           imageUrl: item.imageUrl ?? undefined,
         }));
-
       setIsCheckoutOpen(false);
       setSuccessInfo({
         orderId: order.id.slice(-4).toUpperCase(),
@@ -210,7 +286,17 @@ const CustomerOrderPage = () => {
     },
   });
 
-  const visibleMenu = activeTab === 'available' ? menus.filter((m) => m.isAvailable) : menus;
+  const tabs = useMemo(() => {
+    const base = [{ key: 'all', label: '전체' }];
+    const categoryTabs = categories.map((cat) => ({ key: cat.id, label: cat.name }));
+    return [...base, ...categoryTabs, { key: 'available', label: '주문 가능' }];
+  }, [categories]);
+
+  const visibleMenu = useMemo(() => {
+    if (activeTab === 'available') return menus.filter((m) => m.isAvailable);
+    if (activeTab === 'all') return menus;
+    return menus.filter((m) => m.categoryId === activeTab);
+  }, [menus, activeTab]);
 
   const totalItems = Object.values(cart).reduce((sum, qty) => sum + qty, 0);
   const totalAmount = menus.reduce((sum, item) => sum + (cart[item.id] ?? 0) * item.price, 0);
@@ -230,7 +316,6 @@ const CustomerOrderPage = () => {
     const items = menus
       .filter((item) => (cart[item.id] ?? 0) > 0)
       .map((item) => ({ menuId: item.id, quantity: cart[item.id]! }));
-
     orderMutation.mutate({ tableNumber: Number(tableNumber), items });
   };
 
@@ -245,10 +330,15 @@ const CustomerOrderPage = () => {
     );
   }
 
+  const isLoading = isMenuLoading || isCategoriesLoading;
+
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="h-svh bg-gray-50 flex flex-col overflow-hidden">
       {/* 헤더 */}
-      <header className="bg-baro-blue px-5 py-4 flex items-center justify-between gap-3">
+      <header
+        className="shrink-0 px-5 py-4 flex items-center justify-between gap-3"
+        style={{ backgroundColor: themeHex }}
+      >
         <div className="flex items-center gap-3">
           <div className="size-9 rounded-lg bg-white/20 flex items-center justify-center text-lg select-none shrink-0">
             🍽️
@@ -266,56 +356,91 @@ const CustomerOrderPage = () => {
         )}
       </header>
 
+      {/* 배너 이미지 */}
+      {theme.bannerImageUrl && (
+        <div className="shrink-0 h-36 w-full overflow-hidden">
+          <img
+            src={theme.bannerImageUrl}
+            alt="가게 배너"
+            className="h-full w-full object-cover"
+            style={{ objectPosition: theme.bannerPosition ?? '50% 50%' }}
+          />
+        </div>
+      )}
+
       {/* 카테고리 탭 */}
-      <div className="sticky top-0 z-10 bg-white border-b">
-        <div className="flex px-4">
-          {(
-            [
-              { key: 'all', label: '전체' },
-              { key: 'available', label: '주문 가능' },
-            ] as { key: CategoryTab; label: string }[]
-          ).map((tab) => (
-            <button
-              key={tab.key}
-              onClick={() => setActiveTab(tab.key)}
-              className={`px-4 py-3 text-sm font-medium border-b-2 transition-colors ${
-                activeTab === tab.key
-                  ? 'border-baro-blue text-baro-blue'
-                  : 'border-transparent text-gray-400 hover:text-gray-600'
-              }`}
-            >
-              {tab.label}
-            </button>
-          ))}
+      <div className="shrink-0 bg-white border-b">
+        <div className="flex overflow-x-auto scrollbar-none px-4">
+          {isCategoriesLoading
+            ? [1, 2, 3].map((i) => <Skeleton key={i} className="my-3 mr-2 h-5 w-16 shrink-0" />)
+            : tabs.map((tab) => (
+                <button
+                  key={tab.key}
+                  onClick={() => setActiveTab(tab.key)}
+                  className="shrink-0 px-4 py-3 text-sm font-medium border-b-2 transition-colors"
+                  style={
+                    activeTab === tab.key
+                      ? { borderBottomColor: themeHex, color: themeHex }
+                      : { borderBottomColor: 'transparent', color: '#9ca3af' }
+                  }
+                >
+                  {tab.label}
+                </button>
+              ))}
         </div>
       </div>
 
       {/* 메뉴 목록 */}
-      <div className="px-4 pt-3 pb-28 space-y-2">
-        {isMenuLoading ? (
-          Array.from({ length: 4 }).map((_, i) => (
-            <Skeleton key={i} className="h-24 w-full rounded-xl" />
-          ))
-        ) : isMenuError ? (
-          <div className="flex flex-col items-center justify-center py-16 gap-3 text-gray-400">
-            <AlertCircle className="size-10 opacity-40" />
-            <p className="text-sm">메뉴를 불러오지 못했어요.</p>
-            <p className="text-xs">잠시 후 다시 시도해 주세요.</p>
-          </div>
-        ) : visibleMenu.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-16 text-gray-400">
-            <p className="text-sm">주문 가능한 메뉴가 없어요.</p>
-          </div>
-        ) : (
-          visibleMenu.map((item) => (
-            <MenuItemCard
-              key={item.id}
-              item={item}
-              quantity={cart[item.id] ?? 0}
-              onUpdate={updateCart}
-            />
-          ))
-        )}
+      <div className={cn('flex-1 overflow-y-auto pt-3', totalItems > 0 ? 'pb-28' : 'pb-4')}>
+        <div
+          className={
+            theme.layout === 'grid'
+              ? 'px-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3'
+              : 'px-4 space-y-2'
+          }
+        >
+          {isLoading ? (
+            theme.layout === 'grid' ? (
+              Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton key={i} className="h-52 w-full rounded-xl" />
+              ))
+            ) : (
+              Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton key={i} className="h-24 w-full rounded-xl" />
+              ))
+            )
+          ) : isMenuError ? (
+            <div className="col-span-full flex flex-col items-center justify-center py-16 gap-3 text-gray-400">
+              <AlertCircle className="size-10 opacity-40" />
+              <p className="text-sm">메뉴를 불러오지 못했어요.</p>
+              <p className="text-xs">잠시 후 다시 시도해 주세요.</p>
+            </div>
+          ) : visibleMenu.length === 0 ? (
+            <div className="col-span-full flex flex-col items-center justify-center py-16 text-gray-400">
+              <p className="text-sm">주문 가능한 메뉴가 없어요.</p>
+            </div>
+          ) : theme.layout === 'grid' ? (
+            visibleMenu.map((item) => (
+              <MenuItemGridCard
+                key={item.id}
+                item={item}
+                quantity={cart[item.id] ?? 0}
+                themeHex={themeHex}
+                onUpdate={updateCart}
+              />
+            ))
+          ) : (
+            visibleMenu.map((item) => (
+              <MenuItemListCard
+                key={item.id}
+                item={item}
+                quantity={cart[item.id] ?? 0}
+                themeHex={themeHex}
+                onUpdate={updateCart}
+              />
+            ))
+          )}
+        </div>
       </div>
 
       {/* 장바구니 바 */}
@@ -323,7 +448,8 @@ const CustomerOrderPage = () => {
         <div className="fixed bottom-0 left-0 right-0 p-4 bg-white border-t">
           <button
             onClick={() => setIsCheckoutOpen(true)}
-            className="w-full h-12 bg-baro-blue text-white rounded-xl text-sm font-semibold flex items-center justify-between px-5 active:opacity-90 transition-opacity"
+            className="w-full h-12 text-white rounded-xl text-sm font-semibold flex items-center justify-between px-5 active:opacity-90 transition-opacity"
+            style={{ backgroundColor: themeHex }}
           >
             <span className="size-6 flex items-center justify-center rounded-full bg-white/25 text-xs font-bold">
               {totalItems}
@@ -336,41 +462,45 @@ const CustomerOrderPage = () => {
 
       {/* 주문 확인 모달 */}
       <Dialog open={isCheckoutOpen} onOpenChange={setIsCheckoutOpen}>
-        <DialogContent className="max-w-sm">
+        <DialogContent>
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2 text-base">
-              <ShoppingCart className="size-4 text-baro-blue" />
+              <ShoppingCart className="size-4" style={{ color: themeHex }} />
               주문 확인
             </DialogTitle>
           </DialogHeader>
-
           <div className="space-y-4">
             <div className="rounded-xl bg-gray-50 px-4 py-3 space-y-2">
-              {menus
-                .filter((item) => (cart[item.id] ?? 0) > 0)
-                .map((item) => (
-                  <div key={item.id} className="flex justify-between text-sm">
-                    <span className="text-gray-500">
-                      {item.name} <span className="text-gray-400">× {cart[item.id]}</span>
-                    </span>
-                    <span className="font-medium text-gray-900">
-                      {((cart[item.id] ?? 0) * item.price).toLocaleString()}원
-                    </span>
-                  </div>
-                ))}
+              <div className="max-h-40 overflow-y-auto space-y-2">
+                {menus
+                  .filter((item) => (cart[item.id] ?? 0) > 0)
+                  .map((item) => (
+                    <div key={item.id} className="flex justify-between text-sm">
+                      <span className="text-gray-500">
+                        {item.name} <span className="text-gray-400">× {cart[item.id]}</span>
+                      </span>
+                      <span className="font-medium text-gray-900">
+                        {((cart[item.id] ?? 0) * item.price).toLocaleString()}원
+                      </span>
+                    </div>
+                  ))}
+              </div>
               <div className="border-t border-gray-200 pt-2 flex justify-between text-sm font-bold">
                 <span className="text-gray-900">합계</span>
-                <span className="text-baro-blue">{totalAmount.toLocaleString()}원</span>
+                <span style={{ color: themeHex }}>{totalAmount.toLocaleString()}원</span>
               </div>
             </div>
-
             {tableNumber && (
-              <div className="flex items-center justify-between rounded-xl bg-baro-blue/8 px-4 py-2.5">
+              <div
+                className="flex items-center justify-between rounded-xl px-4 py-2.5"
+                style={{ backgroundColor: `${themeHex}14` }}
+              >
                 <span className="text-sm text-gray-500">테이블 번호</span>
-                <span className="text-sm font-semibold text-baro-blue">{tableNumber}번 테이블</span>
+                <span className="text-sm font-semibold" style={{ color: themeHex }}>
+                  {tableNumber}번 테이블
+                </span>
               </div>
             )}
-
             <div className="space-y-1.5">
               <Label htmlFor="customer-note" className="text-sm text-gray-700">
                 요청사항 <span className="text-gray-400 font-normal">(선택)</span>
@@ -383,9 +513,9 @@ const CustomerOrderPage = () => {
                 className="h-10"
               />
             </div>
-
             <Button
-              className="w-full bg-baro-blue text-white hover:bg-baro-blue/90 rounded-xl h-11 text-sm font-semibold"
+              className="w-full text-white rounded-xl h-11 text-sm font-semibold"
+              style={{ backgroundColor: themeHex }}
               onClick={handleOrder}
               disabled={orderMutation.isPending}
             >

--- a/src/pages/SettingsIngredientsPage.tsx
+++ b/src/pages/SettingsIngredientsPage.tsx
@@ -42,8 +42,8 @@ const SettingsIngredientsPage = () => {
   };
 
   return (
-    <div className="min-h-screen bg-background">
-      <header className="flex items-center gap-3 border-b px-6 py-4">
+    <div className="flex flex-1 flex-col overflow-hidden bg-background">
+      <header className="shrink-0 flex items-center gap-3 border-b px-6 py-4 bg-background">
         <Button variant="ghost" size="icon" onClick={() => navigate(routePaths.storeSettings)}>
           <ArrowLeft className="size-4" />
         </Button>
@@ -65,7 +65,7 @@ const SettingsIngredientsPage = () => {
         </div>
       </header>
 
-      <div className="p-6 space-y-2">
+      <div className="flex-1 overflow-y-auto p-6 space-y-2">
         {isLoading ? (
           Array.from({ length: 3 }).map((_, i) => (
             <Skeleton key={i} className="h-14 w-full rounded-xl" />

--- a/src/pages/SettingsMenuBoardPage.tsx
+++ b/src/pages/SettingsMenuBoardPage.tsx
@@ -1,0 +1,299 @@
+import { useEffect, useRef, useState } from 'react';
+
+import { useQueryClient } from '@tanstack/react-query';
+import { AlignJustify, ArrowLeft, Grid2x2, ImagePlus, Loader2, X } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+
+import { routePaths } from '@/app/routes/routePaths';
+import useAuthStore from '@/features/auth/store/authStore';
+import {
+  DEFAULT_THEME,
+  THEME_COLOR_GROUPS,
+  type StoreThemeDto,
+  uploadBannerImage,
+} from '@/features/store-settings/api/storeTheme.api';
+import { useStoreTheme, useUpdateStoreTheme } from '@/features/store-settings/hooks/useStoreTheme';
+import { cn } from '@/lib/utils';
+import { Button } from '@/shadcn/ui/button';
+import { Skeleton } from '@/shadcn/ui/skeleton';
+
+const SettingsMenuBoardPage = () => {
+  const navigate = useNavigate();
+  const storeId = useAuthStore((s) => s.storeId);
+  const qc = useQueryClient();
+  const { data: theme, isLoading } = useStoreTheme();
+  const { mutate: updateTheme, isPending: isSaving } = useUpdateStoreTheme();
+
+  const [form, setForm] = useState<StoreThemeDto>(DEFAULT_THEME);
+  const [isUploading, setIsUploading] = useState(false);
+  // 업로드 중 로컬 blob URL. form/theme와 분리되어 refetch에 영향받지 않음.
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const bannerInputRef = useRef<HTMLInputElement>(null);
+  const isDraggingRef = useRef(false);
+  const initializedRef = useRef(false);
+
+  const updateFocalPoint = (e: React.MouseEvent<HTMLDivElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const x = Math.round(Math.max(0, Math.min(100, ((e.clientX - rect.left) / rect.width) * 100)));
+    const y = Math.round(Math.max(0, Math.min(100, ((e.clientY - rect.top) / rect.height) * 100)));
+    setForm((prev) => ({ ...prev, bannerPosition: `${x}% ${y}%` }));
+  };
+
+  // 최초 1회만 서버 데이터로 form 초기화. 이후 background refetch는 form에 영향 없음.
+  useEffect(() => {
+    if (theme && !initializedRef.current) {
+      setForm(theme);
+      initializedRef.current = true;
+    }
+  }, [theme]);
+
+  // 미리보기 우선: 업로드 중엔 blob URL, 완료 후엔 form의 서버 URL
+  const displayBannerUrl = previewUrl ?? form.bannerImageUrl;
+
+  const handleBannerUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file || !storeId) return;
+
+    const localUrl = URL.createObjectURL(file);
+    setPreviewUrl(localUrl);
+    setIsUploading(true);
+
+    try {
+      await uploadBannerImage(storeId, file);
+      // 응답 파싱 대신 서버에서 최신 theme를 직접 가져와 bannerImageUrl을 확정
+      await qc.refetchQueries({ queryKey: ['store-theme', storeId] });
+      const fresh = qc.getQueryData<StoreThemeDto>(['store-theme', storeId]);
+      if (fresh?.bannerImageUrl) {
+        setForm((prev) => ({ ...prev, bannerImageUrl: fresh.bannerImageUrl }));
+      }
+    } catch {
+      // 실패 시 form은 그대로 유지 (axios interceptor가 토스트 처리)
+    } finally {
+      setPreviewUrl(null);
+      URL.revokeObjectURL(localUrl);
+      setIsUploading(false);
+      if (bannerInputRef.current) bannerInputRef.current.value = '';
+    }
+  };
+
+  const isDirty = theme
+    ? form.themeColor !== theme.themeColor ||
+      form.layout !== theme.layout ||
+      form.bannerImageUrl !== theme.bannerImageUrl ||
+      form.bannerPosition !== theme.bannerPosition
+    : false;
+
+  const focalX = parseInt((form.bannerPosition ?? '50% 50%').split(' ')[0] ?? '50', 10);
+  const focalY = parseInt((form.bannerPosition ?? '50% 50%').split(' ')[1] ?? '50', 10);
+  const selectedColor = THEME_COLOR_GROUPS.flatMap((g) => g.colors).find(
+    (c) => c.key === form.themeColor,
+  );
+
+  return (
+    <div className="flex flex-1 flex-col overflow-hidden bg-background">
+      <header className="shrink-0 flex items-center gap-3 border-b px-6 py-4 bg-background">
+        <Button variant="ghost" size="icon" onClick={() => navigate(routePaths.storeSettings)}>
+          <ArrowLeft className="size-4" />
+        </Button>
+        <div>
+          <p className="text-sm font-semibold">메뉴판 설정</p>
+          <p className="text-xs text-muted-foreground">
+            손님 메뉴판의 테마 색상, 레이아웃, 배너를 설정합니다.
+          </p>
+        </div>
+        <Button
+          size="sm"
+          onClick={() => updateTheme(form)}
+          disabled={!isDirty || isSaving || isLoading}
+          className="ml-auto bg-baro-blue text-white hover:bg-baro-blue/80"
+        >
+          {isSaving ? <Loader2 className="size-3.5 animate-spin" /> : '저장'}
+        </Button>
+      </header>
+
+      <div className="flex-1 overflow-y-auto p-6">
+        <div className="overflow-hidden rounded-xl border bg-card">
+          {isLoading ? (
+            <div className="space-y-3 p-4">
+              <Skeleton className="h-5 w-24 rounded" />
+              <Skeleton className="h-20 rounded-lg" />
+              <Skeleton className="h-9 w-44 rounded-lg" />
+              <Skeleton className="h-5 w-20 rounded" />
+              <Skeleton className="h-20 rounded-lg" />
+            </div>
+          ) : (
+            <div className="divide-y">
+              {/* 테마 색상 */}
+              <div className="px-4 py-3">
+                <div className="mb-3 flex items-center justify-between">
+                  <p className="text-xs font-medium text-muted-foreground">테마 색상</p>
+                  {selectedColor && (
+                    <div className="flex items-center gap-1.5">
+                      <div
+                        className="size-2.5 rounded-full"
+                        style={{ backgroundColor: selectedColor.hex }}
+                      />
+                      <span className="text-xs text-muted-foreground">{selectedColor.label}</span>
+                    </div>
+                  )}
+                </div>
+                <div className="space-y-2">
+                  {THEME_COLOR_GROUPS.map((group) => (
+                    <div key={group.label} className="flex items-center gap-3">
+                      <span className="w-10 shrink-0 text-[11px] text-muted-foreground/70">
+                        {group.label}
+                      </span>
+                      <div className="flex gap-2">
+                        {group.colors.map((color) => (
+                          <button
+                            key={color.key}
+                            type="button"
+                            title={color.label}
+                            onClick={() => setForm((p) => ({ ...p, themeColor: color.key }))}
+                            className={cn(
+                              'size-7 rounded-full transition-all hover:scale-105',
+                              form.themeColor === color.key && 'scale-110',
+                            )}
+                            style={{
+                              backgroundColor: color.hex,
+                              ...(form.themeColor === color.key
+                                ? { boxShadow: `0 0 0 2px white, 0 0 0 4px ${color.hex}` }
+                                : {}),
+                            }}
+                          />
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {/* 레이아웃 */}
+              <div className="px-4 py-3">
+                <p className="mb-3 text-xs font-medium text-muted-foreground">레이아웃</p>
+                <div className="inline-flex gap-0.5 rounded-lg bg-gray-100 p-1">
+                  {(
+                    [
+                      { key: 'list', label: '리스트', icon: AlignJustify },
+                      { key: 'grid', label: '그리드', icon: Grid2x2 },
+                    ] as const
+                  ).map(({ key, label, icon: Icon }) => (
+                    <button
+                      key={key}
+                      type="button"
+                      onClick={() => setForm((p) => ({ ...p, layout: key }))}
+                      className={cn(
+                        'flex items-center gap-2 rounded-md px-5 py-2 text-sm transition-all',
+                        form.layout === key
+                          ? 'bg-white font-medium text-gray-900 shadow-sm'
+                          : 'text-gray-400 hover:text-gray-600',
+                      )}
+                    >
+                      <Icon className="size-4" />
+                      {label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {/* 배너 이미지 */}
+              <div className="px-4 py-3">
+                <div className="mb-3 flex items-center justify-between">
+                  <p className="text-xs font-medium text-muted-foreground">
+                    배너 이미지 <span className="font-normal">(선택 · 업로드 즉시 저장)</span>
+                  </p>
+                  {displayBannerUrl && !isUploading && (
+                    <button
+                      type="button"
+                      onClick={() => bannerInputRef.current?.click()}
+                      className="text-xs text-baro-blue transition-colors hover:underline"
+                    >
+                      이미지 변경
+                    </button>
+                  )}
+                </div>
+                {displayBannerUrl ? (
+                  <div className="space-y-1.5">
+                    <div
+                      className="relative cursor-crosshair select-none overflow-hidden rounded-xl border"
+                      style={{ aspectRatio: '390 / 144', maxHeight: '9rem' }}
+                      onMouseDown={(e) => {
+                        isDraggingRef.current = true;
+                        updateFocalPoint(e);
+                      }}
+                      onMouseMove={(e) => {
+                        if (isDraggingRef.current) updateFocalPoint(e);
+                      }}
+                      onMouseUp={() => {
+                        isDraggingRef.current = false;
+                      }}
+                      onMouseLeave={() => {
+                        isDraggingRef.current = false;
+                      }}
+                    >
+                      <img
+                        src={displayBannerUrl ?? undefined}
+                        alt="배너"
+                        className="h-full w-full object-cover pointer-events-none"
+                        style={{ objectPosition: form.bannerPosition ?? '50% 50%' }}
+                        draggable={false}
+                      />
+                      <div
+                        className="absolute pointer-events-none"
+                        style={{
+                          left: `${focalX}%`,
+                          top: `${focalY}%`,
+                          transform: 'translate(-50%, -50%)',
+                        }}
+                      >
+                        <div className="size-5 rounded-full border-2 border-white bg-white/20 shadow-lg ring-1 ring-black/20" />
+                      </div>
+                      {isUploading && (
+                        <div className="absolute inset-0 flex items-center justify-center bg-white/60 pointer-events-none">
+                          <Loader2 className="size-5 animate-spin text-baro-blue" />
+                        </div>
+                      )}
+                      {!isUploading && (
+                        <button
+                          type="button"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setForm((p) => ({ ...p, bannerImageUrl: null }));
+                          }}
+                          className="absolute right-2 top-2 flex size-6 items-center justify-center rounded-full bg-black/50 text-white transition-colors hover:bg-black/70"
+                        >
+                          <X className="size-3.5" />
+                        </button>
+                      )}
+                    </div>
+                    <p className="text-[11px] text-muted-foreground/70">
+                      클릭하거나 드래그해서 노출 영역을 조정하세요
+                    </p>
+                  </div>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => bannerInputRef.current?.click()}
+                    className="flex h-20 w-full flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-200 bg-gray-50/60 transition-colors hover:border-baro-blue/40 hover:bg-baro-blue/5"
+                  >
+                    <ImagePlus className="size-5 text-gray-300" />
+                    <span className="text-xs text-muted-foreground">배너 이미지 추가</span>
+                  </button>
+                )}
+                <input
+                  ref={bannerInputRef}
+                  type="file"
+                  accept="image/*"
+                  className="hidden"
+                  onChange={handleBannerUpload}
+                />
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SettingsMenuBoardPage;

--- a/src/pages/SettingsMenusPage.tsx
+++ b/src/pages/SettingsMenusPage.tsx
@@ -1,7 +1,9 @@
-import { useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 
 import {
   ArrowLeft,
+  ChevronDown,
+  ChevronUp,
   ImageOff,
   ImagePlus,
   Loader2,
@@ -15,11 +17,19 @@ import { useNavigate } from 'react-router-dom';
 
 import { routePaths } from '@/app/routes/routePaths';
 import useAuthStore from '@/features/auth/store/authStore';
+import type { MenuCategoryDto } from '@/features/store-settings/api/menuCategories.api';
 import type { MenuDto } from '@/features/store-settings/api/menus.api';
 import { uploadMenuImage } from '@/features/store-settings/api/menus.api';
 import MenuOcrModal, {
   type OcrMenuConfirmItem,
 } from '@/features/store-settings/components/MenuOcrModal';
+import {
+  useMenuCategories,
+  useCreateMenuCategory,
+  useUpdateMenuCategory,
+  useDeleteMenuCategory,
+  useReorderMenuCategories,
+} from '@/features/store-settings/hooks/useMenuCategories';
 import {
   useMenus,
   useCreateMenu,
@@ -30,6 +40,7 @@ import { Button } from '@/shadcn/ui/button';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/shadcn/ui/dialog';
 import { Input } from '@/shadcn/ui/input';
 import { Label } from '@/shadcn/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger } from '@/shadcn/ui/select';
 import { Skeleton } from '@/shadcn/ui/skeleton';
 
 /* ── 모달 폼 타입 ── */
@@ -38,14 +49,22 @@ type MenuForm = {
   description: string;
   price: string;
   imageUrl: string | null;
+  categoryId: string;
 };
 
-const EMPTY_FORM: MenuForm = { name: '', description: '', price: '', imageUrl: null };
+const EMPTY_FORM: MenuForm = {
+  name: '',
+  description: '',
+  price: '',
+  imageUrl: null,
+  categoryId: '',
+};
 
 /* ── 메뉴 등록/수정 모달 ── */
 const MenuModal = ({
   open,
   editing,
+  categories,
   existingNames = [],
   isSaving,
   onClose,
@@ -53,6 +72,7 @@ const MenuModal = ({
 }: {
   open: boolean;
   editing: MenuDto | null;
+  categories: MenuCategoryDto[];
   existingNames?: string[];
   isSaving: boolean;
   onClose: () => void;
@@ -66,6 +86,7 @@ const MenuModal = ({
           description: editing.description ?? '',
           price: String(editing.price),
           imageUrl: editing.imageUrl,
+          categoryId: editing.categoryId ?? '',
         }
       : EMPTY_FORM,
   );
@@ -111,6 +132,7 @@ const MenuModal = ({
       description: form.description.trim() || null,
       price: Number(form.price),
       imageUrl: form.imageUrl,
+      categoryId: form.categoryId || null,
     });
   };
 
@@ -159,6 +181,35 @@ const MenuModal = ({
               onChange={handleImageChange}
             />
           </div>
+
+          {/* 카테고리 */}
+          {categories.length > 0 && (
+            <div className="space-y-1.5">
+              <Label htmlFor="menu-category">카테고리</Label>
+              <Select
+                value={form.categoryId}
+                onValueChange={(val) => setForm((p) => ({ ...p, categoryId: val ?? '' }))}
+              >
+                <SelectTrigger id="menu-category" className="h-10 w-full">
+                  {form.categoryId ? (
+                    <span className="text-sm">
+                      {categories.find((c) => c.id === form.categoryId)?.name ?? '미분류'}
+                    </span>
+                  ) : (
+                    <span className="text-sm text-muted-foreground">카테고리 선택 (선택)</span>
+                  )}
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="">미분류</SelectItem>
+                  {categories.map((cat) => (
+                    <SelectItem key={cat.id} value={cat.id}>
+                      {cat.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
 
           {/* 메뉴 이름 */}
           <div className="space-y-1.5">
@@ -241,7 +292,6 @@ const MenuCard = ({
   onDelete: () => void;
 }) => (
   <div className="group overflow-hidden rounded-xl border bg-card transition-shadow hover:shadow-md">
-    {/* 사진 영역 */}
     <div className="relative h-28 bg-gray-100 dark:bg-gray-800">
       {menu.imageUrl ? (
         <img src={menu.imageUrl} alt={menu.name} className="h-full w-full object-cover" />
@@ -250,8 +300,6 @@ const MenuCard = ({
           <ImageOff className="size-8 text-gray-300" />
         </div>
       )}
-
-      {/* 액션 버튼 (호버 시) */}
       <div className="absolute right-2 top-2 flex gap-1 opacity-0 transition-opacity group-hover:opacity-100">
         <button
           type="button"
@@ -269,8 +317,6 @@ const MenuCard = ({
         </button>
       </div>
     </div>
-
-    {/* 정보 영역 */}
     <div className="px-3 py-2.5">
       <p className="truncate text-sm font-semibold">{menu.name}</p>
       {menu.description && (
@@ -283,11 +329,246 @@ const MenuCard = ({
   </div>
 );
 
+/* ── 카테고리 관리 섹션 ── */
+const CategorySection = () => {
+  const { data: categories = [], isLoading } = useMenuCategories();
+  const { mutate: createCategory, isPending: isCreating } = useCreateMenuCategory();
+  const { mutate: updateCategory } = useUpdateMenuCategory();
+  const { mutate: deleteCategory } = useDeleteMenuCategory();
+  const { mutate: reorder } = useReorderMenuCategories();
+
+  const [isAdding, setIsAdding] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editName, setEditName] = useState('');
+
+  const handleAdd = () => {
+    if (!newName.trim()) return;
+    createCategory(newName.trim(), {
+      onSuccess: () => {
+        setNewName('');
+        setIsAdding(false);
+      },
+    });
+  };
+
+  const handleEditSave = (categoryId: string) => {
+    if (!editName.trim()) return;
+    updateCategory({ categoryId, name: editName.trim() }, { onSuccess: () => setEditingId(null) });
+  };
+
+  const handleMove = (index: number, direction: 'up' | 'down') => {
+    const ids = categories.map((c) => c.id);
+    const newIndex = direction === 'up' ? index - 1 : index + 1;
+    const [removed] = ids.splice(index, 1);
+    ids.splice(newIndex, 0, removed);
+    reorder(ids);
+  };
+
+  return (
+    <div className="mb-6 rounded-xl border bg-card p-4">
+      <div className="flex items-center justify-between mb-3">
+        <div>
+          <p className="text-sm font-semibold">카테고리 관리</p>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            메뉴를 그룹으로 묶어 메뉴판을 구성합니다.
+          </p>
+        </div>
+        {!isAdding && (
+          <Button size="sm" variant="outline" onClick={() => setIsAdding(true)}>
+            <Plus className="size-3.5 mr-1" /> 카테고리 추가
+          </Button>
+        )}
+      </div>
+
+      {isLoading ? (
+        <div className="space-y-2">
+          {[1, 2].map((i) => (
+            <Skeleton key={i} className="h-10 rounded-lg" />
+          ))}
+        </div>
+      ) : (
+        <div className="space-y-1.5">
+          {categories.length === 0 && !isAdding && (
+            <div className="rounded-lg border-2 border-dashed border-gray-200 py-6 text-center">
+              <p className="text-xs text-muted-foreground">
+                카테고리를 추가하면 메뉴판을 섹션별로 구성할 수 있어요
+              </p>
+            </div>
+          )}
+
+          {categories.map((cat, index) =>
+            editingId === cat.id ? (
+              <div key={cat.id} className="flex items-center gap-2 rounded-lg bg-baro-blue/5 p-2">
+                <Input
+                  value={editName}
+                  onChange={(e) => setEditName(e.target.value)}
+                  className="h-8 text-sm"
+                  autoFocus
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') handleEditSave(cat.id);
+                    if (e.key === 'Escape') setEditingId(null);
+                  }}
+                />
+                <Button
+                  size="sm"
+                  onClick={() => handleEditSave(cat.id)}
+                  className="h-8 shrink-0 bg-baro-blue text-white hover:bg-baro-blue/80"
+                >
+                  저장
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => setEditingId(null)}
+                  className="h-8 shrink-0"
+                >
+                  취소
+                </Button>
+              </div>
+            ) : (
+              <div key={cat.id} className="flex items-center gap-2 rounded-lg p-2 hover:bg-gray-50">
+                <div className="flex flex-col">
+                  <button
+                    disabled={index === 0}
+                    onClick={() => handleMove(index, 'up')}
+                    className="flex size-4 items-center justify-center text-gray-400 transition-colors hover:text-gray-600 disabled:opacity-20"
+                  >
+                    <ChevronUp className="size-3" />
+                  </button>
+                  <button
+                    disabled={index === categories.length - 1}
+                    onClick={() => handleMove(index, 'down')}
+                    className="flex size-4 items-center justify-center text-gray-400 transition-colors hover:text-gray-600 disabled:opacity-20"
+                  >
+                    <ChevronDown className="size-3" />
+                  </button>
+                </div>
+                <p className="flex-1 text-sm">{cat.name}</p>
+                <button
+                  onClick={() => {
+                    setEditingId(cat.id);
+                    setEditName(cat.name);
+                  }}
+                  className="flex size-6 items-center justify-center text-gray-400 transition-colors hover:text-baro-blue"
+                >
+                  <Pencil className="size-3" />
+                </button>
+                <button
+                  onClick={() => deleteCategory(cat.id)}
+                  className="flex size-6 items-center justify-center text-gray-400 transition-colors hover:text-red-500"
+                >
+                  <Trash2 className="size-3" />
+                </button>
+              </div>
+            ),
+          )}
+
+          {isAdding && (
+            <div className="flex items-center gap-2 rounded-lg bg-baro-blue/5 p-2">
+              <Input
+                placeholder="새 카테고리 이름"
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                className="h-8 text-sm"
+                autoFocus
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') handleAdd();
+                  if (e.key === 'Escape') {
+                    setIsAdding(false);
+                    setNewName('');
+                  }
+                }}
+              />
+              <Button
+                size="sm"
+                onClick={handleAdd}
+                disabled={isCreating}
+                className="h-8 shrink-0 bg-baro-blue text-white hover:bg-baro-blue/80"
+              >
+                추가
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => {
+                  setIsAdding(false);
+                  setNewName('');
+                }}
+                className="h-8 shrink-0"
+              >
+                취소
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+/* ── 메뉴 그리드 (카테고리별 그룹화) ── */
+const MenuGrid = ({
+  menus,
+  categories,
+  onEdit,
+  onDelete,
+}: {
+  menus: MenuDto[];
+  categories: MenuCategoryDto[];
+  onEdit: (menu: MenuDto) => void;
+  onDelete: (menuId: string) => void;
+}) => {
+  const grouped = useMemo(() => {
+    const result: { category: MenuCategoryDto | null; items: MenuDto[] }[] = [];
+
+    if (categories.length === 0) {
+      return [{ category: null, items: menus }];
+    }
+
+    for (const cat of categories) {
+      const items = menus.filter((m) => m.categoryId === cat.id);
+      if (items.length > 0) result.push({ category: cat, items });
+    }
+
+    const uncategorized = menus.filter(
+      (m) => !m.categoryId || !categories.find((c) => c.id === m.categoryId),
+    );
+    if (uncategorized.length > 0) result.push({ category: null, items: uncategorized });
+
+    return result;
+  }, [menus, categories]);
+
+  return (
+    <div className="space-y-6">
+      {grouped.map(({ category, items }) => (
+        <div key={category?.id ?? 'uncategorized'}>
+          {category && <p className="mb-3 text-sm font-semibold text-gray-700">{category.name}</p>}
+          {!category && categories.length > 0 && (
+            <p className="mb-3 text-sm font-semibold text-gray-400">미분류</p>
+          )}
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {items.map((menu) => (
+              <MenuCard
+                key={menu.id}
+                menu={menu}
+                onEdit={() => onEdit(menu)}
+                onDelete={() => onDelete(menu.id)}
+              />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
 /* ── 메인 페이지 ── */
 const SettingsMenusPage = () => {
   const navigate = useNavigate();
   const storeId = useAuthStore((s) => s.storeId);
   const { data: menus, isLoading } = useMenus();
+  const { data: categories = [] } = useMenuCategories();
   const {
     mutate: createMenu,
     mutateAsync: createMenuAsync,
@@ -339,13 +620,14 @@ const SettingsMenusPage = () => {
         price: item.price,
         description: item.description,
         imageUrl,
+        categoryId: null,
       });
     }
   };
 
   return (
-    <div className="min-h-screen bg-background">
-      <header className="flex items-center gap-3 border-b px-6 py-4">
+    <div className="flex flex-1 flex-col overflow-hidden bg-background">
+      <header className="shrink-0 flex items-center gap-3 border-b px-6 py-4 bg-background">
         <Button variant="ghost" size="icon" onClick={() => navigate(routePaths.storeSettings)}>
           <ArrowLeft className="size-4" />
         </Button>
@@ -367,7 +649,9 @@ const SettingsMenusPage = () => {
         </div>
       </header>
 
-      <div className="p-6">
+      <div className="flex-1 overflow-y-auto p-6">
+        <CategorySection />
+
         {isLoading ? (
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
             {Array.from({ length: 6 }).map((_, i) => (
@@ -404,16 +688,12 @@ const SettingsMenusPage = () => {
             </div>
           </div>
         ) : (
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-            {menus.map((menu) => (
-              <MenuCard
-                key={menu.id}
-                menu={menu}
-                onEdit={() => handleOpenEdit(menu)}
-                onDelete={() => deleteMenu(menu.id)}
-              />
-            ))}
-          </div>
+          <MenuGrid
+            menus={menus}
+            categories={categories}
+            onEdit={handleOpenEdit}
+            onDelete={(id) => deleteMenu(id)}
+          />
         )}
       </div>
 
@@ -421,6 +701,7 @@ const SettingsMenusPage = () => {
         key={modalKey}
         open={open}
         editing={editing}
+        categories={categories}
         existingNames={(menus ?? []).map((m) => m.name)}
         isSaving={isCreating || isUpdating}
         onClose={handleClose}

--- a/src/pages/SettingsRecipesPage.tsx
+++ b/src/pages/SettingsRecipesPage.tsx
@@ -212,8 +212,8 @@ const SettingsRecipesPage = () => {
   const hasListItems = existingForMenu.length > 0 || pendingItems.length > 0;
 
   return (
-    <div className="min-h-screen bg-background">
-      <header className="flex items-center gap-3 border-b px-6 py-4">
+    <div className="flex flex-1 flex-col overflow-hidden bg-background">
+      <header className="shrink-0 flex items-center gap-3 border-b px-6 py-4 bg-background">
         <Button variant="ghost" size="icon" onClick={() => navigate(routePaths.storeSettings)}>
           <ArrowLeft className="size-4" />
         </Button>
@@ -230,7 +230,7 @@ const SettingsRecipesPage = () => {
         </Button>
       </header>
 
-      <div className="p-6 space-y-3">
+      <div className="flex-1 overflow-y-auto p-6 space-y-3">
         {isLoading ? (
           Array.from({ length: 2 }).map((_, i) => (
             <Skeleton key={i} className="h-24 w-full rounded-xl" />


### PR DESCRIPTION
## 📌 요약

- 손님 주문 메뉴판에 카테고리 탭 필터링, 테마 색상, 배너 이미지·포지션 서버 연동
- 메뉴판 설정(테마·레이아웃·배너)을 메뉴 관리와 분리하여 별도 페이지로 구성
- 가게 설정 서브 페이지 전체에 고정 헤더·스크롤 레이아웃 적용

<br/>

## 🏷️ 관련 이슈

- Closes #86

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- 손님 메뉴판 카테고리 탭 필터(전체·카테고리별·주문가능) 추가
- 배너 이미지 focal point(노출 영역) 설정 UI 및 서버 연동
- `/store-settings/menu-board` 메뉴판 설정 전용 페이지 신설
- 손님 주문 메뉴판 헤더·배너·카테고리 탭 고정, 메뉴 목록만 스크롤

<br/>

### 📂 세부 변경사항

- `customerOrder.api.types.ts` — ApiMenuCategory, ApiStoreTheme 타입 추가, ApiMenu에 categoryId 추가
- `menu.api.ts` — fetchStoreMenuCategories, fetchStoreTheme 함수 추가
- `storeTheme.api.ts` (신규) — bannerPosition 포함 테마 CRUD + 배너 업로드 API
- `useStoreTheme.ts` (신규) — useStoreTheme, useUpdateStoreTheme 훅
- `menuCategories.api.ts` / `useMenuCategories.ts` (신규) — 메뉴 카테고리 API·훅
- `SettingsMenuBoardPage.tsx` (신규) — 테마·레이아웃·배너 focal point 설정 페이지
- `StoreOperationSection.tsx` — 메뉴판 설정 NavRow 추가
- `Router.tsx` / `routePaths.ts` — `/store-settings/menu-board` 라우트 추가
- `SettingsMenusPage.tsx` / `SettingsRecipesPage.tsx` / `SettingsIngredientsPage.tsx` — 고정 헤더·스크롤 레이아웃
- `CustomerOrderPage.tsx` — 카테고리 탭·테마·배너 포지션 연동, 모달 UX 개선

<br/>

## 📸 Screenshots

<img width="300" alt="image" src="https://github.com/user-attachments/assets/112489ae-8b73-4abc-a493-999b7f7493ba" />

<img width="1918" height="977" alt="image" src="https://github.com/user-attachments/assets/67e3f59a-450e-4ab6-9ef9-4c3c4b78cb6f" />

<br/>

## 🧪 테스트 방법

1. 가게 설정 → 메뉴판 설정 진입 → 테마 색상·레이아웃·배너 이미지 변경 후 저장 확인
2. 배너 이미지 업로드 후 focal point 드래그 조정 → 저장 → 손님 메뉴판에서 반영 확인
3. 손님 주문 메뉴판(`/order?table=1`)에서 카테고리 탭 필터 동작 확인
4. 메뉴 목록 스크롤 시 헤더·배너·카테고리 탭이 고정되는지 확인
5. 메뉴 다수 선택 후 주문하기 모달에서 목록 영역만 스크롤되는지 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [x] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- 배너 이미지는 업로드 즉시 서버에 저장됨 (별도 저장 버튼 불필요). 테마 색상·레이아웃·배너 포지션은 저장 버튼 클릭 시 반영.
- 배너 업로드 중 로컬 blob URL로 즉시 미리보기를 보여주고, 업로드 완료 후 서버 refetch로 URL 확정