### PR TITLE
✨ (#96) feat: 식자재 수정·보관·삭제 기능 추가

### DIFF
--- a/src/features/inventory/components/InventoryTable.tsx
+++ b/src/features/inventory/components/InventoryTable.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import {
   AlertTriangle,
+  Archive,
   ArrowUpDown,
   BookOpen,
   CheckCircle2,
@@ -19,9 +20,14 @@ import { routePaths } from '@/app/routes/routePaths';
 import InventoryStockEditDialog from '@/features/inventory/components/InventoryStockEditDialog';
 import type { InventoryItem, InventoryStatus } from '@/features/inventory/types/inventory.types';
 import type { IngredientDto } from '@/features/store-settings/api/ingredients.api';
-import { useIngredients, useToggleFavorite } from '@/features/store-settings/hooks/useIngredients';
+import {
+  useIngredients,
+  useArchivedIngredients,
+  useToggleFavorite,
+} from '@/features/store-settings/hooks/useIngredients';
 import { cn } from '@/lib/utils';
 import { Card, CardContent, CardHeader, CardTitle } from '@/shadcn/ui/card';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/shadcn/ui/dialog';
 import { Input } from '@/shadcn/ui/input';
 import { Skeleton } from '@/shadcn/ui/skeleton';
 
@@ -235,6 +241,7 @@ const InventoryRow = ({ item, onToggleFavorite, onEdit }: InventoryRowProps) => 
 const InventoryTable = () => {
   const navigate = useNavigate();
   const { data: ingredientList = [], isLoading, isError } = useIngredients();
+  const { data: archivedList = [] } = useArchivedIngredients();
   const toggleFavorite = useToggleFavorite();
   const items = ingredientList.map(toInventoryItem);
   const [search, setSearch] = useState('');
@@ -243,6 +250,7 @@ const InventoryTable = () => {
   const [sortKey, setSortKey] = useState<SortKey>('default');
   const [sortDir, setSortDir] = useState<SortDir>('asc');
   const [editingItem, setEditingItem] = useState<InventoryItem | null>(null);
+  const [archivedOpen, setArchivedOpen] = useState(false);
 
   const handleToggleFavorite = (id: string, current: boolean) => {
     toggleFavorite.mutate({ id, isFavorite: !current });
@@ -312,6 +320,18 @@ const InventoryTable = () => {
               >
                 <ScanLine className="w-3.5 h-3.5" />
                 재고 등록하기
+              </button>
+              <button
+                onClick={() => setArchivedOpen(true)}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium border border-input text-muted-foreground hover:bg-muted/50 transition-colors"
+              >
+                <Archive className="w-3.5 h-3.5" />
+                보관된 식자재
+                {archivedList.length > 0 && (
+                  <span className="ml-0.5 bg-muted text-muted-foreground rounded-full w-4 h-4 inline-flex items-center justify-center text-[10px] font-bold">
+                    {archivedList.length}
+                  </span>
+                )}
               </button>
               {/* 즐겨찾기 필터 버튼 */}
               <button
@@ -482,6 +502,40 @@ const InventoryTable = () => {
         onClose={() => setEditingItem(null)}
         item={editingItem}
       />
+
+      {/* 보관된 식자재 조회 모달 */}
+      <Dialog open={archivedOpen} onOpenChange={setArchivedOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Archive className="w-4 h-4 text-muted-foreground" />
+              보관된 식자재
+            </DialogTitle>
+          </DialogHeader>
+          <div className="space-y-2 max-h-80 overflow-y-auto pr-1">
+            {archivedList.length === 0 ? (
+              <p className="text-sm text-muted-foreground text-center py-8">
+                보관된 식자재가 없습니다.
+              </p>
+            ) : (
+              archivedList.map((ing) => (
+                <div
+                  key={ing.id}
+                  className="flex items-center justify-between rounded-lg border px-4 py-2.5 bg-muted/30"
+                >
+                  <div>
+                    <p className="text-sm font-medium">{ing.name}</p>
+                    <p className="text-xs text-muted-foreground">단위: {ing.unit}</p>
+                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    {Number(ing.currentStock).toLocaleString()} {ing.unit}
+                  </p>
+                </div>
+              ))
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
     </>
   );
 };

--- a/src/features/store-settings/api/ingredients.api.ts
+++ b/src/features/store-settings/api/ingredients.api.ts
@@ -10,10 +10,21 @@ export interface IngredientDto {
   lastInboundDate: string | null;
   relatedMenus: string[];
   isFavorite: boolean;
+  isArchived: boolean;
 }
 
-export async function fetchIngredients(storeId: string): Promise<IngredientDto[]> {
-  const res = await axiosInstance.get(`/stores/${storeId}/ingredients`);
+export interface DeleteConflictDetail {
+  inboundCount: number;
+  closingCount: number;
+}
+
+export async function fetchIngredients(
+  storeId: string,
+  archived = false,
+): Promise<IngredientDto[]> {
+  const res = await axiosInstance.get(`/stores/${storeId}/ingredients`, {
+    params: archived ? { archived: true } : undefined,
+  });
   return res.data.data;
 }
 
@@ -41,6 +52,8 @@ export async function updateIngredient(
   return res.data.data;
 }
 
-export async function deleteIngredient(storeId: string, id: string): Promise<void> {
-  await axiosInstance.delete(`/stores/${storeId}/ingredients/${id}`);
+export async function deleteIngredient(storeId: string, id: string, force = false): Promise<void> {
+  await axiosInstance.delete(`/stores/${storeId}/ingredients/${id}`, {
+    params: force ? { force: true } : undefined,
+  });
 }

--- a/src/features/store-settings/hooks/useIngredients.ts
+++ b/src/features/store-settings/hooks/useIngredients.ts
@@ -9,6 +9,8 @@ import {
   type IngredientDto,
 } from '@/features/store-settings/api/ingredients.api';
 
+export type { IngredientDto };
+
 export function useIngredients() {
   const storeId = useAuthStore((s) => s.storeId);
   return useQuery({
@@ -38,11 +40,39 @@ export function useUpdateIngredient() {
   });
 }
 
+export function useArchivedIngredients() {
+  const storeId = useAuthStore((s) => s.storeId);
+  return useQuery({
+    queryKey: ['ingredients', storeId, 'archived'],
+    queryFn: () => fetchIngredients(storeId!, true),
+    enabled: !!storeId,
+  });
+}
+
+export function useArchiveIngredient() {
+  const storeId = useAuthStore((s) => s.storeId);
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, isArchived }: { id: string; isArchived: boolean }) =>
+      updateIngredient(storeId!, id, { isArchived }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['ingredients', storeId] }),
+  });
+}
+
 export function useDeleteIngredient() {
   const storeId = useAuthStore((s) => s.storeId);
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => deleteIngredient(storeId!, id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['ingredients', storeId] }),
+  });
+}
+
+export function useForceDeleteIngredient() {
+  const storeId = useAuthStore((s) => s.storeId);
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => deleteIngredient(storeId!, id, true),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['ingredients', storeId] }),
   });
 }

--- a/src/pages/SettingsIngredientsPage.tsx
+++ b/src/pages/SettingsIngredientsPage.tsx
@@ -1,44 +1,108 @@
 import { useState } from 'react';
 
-import { ArrowLeft, Plus, ShieldCheck, Trash2 } from 'lucide-react';
+import { isAxiosError } from 'axios';
+import {
+  Archive,
+  ArchiveRestore,
+  ArrowLeft,
+  Pencil,
+  Plus,
+  ShieldCheck,
+  Trash2,
+} from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
 import { routePaths } from '@/app/routes/routePaths';
+import { type DeleteConflictDetail } from '@/features/store-settings/api/ingredients.api';
 import {
   useIngredients,
+  useArchivedIngredients,
+  useArchiveIngredient,
   useDeleteIngredient,
+  useForceDeleteIngredient,
 } from '@/features/store-settings/hooks/useIngredients';
 import {
   useStoreSettings,
   useUpdateStoreSettings,
 } from '@/features/store-settings/hooks/useStoreSettings';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/shadcn/ui/alert-dialog';
 import { Button } from '@/shadcn/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/shadcn/ui/dialog';
 import { Skeleton } from '@/shadcn/ui/skeleton';
 import IngredientRegisterModal from '@/shared/components/IngredientRegisterModal';
 import SafetyStockDial from '@/shared/components/SafetyStockDial';
 
+type IngredientUnit = 'g' | 'ml' | '개';
+type EditingIngredient = { id: string; name: string; unit: IngredientUnit };
+type DeleteTarget = { id: string; name: string };
+
 const SettingsIngredientsPage = () => {
   const navigate = useNavigate();
-  const { data: ingredients, isLoading } = useIngredients();
+  const { data: activeIngredients, isLoading: isActiveLoading } = useIngredients();
+  const { data: archivedIngredients, isLoading: isArchivedLoading } = useArchivedIngredients();
   const { data: storeSettings } = useStoreSettings();
-  const { mutate: deleteIngredient } = useDeleteIngredient();
+  const { mutate: archiveIngredient, isPending: isArchiving } = useArchiveIngredient();
+  const { mutate: deleteIngredient, isPending: isDeleting } = useDeleteIngredient();
+  const { mutate: forceDeleteIngredient, isPending: isForceDeleting } = useForceDeleteIngredient();
   const { mutate: updateStoreSettings, isPending: isSavingPct } = useUpdateStoreSettings();
 
+  const [showArchived, setShowArchived] = useState(false);
   const [safetyPct, setSafetyPct] = useState(20);
   const [addOpen, setAddOpen] = useState(false);
   const [safetyOpen, setSafetyOpen] = useState(false);
+  const [editingIngredient, setEditingIngredient] = useState<EditingIngredient | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);
+  const [conflictDetail, setConflictDetail] = useState<DeleteConflictDetail | null>(null);
 
-  // 모달 열 때 서버 값으로 다이얼 초기화
+  const displayedIngredients = showArchived ? archivedIngredients : activeIngredients;
+  const isLoading = showArchived ? isArchivedLoading : isActiveLoading;
+
   const handleOpenSafety = () => {
     setSafetyPct(storeSettings?.safetyStockPct ?? 20);
     setSafetyOpen(true);
   };
 
   const handleApplySafety = () => {
-    // PATCH /stores/:storeId { safetyStockPct } 한 번으로 백엔드가 전체 식자재 일괄 업데이트
     updateStoreSettings({ safetyStockPct: safetyPct });
     setSafetyOpen(false);
+  };
+
+  const handleDeleteConfirm = () => {
+    if (!deleteTarget) return;
+    deleteIngredient(deleteTarget.id, {
+      onSuccess: () => setDeleteTarget(null),
+      onError: (err) => {
+        if (isAxiosError(err) && err.response?.status === 409) {
+          setConflictDetail(
+            err.response.data?.error?.detail ?? { inboundCount: 0, closingCount: 0 },
+          );
+        }
+      },
+    });
+  };
+
+  const handleForceDeleteConfirm = () => {
+    if (!deleteTarget) return;
+    forceDeleteIngredient(deleteTarget.id, {
+      onSuccess: () => {
+        setDeleteTarget(null);
+        setConflictDetail(null);
+      },
+    });
+  };
+
+  const handleCancelDelete = () => {
+    setDeleteTarget(null);
+    setConflictDetail(null);
   };
 
   return (
@@ -49,11 +113,27 @@ const SettingsIngredientsPage = () => {
         </Button>
         <div>
           <p className="text-sm font-semibold">식자재 관리</p>
-          <p className="text-xs text-muted-foreground">재고로 관리할 식자재를 등록합니다.</p>
+          <p className="text-xs text-muted-foreground">
+            {showArchived ? '보관된 식자재 목록입니다.' : '재고로 관리할 식자재를 등록합니다.'}
+          </p>
         </div>
         <div className="ml-auto flex items-center gap-2">
           <Button variant="outline" size="sm" onClick={handleOpenSafety}>
             <ShieldCheck className="size-4 mr-1" /> 안전 재고 기준
+          </Button>
+          <Button
+            variant={showArchived ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => setShowArchived((prev) => !prev)}
+            className={showArchived ? 'bg-baro-blue hover:bg-baro-blue/80 text-white' : ''}
+          >
+            <Archive className="size-4 mr-1" />
+            보관함
+            {(archivedIngredients?.length ?? 0) > 0 && (
+              <span className="ml-1 bg-white/30 text-current rounded-full px-1.5 py-0.5 text-[10px] font-bold leading-none">
+                {archivedIngredients!.length}
+              </span>
+            )}
           </Button>
           <Button
             size="sm"
@@ -70,13 +150,19 @@ const SettingsIngredientsPage = () => {
           Array.from({ length: 3 }).map((_, i) => (
             <Skeleton key={i} className="h-14 w-full rounded-xl" />
           ))
-        ) : !ingredients?.length ? (
+        ) : !displayedIngredients?.length ? (
           <div className="flex flex-col items-center justify-center py-20 text-muted-foreground">
-            <p className="text-sm">등록된 식자재가 없습니다.</p>
-            <p className="text-xs mt-1">식자재 추가 버튼을 눌러 시작하세요.</p>
+            {showArchived ? (
+              <p className="text-sm">보관된 식자재가 없습니다.</p>
+            ) : (
+              <>
+                <p className="text-sm">등록된 식자재가 없습니다.</p>
+                <p className="text-xs mt-1">식자재 추가 버튼을 눌러 시작하세요.</p>
+              </>
+            )}
           </div>
         ) : (
-          ingredients.map((ing) => (
+          displayedIngredients.map((ing) => (
             <div
               key={ing.id}
               className="flex items-center justify-between rounded-xl border px-4 py-3 bg-card"
@@ -86,35 +172,149 @@ const SettingsIngredientsPage = () => {
                 <p className="text-xs text-muted-foreground">단위: {ing.unit}</p>
               </div>
               <div className="flex items-center gap-4">
-                <div className="text-right">
-                  <p className="text-xs text-muted-foreground">현재 재고</p>
-                  <p className="text-sm font-semibold">
-                    {Number(ing.currentStock).toLocaleString()} {ing.unit}
-                  </p>
+                {!showArchived && (
+                  <>
+                    <div className="text-right">
+                      <p className="text-xs text-muted-foreground">현재 재고</p>
+                      <p className="text-sm font-semibold">
+                        {Number(ing.currentStock).toLocaleString()} {ing.unit}
+                      </p>
+                    </div>
+                    <div className="text-right">
+                      <p className="text-xs text-muted-foreground">안전 재고</p>
+                      <p className="text-sm font-semibold">
+                        {Number(ing.safetyStock).toLocaleString()} {ing.unit}
+                      </p>
+                    </div>
+                  </>
+                )}
+                <div className="flex items-center gap-1">
+                  {showArchived ? (
+                    <>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="text-muted-foreground hover:text-baro-green"
+                        onClick={() => archiveIngredient({ id: ing.id, isArchived: false })}
+                        disabled={isArchiving}
+                      >
+                        <ArchiveRestore className="size-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="text-muted-foreground hover:text-destructive"
+                        onClick={() => setDeleteTarget({ id: ing.id, name: ing.name })}
+                      >
+                        <Trash2 className="size-4" />
+                      </Button>
+                    </>
+                  ) : (
+                    <>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="text-muted-foreground hover:text-baro-blue"
+                        onClick={() =>
+                          setEditingIngredient({ id: ing.id, name: ing.name, unit: ing.unit })
+                        }
+                      >
+                        <Pencil className="size-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="text-muted-foreground hover:text-baro-blue"
+                        onClick={() => archiveIngredient({ id: ing.id, isArchived: true })}
+                        disabled={isArchiving}
+                      >
+                        <Archive className="size-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="text-muted-foreground hover:text-destructive"
+                        onClick={() => setDeleteTarget({ id: ing.id, name: ing.name })}
+                      >
+                        <Trash2 className="size-4" />
+                      </Button>
+                    </>
+                  )}
                 </div>
-                <div className="text-right">
-                  <p className="text-xs text-muted-foreground">안전 재고</p>
-                  <p className="text-sm font-semibold">
-                    {Number(ing.safetyStock).toLocaleString()} {ing.unit}
-                  </p>
-                </div>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="text-muted-foreground hover:text-destructive"
-                  onClick={() => deleteIngredient(ing.id)}
-                >
-                  <Trash2 className="size-4" />
-                </Button>
               </div>
             </div>
           ))
         )}
       </div>
 
-      <IngredientRegisterModal open={addOpen} onClose={() => setAddOpen(false)} />
+      {/* 식자재 추가 모달 */}
+      <IngredientRegisterModal
+        key={addOpen ? 'add-open' : 'add-closed'}
+        open={addOpen}
+        onClose={() => setAddOpen(false)}
+      />
 
-      {/* ── 안전 재고 기준 다이얼로그 ── */}
+      {/* 식자재 수정 모달 */}
+      <IngredientRegisterModal
+        key={editingIngredient?.id ?? 'edit-closed'}
+        open={!!editingIngredient}
+        editingId={editingIngredient?.id}
+        initialName={editingIngredient?.name}
+        initialUnit={editingIngredient?.unit}
+        onClose={() => setEditingIngredient(null)}
+      />
+
+      {/* 1차 삭제 확인 */}
+      <AlertDialog
+        open={!!deleteTarget && !conflictDetail}
+        onOpenChange={(open) => !open && handleCancelDelete()}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>식자재를 삭제하시겠습니까?</AlertDialogTitle>
+            <AlertDialogDescription>
+              <span className="font-medium text-foreground">{deleteTarget?.name}</span>을(를)
+              삭제하면 되돌릴 수 없습니다.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>취소</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive hover:bg-destructive/90 text-white"
+              onClick={handleDeleteConfirm}
+              disabled={isDeleting}
+            >
+              {isDeleting ? '확인 중...' : '삭제'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* 2차 삭제 확인 (관련 기록 있을 때) */}
+      <AlertDialog open={!!conflictDetail} onOpenChange={(open) => !open && handleCancelDelete()}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>관련 기록도 함께 삭제됩니다</AlertDialogTitle>
+            <AlertDialogDescription>
+              <span className="font-medium text-foreground">{deleteTarget?.name}</span>에 연결된
+              입고 기록 {conflictDetail?.inboundCount ?? 0}건, 마감 기록{' '}
+              {conflictDetail?.closingCount ?? 0}건이 함께 삭제됩니다. 계속하시겠습니까?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>취소</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive hover:bg-destructive/90 text-white"
+              onClick={handleForceDeleteConfirm}
+              disabled={isForceDeleting}
+            >
+              {isForceDeleting ? '삭제 중...' : '모두 삭제'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* 안전 재고 기준 다이얼로그 */}
       <Dialog open={safetyOpen} onOpenChange={setSafetyOpen}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>

--- a/src/shadcn/ui/alert-dialog.tsx
+++ b/src/shadcn/ui/alert-dialog.tsx
@@ -1,0 +1,185 @@
+import * as React from "react"
+import { AlertDialog as AlertDialogPrimitive } from "@base-ui/react/alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/shadcn/ui/button"
+
+function AlertDialog({ ...props }: AlertDialogPrimitive.Root.Props) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({ ...props }: AlertDialogPrimitive.Trigger.Props) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({ ...props }: AlertDialogPrimitive.Portal.Props) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: AlertDialogPrimitive.Backdrop.Props) {
+  return (
+    <AlertDialogPrimitive.Backdrop
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  size = "default",
+  ...props
+}: AlertDialogPrimitive.Popup.Props & {
+  size?: "default" | "sm"
+}) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Popup
+        data-slot="alert-dialog-content"
+        data-size={size}
+        className={cn(
+          "group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn(
+        "grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-4 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogMedia({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-media"
+      className={cn(
+        "mb-2 inline-flex size-10 items-center justify-center rounded-md bg-muted sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-6",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn(
+        "font-heading text-base font-medium sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn(
+        "text-sm text-balance text-muted-foreground md:text-pretty *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  return (
+    <Button
+      data-slot="alert-dialog-action"
+      className={cn(className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  variant = "outline",
+  size = "default",
+  ...props
+}: AlertDialogPrimitive.Close.Props &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <AlertDialogPrimitive.Close
+      data-slot="alert-dialog-cancel"
+      className={cn(className)}
+      render={<Button variant={variant} size={size} />}
+      {...props}
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+}

--- a/src/shared/components/IngredientRegisterModal.tsx
+++ b/src/shared/components/IngredientRegisterModal.tsx
@@ -1,8 +1,11 @@
 import { useState } from 'react';
 
-import { PackagePlus } from 'lucide-react';
+import { PackagePlus, Pencil } from 'lucide-react';
 
-import { useCreateIngredient } from '@/features/store-settings/hooks/useIngredients';
+import {
+  useCreateIngredient,
+  useUpdateIngredient,
+} from '@/features/store-settings/hooks/useIngredients';
 import { Button } from '@/shadcn/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/shadcn/ui/dialog';
 import { Input } from '@/shadcn/ui/input';
@@ -17,6 +20,8 @@ interface IngredientRegisterModalProps {
   open: boolean;
   initialName?: string;
   initialUnit?: IngredientUnit;
+  /** 전달 시 수정 모드로 동작 */
+  editingId?: string;
   onClose: () => void;
   onConfirm?: (ingredientId: string) => void;
 }
@@ -25,24 +30,37 @@ const IngredientRegisterModal = ({
   open,
   initialName = '',
   initialUnit = 'g',
+  editingId,
   onClose,
   onConfirm,
 }: IngredientRegisterModalProps) => {
-  const { mutate: createIngredient, isPending } = useCreateIngredient();
+  const { mutate: createIngredient, isPending: isCreating } = useCreateIngredient();
+  const { mutate: updateIngredient, isPending: isUpdating } = useUpdateIngredient();
   const [form, setForm] = useState({ name: initialName, unit: initialUnit });
+
+  const isEditMode = !!editingId;
+  const isPending = isCreating || isUpdating;
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!form.name.trim()) return;
-    createIngredient(
-      { name: form.name, unit: form.unit },
-      {
-        onSuccess: (created) => {
-          onConfirm?.(created.id);
-          onClose();
+
+    if (isEditMode) {
+      updateIngredient(
+        { id: editingId, data: { name: form.name, unit: form.unit } },
+        { onSuccess: () => onClose() },
+      );
+    } else {
+      createIngredient(
+        { name: form.name, unit: form.unit },
+        {
+          onSuccess: (created) => {
+            onConfirm?.(created.id);
+            onClose();
+          },
         },
-      },
-    );
+      );
+    }
   };
 
   return (
@@ -51,12 +69,18 @@ const IngredientRegisterModal = ({
         <DialogHeader className="gap-0">
           <DialogTitle className="text-lg! leading-none! flex items-center gap-2">
             <div className="w-8 h-8 rounded-lg bg-baro-blue/10 flex items-center justify-center shrink-0">
-              <PackagePlus className="w-4 h-4 text-baro-blue" />
+              {isEditMode ? (
+                <Pencil className="w-4 h-4 text-baro-blue" />
+              ) : (
+                <PackagePlus className="w-4 h-4 text-baro-blue" />
+              )}
             </div>
-            식자재 등록
+            {isEditMode ? '식자재 수정' : '식자재 등록'}
           </DialogTitle>
           <p className="text-xs text-muted-foreground">
-            등록한 단위는 이후 재고 관리에 고정으로 사용됩니다
+            {isEditMode
+              ? '식자재 이름과 단위를 수정합니다.'
+              : '등록한 단위는 이후 재고 관리에 고정으로 사용됩니다'}
           </p>
         </DialogHeader>
 
@@ -106,7 +130,13 @@ const IngredientRegisterModal = ({
               disabled={!form.name.trim() || isPending}
               className="flex-1 bg-baro-blue hover:bg-baro-blue/90 text-white"
             >
-              {isPending ? '등록 중...' : '등록'}
+              {isPending
+                ? isEditMode
+                  ? '수정 중...'
+                  : '등록 중...'
+                : isEditMode
+                  ? '수정'
+                  : '등록'}
             </Button>
           </div>
         </form>


### PR DESCRIPTION
## 📌 요약

- 식자재 설정 페이지에 수정·보관·삭제 기능 추가
- 삭제 시 관련 기록이 있을 경우 2단계 확인 플로우 적용
- 전체 재고현황 페이지에 보관된 식자재 조회 모달 추가

<br/>

## 🏷️ 관련 이슈

- Closes #96

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- 식자재 행에 수정(✏️)·보관(🗄️)·삭제(🗑️) 버튼 추가
- 헤더 보관함 버튼으로 활성 ↔ 보관 뷰 토글 (보관 뷰에서는 복원·완전삭제 가능)
- 삭제 2단계 플로우: 기록 없으면 즉시 삭제 / 409 수신 시 입고·마감 건수 표시 후 force 삭제
- 전체 재고현황 페이지 보관된 식자재 조회 전용 모달 (액션 없음)

<br/>

### 📂 세부 변경사항

- `IngredientRegisterModal` — `editingId` prop 추가로 수정 모드 지원
- `ingredients.api.ts` — `isArchived` 필드, `archived` 조회 파라미터, `force` 삭제 파라미터 추가
- `useIngredients.ts` — `useArchivedIngredients`, `useArchiveIngredient`, `useForceDeleteIngredient` 훅 추가
- `SettingsIngredientsPage.tsx` — 전면 개편
- `InventoryTable.tsx` — 보관된 식자재 버튼 및 모달 추가
- `alert-dialog.tsx` — shadcn alert-dialog 컴포넌트 추가

<br/>

## 📸 Screenshots

| Before | After |
| ------ | ----- |
| 삭제 버튼만 존재, 즉시 삭제 | 수정·보관·삭제 버튼, 확인 다이얼로그 |

<br/>

## 🧪 테스트 방법

1. 식자재 설정 페이지에서 ✏️ 버튼 클릭 → 이름·단위 수정 후 저장 확인
2. 🗄️ 버튼 클릭 → 보관함 뷰에서 해당 식자재 확인, 복원 버튼으로 복원 확인
3. 🗑️ 버튼 클릭 → 1차 확인 다이얼로그 → 삭제 확인
4. 입고 기록이 있는 식자재 삭제 시 → 409 수신 → 2차 다이얼로그(건수 표시) → 모두 삭제 확인
5. 전체 재고현황 페이지 헤더 "보관된 식자재" 버튼 → 조회 모달 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [x] Backend
- [x] API
- [x] Database

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음

<br/>

## 💬 Additional Notes

- 백엔드 API 변경사항 선반영: `GET /ingredients?archived=true`, `PATCH { isArchived }`, `DELETE ?force=true`, 409 응답 `{ error: { detail: { inboundCount, closingCount } } }`