### PR TITLE
✨ (#95) feat: 요청사항·주문번호 표시 및 손님 주문 완료 화면 개선

### DIFF
--- a/src/features/customer-order/components/CustomerOrderStatusCard.tsx
+++ b/src/features/customer-order/components/CustomerOrderStatusCard.tsx
@@ -43,10 +43,13 @@ const OrderCard = ({ order, storeId }: OrderCardProps) => {
   const itemSummary = order.items?.map((i) => `${i.menu.name} x${i.quantity}`).join(' · ') ?? '';
 
   return (
-    <div className="rounded-lg border bg-card p-3 space-y-2">
+    <div className="rounded-lg border bg-card p-3 space-y-3">
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-2 min-w-0">
           <span className="text-sm font-medium truncate">{order.tableNumber}번 테이블</span>
+          <span className="text-xs text-muted-foreground shrink-0">
+            #{order.id.slice(-4).toUpperCase()}
+          </span>
           <OrderStatusBadge status={order.status} />
         </div>
         <div className="flex items-center gap-1 text-xs text-muted-foreground shrink-0">
@@ -56,6 +59,10 @@ const OrderCard = ({ order, storeId }: OrderCardProps) => {
       </div>
 
       {itemSummary && <p className="text-xs text-muted-foreground line-clamp-2">{itemSummary}</p>}
+
+      {order.customerNote && (
+        <p className="text-xs text-muted-foreground line-clamp-2 py-1">💬 {order.customerNote}</p>
+      )}
 
       <div className="flex items-center justify-between">
         <span className="text-sm font-semibold">{order.totalPrice.toLocaleString()}원</span>

--- a/src/features/customer-order/types/customerOrder.api.types.ts
+++ b/src/features/customer-order/types/customerOrder.api.types.ts
@@ -53,6 +53,7 @@ export interface ApiOrder {
   tableNumber: number;
   status: ApiOrderStatus;
   totalPrice: number;
+  customerNote?: string;
   createdAt: string;
   updatedAt: string;
   items?: ApiOrderItem[];
@@ -61,6 +62,7 @@ export interface ApiOrder {
 export interface CreateOrderRequest {
   tableNumber: number;
   items: { menuId: string; quantity: number }[];
+  customerNote?: string;
 }
 
 export interface UpdateOrderStatusRequest {

--- a/src/pages/CustomerOrderPage.tsx
+++ b/src/pages/CustomerOrderPage.tsx
@@ -163,11 +163,19 @@ interface OrderSuccessProps {
   orderId: string;
   totalAmount: number;
   items: CartItem[];
+  customerNote?: string;
   themeHex: string;
   onReorder: () => void;
 }
 
-const OrderSuccess = ({ orderId, totalAmount, items, themeHex, onReorder }: OrderSuccessProps) => {
+const OrderSuccess = ({
+  orderId,
+  totalAmount,
+  items,
+  customerNote,
+  themeHex,
+  onReorder,
+}: OrderSuccessProps) => {
   const [expanded, setExpanded] = useState(false);
   const hasMore = items.length > PREVIEW_COUNT;
   const visibleItems = expanded ? items : items.slice(0, PREVIEW_COUNT);
@@ -211,6 +219,12 @@ const OrderSuccess = ({ orderId, totalAmount, items, themeHex, onReorder }: Orde
               </button>
             )}
           </div>
+          {customerNote && (
+            <div className="border-t pt-3 text-sm text-gray-500">
+              <span className="font-medium text-gray-400">요청사항</span>
+              <p className="mt-1 text-gray-600">{customerNote}</p>
+            </div>
+          )}
           <div className="border-t pt-3 flex justify-between items-center text-sm">
             <span className="text-gray-500 font-medium">합계</span>
             <span className="font-bold" style={{ color: themeHex }}>
@@ -224,7 +238,7 @@ const OrderSuccess = ({ orderId, totalAmount, items, themeHex, onReorder }: Orde
         style={{ backgroundColor: themeHex }}
         onClick={onReorder}
       >
-        다시 주문하기
+        추가 주문하기
       </Button>
     </div>
   );
@@ -240,11 +254,20 @@ const CustomerOrderPage = () => {
   const [cart, setCart] = useState<Record<string, number>>({});
   const [isCheckoutOpen, setIsCheckoutOpen] = useState(false);
   const [customerNote, setCustomerNote] = useState('');
+  const lsKey = `baro_order_success_${storeId}`;
   const [successInfo, setSuccessInfo] = useState<{
     orderId: string;
     totalAmount: number;
     items: CartItem[];
-  } | null>(null);
+    customerNote?: string;
+  } | null>(() => {
+    try {
+      const raw = localStorage.getItem(`baro_order_success_${storeId}`);
+      return raw ? JSON.parse(raw) : null;
+    } catch {
+      return null;
+    }
+  });
 
   const {
     data: menus = [],
@@ -283,11 +306,14 @@ const CustomerOrderPage = () => {
           imageUrl: item.imageUrl ?? undefined,
         }));
       setIsCheckoutOpen(false);
-      setSuccessInfo({
+      const info = {
         orderId: order.id.slice(-4).toUpperCase(),
         totalAmount: order.totalPrice,
         items: cartItems,
-      });
+        customerNote: customerNote || undefined,
+      };
+      localStorage.setItem(lsKey, JSON.stringify(info));
+      setSuccessInfo(info);
       setCart({});
       setCustomerNote('');
     },
@@ -323,7 +349,11 @@ const CustomerOrderPage = () => {
     const items = menus
       .filter((item) => (cart[item.id] ?? 0) > 0)
       .map((item) => ({ menuId: item.id, quantity: cart[item.id]! }));
-    orderMutation.mutate({ tableNumber: Number(tableNumber), items });
+    orderMutation.mutate({
+      tableNumber: Number(tableNumber),
+      items,
+      customerNote: customerNote || undefined,
+    });
   };
 
   if (successInfo) {
@@ -332,8 +362,12 @@ const CustomerOrderPage = () => {
         orderId={successInfo.orderId}
         totalAmount={successInfo.totalAmount}
         items={successInfo.items}
+        customerNote={successInfo.customerNote}
         themeHex={themeHex}
-        onReorder={() => setSuccessInfo(null)}
+        onReorder={() => {
+          localStorage.removeItem(lsKey);
+          setSuccessInfo(null);
+        }}
       />
     );
   }


### PR DESCRIPTION
## 📌 요약

- 손님 주문 시 요청사항을 서버에 전송하지 않던 버그 수정
- 사장님 대시보드 주문 카드에 요청사항·주문번호 표시
- 손님 주문 완료 화면에 요청사항·주문번호 표시 및 새로고침 후에도 유지

<br/>

## 🏷️ 관련 이슈

- Closes #95

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- `CreateOrderRequest` · `ApiOrder` 타입에 `customerNote?: string` 필드 추가
- 주문 생성 시 `customerNote`를 서버 payload에 포함 (기존 버그 수정)
- 사장님 `OrderCard`에 주문번호(`#XXXX`) 및 요청사항(`💬`) 표시
- 손님 완료 화면에 요청사항 노출 및 `localStorage`로 새로고침 후에도 상태 유지
- 버튼 텍스트 "다시 주문하기" → "추가 주문하기" 변경

<br/>

### 📂 세부 변경사항

- `customerOrder.api.types.ts` — `ApiOrder`, `CreateOrderRequest`에 `customerNote` 필드 추가
- `CustomerOrderPage.tsx` — mutate payload에 `customerNote` 포함, 완료 화면에 요청사항 표시, `localStorage` 연동
- `CustomerOrderStatusCard.tsx` — `OrderCard`에 주문번호·요청사항 UI 추가

<br/>

## 📸 Screenshots

| Before | After |
| ------ | ----- |
| 주문 카드에 메뉴·금액·버튼만 표시 | <img width="952" height="505" alt="image" src="https://github.com/user-attachments/assets/a69b2cea-4c37-416e-8bc1-5b15c08343cc" /> |
| 새로고침 시 완료 화면 소실 | <img width="503" height="872" alt="image" src="https://github.com/user-attachments/assets/ba169240-fc61-4a24-acf3-6e7f82fc39d0" /> |

<br/>

## 🧪 테스트 방법

1. 손님 주문 페이지에서 요청사항 입력 후 주문
2. 사장님 대시보드에서 해당 주문 카드에 주문번호·요청사항이 표시되는지 확인
3. 손님 완료 화면에서 주문번호·요청사항이 표시되는지 확인
4. 완료 화면에서 새로고침 시 화면이 유지되는지 확인
5. "추가 주문하기" 클릭 시 메뉴 화면으로 복귀되는지 확인
6. 요청사항 미입력 시 관련 UI가 노출되지 않는지 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [x] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- 주문번호는 서버 UUID의 마지막 4자리(`id.slice(-4).toUpperCase()`)로, 손님·사장님 양쪽에서 동일한 값을 표시
- 백엔드에서 `customerNote` 필드 지원 전까지는 프론트 타입만 준비된 상태 (백엔드 이슈 #43 참고)

🤖 Generated with [Claude Code](https://claude.com/claude-code)