### PR TITLE
✨ (#67) feat: 레시피 수정·삭제 기능 추가 및 설정 페이지 검색 기능 개선

### DIFF
--- a/src/pages/SettingsIngredientsPage.tsx
+++ b/src/pages/SettingsIngredientsPage.tsx
@@ -7,6 +7,7 @@ import {
   ArrowLeft,
   Pencil,
   Plus,
+  Search,
   ShieldCheck,
   Trash2,
 } from 'lucide-react';
@@ -37,6 +38,7 @@ import {
 } from '@/shadcn/ui/alert-dialog';
 import { Button } from '@/shadcn/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/shadcn/ui/dialog';
+import { Input } from '@/shadcn/ui/input';
 import { Skeleton } from '@/shadcn/ui/skeleton';
 import IngredientRegisterModal from '@/shared/components/IngredientRegisterModal';
 import SafetyStockDial from '@/shared/components/SafetyStockDial';
@@ -55,6 +57,7 @@ const SettingsIngredientsPage = () => {
   const { mutate: forceDeleteIngredient, isPending: isForceDeleting } = useForceDeleteIngredient();
   const { mutate: updateStoreSettings, isPending: isSavingPct } = useUpdateStoreSettings();
 
+  const [searchQuery, setSearchQuery] = useState('');
   const [showArchived, setShowArchived] = useState(false);
   const [safetyPct, setSafetyPct] = useState(20);
   const [addOpen, setAddOpen] = useState(false);
@@ -65,6 +68,9 @@ const SettingsIngredientsPage = () => {
 
   const displayedIngredients = showArchived ? archivedIngredients : activeIngredients;
   const isLoading = showArchived ? isArchivedLoading : isActiveLoading;
+  const filteredIngredients = displayedIngredients?.filter((ing) =>
+    ing.name.toLowerCase().includes(searchQuery.toLowerCase()),
+  );
 
   const handleOpenSafety = () => {
     setSafetyPct(storeSettings?.safetyStockPct ?? 20);
@@ -118,6 +124,15 @@ const SettingsIngredientsPage = () => {
           </p>
         </div>
         <div className="ml-auto flex items-center gap-2">
+          <div className="relative w-52">
+            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground pointer-events-none" />
+            <Input
+              placeholder="식자재 이름 검색"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="h-8 pl-8 pr-3 text-sm"
+            />
+          </div>
           <Button variant="outline" size="sm" onClick={handleOpenSafety}>
             <ShieldCheck className="size-4 mr-1" /> 안전 재고 기준
           </Button>
@@ -161,8 +176,12 @@ const SettingsIngredientsPage = () => {
               </>
             )}
           </div>
+        ) : !filteredIngredients?.length ? (
+          <div className="flex flex-col items-center justify-center py-20 text-muted-foreground">
+            <p className="text-sm">검색 결과가 없습니다.</p>
+          </div>
         ) : (
-          displayedIngredients.map((ing) => (
+          filteredIngredients.map((ing) => (
             <div
               key={ing.id}
               className="flex items-center justify-between rounded-xl border px-4 py-3 bg-card"

--- a/src/pages/SettingsMenusPage.tsx
+++ b/src/pages/SettingsMenusPage.tsx
@@ -10,6 +10,7 @@ import {
   Pencil,
   Plus,
   ScanLine,
+  Search,
   Trash2,
   X,
 } from 'lucide-react';
@@ -577,10 +578,15 @@ const SettingsMenusPage = () => {
   const { mutate: updateMenu, isPending: isUpdating } = useUpdateMenu();
   const { mutate: deleteMenu } = useDeleteMenu();
 
+  const [searchQuery, setSearchQuery] = useState('');
   const [open, setOpen] = useState(false);
   const [editing, setEditing] = useState<MenuDto | null>(null);
   const [modalKey, setModalKey] = useState(0);
   const [ocrOpen, setOcrOpen] = useState(false);
+
+  const filteredMenus = menus?.filter((m) =>
+    m.name.toLowerCase().includes(searchQuery.toLowerCase()),
+  );
 
   const handleOpenNew = () => {
     setEditing(null);
@@ -635,7 +641,16 @@ const SettingsMenusPage = () => {
           <p className="text-sm font-semibold">메뉴 관리</p>
           <p className="text-xs text-muted-foreground">판매 메뉴를 등록하고 관리합니다.</p>
         </div>
-        <div className="ml-auto flex gap-2">
+        <div className="ml-auto flex items-center gap-2">
+          <div className="relative w-52">
+            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground pointer-events-none" />
+            <Input
+              placeholder="메뉴 이름 검색"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="h-8 pl-8 pr-3 text-sm"
+            />
+          </div>
           <Button size="sm" variant="outline" onClick={() => setOcrOpen(true)}>
             <ScanLine className="size-4 mr-1" /> 메뉴판으로 등록
           </Button>
@@ -687,9 +702,13 @@ const SettingsMenusPage = () => {
               </Button>
             </div>
           </div>
+        ) : !filteredMenus?.length ? (
+          <div className="flex flex-col items-center justify-center py-20 text-muted-foreground">
+            <p className="text-sm">검색 결과가 없습니다.</p>
+          </div>
         ) : (
           <MenuGrid
-            menus={menus}
+            menus={filteredMenus}
             categories={categories}
             onEdit={handleOpenEdit}
             onDelete={(id) => deleteMenu(id)}

--- a/src/pages/SettingsRecipesPage.tsx
+++ b/src/pages/SettingsRecipesPage.tsx
@@ -246,9 +246,7 @@ const SettingsRecipesPage = () => {
     const toDelete = localRecipes.filter((r) => r.deleted).map((r) => r.id);
     const toUpdate = localRecipes.filter(
       (r) =>
-        !r.deleted &&
-        editAmounts[r.id] !== undefined &&
-        editAmounts[r.id] !== String(r.amount),
+        !r.deleted && editAmounts[r.id] !== undefined && editAmounts[r.id] !== String(r.amount),
     );
     const toCreate = pendingItems.filter((p) => p.amount && Number(p.amount) > 0);
 
@@ -424,9 +422,7 @@ const SettingsRecipesPage = () => {
                             placeholder="0"
                             min={0}
                             value={editAmounts[recipe.id] ?? String(recipe.amount)}
-                            onChange={(e) =>
-                              handleExistingAmountChange(recipe.id, e.target.value)
-                            }
+                            onChange={(e) => handleExistingAmountChange(recipe.id, e.target.value)}
                             className="h-8 px-2 text-right text-sm"
                           />
                           <span className="text-xs text-muted-foreground">
@@ -491,25 +487,25 @@ const SettingsRecipesPage = () => {
               onClick={handleSave}
               disabled={isCreating || isDeleting}
             >
-              {isCreating || isDeleting ? (
-                <Loader2 className="size-4 animate-spin" />
-              ) : (
-                '저장하기'
-              )}
+              {isCreating || isDeleting ? <Loader2 className="size-4 animate-spin" /> : '저장하기'}
             </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
 
-      <Dialog open={deletingMenuId !== null} onOpenChange={(v) => { if (!v) setDeletingMenuId(null); }}>
+      <Dialog
+        open={deletingMenuId !== null}
+        onOpenChange={(v) => {
+          if (!v) setDeletingMenuId(null);
+        }}
+      >
         <DialogContent className="max-w-sm">
           <DialogHeader>
             <DialogTitle>레시피 삭제</DialogTitle>
             <DialogDescription>
               <span className="font-medium text-foreground">{deletingMenuName}</span>의 레시피에
               등록된 식자재를 모두 삭제하시겠습니까?
-              <br />
-              이 작업은 되돌릴 수 없습니다.
+              <br />이 작업은 되돌릴 수 없습니다.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>

--- a/src/pages/SettingsRecipesPage.tsx
+++ b/src/pages/SettingsRecipesPage.tsx
@@ -6,7 +6,9 @@ import {
   ChevronDown,
   ChevronUp,
   Loader2,
+  Pencil,
   Plus,
+  Search,
   Trash2,
   X,
 } from 'lucide-react';
@@ -34,7 +36,6 @@ import {
 } from '@/shadcn/ui/dialog';
 import { Input } from '@/shadcn/ui/input';
 import { Label } from '@/shadcn/ui/label';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/shadcn/ui/select';
 import { Skeleton } from '@/shadcn/ui/skeleton';
 
 /* ── 식자재 태그 ── */
@@ -73,32 +74,56 @@ const IngredientTag = ({
 const RecipeAccordion = ({
   menuName,
   recipes,
-  onDelete,
+  onEdit,
+  onDeleteAll,
+  onDeleteOne,
 }: {
   menuId: string;
   menuName: string;
   recipes: RecipeDto[];
-  onDelete: (recipeId: string) => void;
+  onEdit: () => void;
+  onDeleteAll: () => void;
+  onDeleteOne: (recipeId: string) => void;
 }) => {
   const [open, setOpen] = useState(true);
 
   return (
     <div className="overflow-hidden rounded-xl border">
-      <button
-        type="button"
+      <div
+        className="flex w-full items-center justify-between px-4 py-3 cursor-pointer transition-colors hover:bg-muted/30"
         onClick={() => setOpen((v) => !v)}
-        className="flex w-full items-center justify-between px-4 py-3 text-left transition-colors hover:bg-muted/30"
       >
         <div className="flex items-center gap-2">
           <span className="text-sm font-semibold">{menuName}</span>
           <span className="text-xs text-muted-foreground">식자재 {recipes.length}가지</span>
         </div>
-        {open ? (
-          <ChevronUp className="size-4 text-muted-foreground" />
-        ) : (
-          <ChevronDown className="size-4 text-muted-foreground" />
-        )}
-      </button>
+        <div className="flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-7 text-muted-foreground hover:text-baro-blue hover:bg-baro-blue/5"
+            onClick={onEdit}
+          >
+            <Pencil className="size-3.5" />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-7 text-muted-foreground hover:text-baro-red hover:bg-red-50"
+            onClick={onDeleteAll}
+            disabled={recipes.length === 0}
+          >
+            <Trash2 className="size-3.5" />
+          </Button>
+          {open ? (
+            <ChevronUp className="size-4 text-muted-foreground ml-1" />
+          ) : (
+            <ChevronDown className="size-4 text-muted-foreground ml-1" />
+          )}
+        </div>
+      </div>
 
       {open && (
         <div className="border-t">
@@ -124,7 +149,7 @@ const RecipeAccordion = ({
                   <span className="text-xs text-muted-foreground">{r.ingredientUnit}</span>
                   <button
                     type="button"
-                    onClick={() => onDelete(r.id)}
+                    onClick={() => onDeleteOne(r.id)}
                     className="flex items-center justify-center rounded p-1 text-gray-400 hover:bg-red-50 hover:text-red-500"
                   >
                     <Trash2 className="size-3.5" />
@@ -139,6 +164,8 @@ const RecipeAccordion = ({
   );
 };
 
+type LocalRecipe = RecipeDto & { deleted?: boolean };
+
 /* ── 메인 페이지 ── */
 const SettingsRecipesPage = () => {
   const navigate = useNavigate();
@@ -146,56 +173,118 @@ const SettingsRecipesPage = () => {
   const { data: menus } = useMenus();
   const { data: ingredients } = useIngredients();
   const { mutate: createRecipe, isPending: isCreating } = useCreateRecipe();
-  const { mutate: deleteRecipe } = useDeleteRecipe();
+  const { mutate: deleteRecipe, isPending: isDeleting } = useDeleteRecipe();
 
-  const [open, setOpen] = useState(false);
-  const [selectedMenuId, setSelectedMenuId] = useState('');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [editingMenuId, setEditingMenuId] = useState<string | null>(null);
+  const [deletingMenuId, setDeletingMenuId] = useState<string | null>(null);
+  const [localRecipes, setLocalRecipes] = useState<LocalRecipe[]>([]);
+  const [editAmounts, setEditAmounts] = useState<Record<string, string>>({});
   const [pendingItems, setPendingItems] = useState<{ ingredientId: string; amount: string }[]>([]);
 
-  const existingForMenu = recipes?.filter((r) => r.menuId === selectedMenuId) ?? [];
-  const existingIngredientIds = existingForMenu.map((r) => r.ingredientId);
+  const openEdit = (menuId: string) => {
+    const existing = recipes?.filter((r) => r.menuId === menuId) ?? [];
+    setLocalRecipes(existing.map((r) => ({ ...r })));
+    const amounts: Record<string, string> = {};
+    existing.forEach((r) => {
+      amounts[r.id] = String(r.amount);
+    });
+    setEditAmounts(amounts);
+    setPendingItems([]);
+    setEditingMenuId(menuId);
+  };
+
+  const closeModal = () => {
+    setEditingMenuId(null);
+    setLocalRecipes([]);
+    setEditAmounts({});
+    setPendingItems([]);
+  };
+
+  const handleDeleteAll = () => {
+    if (!deletingMenuId) return;
+    const toDelete = recipes?.filter((r) => r.menuId === deletingMenuId) ?? [];
+    toDelete.forEach((r) => deleteRecipe(r.id));
+    setDeletingMenuId(null);
+  };
+
+  const visibleRecipes = localRecipes.filter((r) => !r.deleted);
+  const existingIngredientIds = visibleRecipes.map((r) => r.ingredientId);
   const addedIds = [...existingIngredientIds, ...pendingItems.map((p) => p.ingredientId)];
 
   const handleTagClick = (ingredientId: string) => {
     if (pendingItems.some((p) => p.ingredientId === ingredientId)) {
       setPendingItems((prev) => prev.filter((p) => p.ingredientId !== ingredientId));
     } else if (existingIngredientIds.includes(ingredientId)) {
-      const recipe = existingForMenu.find((r) => r.ingredientId === ingredientId);
-      if (recipe) deleteRecipe(recipe.id);
+      setLocalRecipes((prev) =>
+        prev.map((r) => (r.ingredientId === ingredientId ? { ...r, deleted: true } : r)),
+      );
     } else {
       setPendingItems((prev) => [...prev, { ingredientId, amount: '' }]);
     }
+  };
+
+  const handleRemoveExisting = (recipeId: string) => {
+    setLocalRecipes((prev) => prev.map((r) => (r.id === recipeId ? { ...r, deleted: true } : r)));
+  };
+
+  const handleExistingAmountChange = (recipeId: string, amount: string) => {
+    setEditAmounts((prev) => ({ ...prev, [recipeId]: amount }));
+  };
+
+  const handlePendingAmountChange = (ingredientId: string, amount: string) => {
+    setPendingItems((prev) =>
+      prev.map((p) => (p.ingredientId === ingredientId ? { ...p, amount } : p)),
+    );
   };
 
   const handleRemovePending = (ingredientId: string) => {
     setPendingItems((prev) => prev.filter((p) => p.ingredientId !== ingredientId));
   };
 
-  const handleAmountChange = (ingredientId: string, amount: string) => {
-    setPendingItems((prev) =>
-      prev.map((p) => (p.ingredientId === ingredientId ? { ...p, amount } : p)),
-    );
-  };
-
-  const closeModal = () => {
-    setOpen(false);
-    setSelectedMenuId('');
-    setPendingItems([]);
-  };
-
   const handleSave = () => {
-    const valid = pendingItems.filter((p) => p.amount && Number(p.amount) > 0);
-    if (!valid.length) return;
-    let remaining = valid.length;
-    valid.forEach((item) => {
-      createRecipe(
-        { menuId: selectedMenuId, ingredientId: item.ingredientId, amount: Number(item.amount) },
-        {
-          onSuccess: () => {
-            remaining--;
-            if (remaining === 0) closeModal();
-          },
+    const toDelete = localRecipes.filter((r) => r.deleted).map((r) => r.id);
+    const toUpdate = localRecipes.filter(
+      (r) =>
+        !r.deleted &&
+        editAmounts[r.id] !== undefined &&
+        editAmounts[r.id] !== String(r.amount),
+    );
+    const toCreate = pendingItems.filter((p) => p.amount && Number(p.amount) > 0);
+
+    const total = toDelete.length + toUpdate.length + toCreate.length;
+    if (total === 0) {
+      closeModal();
+      return;
+    }
+
+    let remaining = total;
+    const onDone = () => {
+      remaining--;
+      if (remaining === 0) closeModal();
+    };
+
+    toDelete.forEach((id) => deleteRecipe(id, { onSuccess: onDone }));
+
+    toUpdate.forEach((recipe) => {
+      deleteRecipe(recipe.id, {
+        onSuccess: () => {
+          createRecipe(
+            {
+              menuId: editingMenuId!,
+              ingredientId: recipe.ingredientId,
+              amount: Number(editAmounts[recipe.id]),
+            },
+            { onSuccess: onDone },
+          );
         },
+      });
+    });
+
+    toCreate.forEach((item) => {
+      createRecipe(
+        { menuId: editingMenuId!, ingredientId: item.ingredientId, amount: Number(item.amount) },
+        { onSuccess: onDone },
       );
     });
   };
@@ -206,10 +295,11 @@ const SettingsRecipesPage = () => {
       menuName: menu.name,
       recipes: recipes?.filter((r) => r.menuId === menu.id) ?? [],
     }))
-    .filter((g) => g.recipes.length > 0 || menus.length > 0);
+    .filter((g) => g.menuName.toLowerCase().includes(searchQuery.toLowerCase()));
 
-  const selectedMenuName = menus?.find((m) => m.id === selectedMenuId)?.name;
-  const hasListItems = existingForMenu.length > 0 || pendingItems.length > 0;
+  const editingMenuName = menus?.find((m) => m.id === editingMenuId)?.name;
+  const deletingMenuName = menus?.find((m) => m.id === deletingMenuId)?.name;
+  const hasListItems = visibleRecipes.length > 0 || pendingItems.length > 0;
 
   return (
     <div className="flex flex-1 flex-col overflow-hidden bg-background">
@@ -221,13 +311,15 @@ const SettingsRecipesPage = () => {
           <p className="text-sm font-semibold">레시피 관리</p>
           <p className="text-xs text-muted-foreground">메뉴별 식자재 사용량을 설정합니다.</p>
         </div>
-        <Button
-          size="sm"
-          className="ml-auto bg-baro-blue hover:bg-baro-blue/80 text-white"
-          onClick={() => setOpen(true)}
-        >
-          <Plus className="size-4 mr-1" /> 레시피 추가
-        </Button>
+        <div className="relative ml-auto w-56">
+          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground pointer-events-none" />
+          <Input
+            placeholder="메뉴 이름 검색"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="h-8 pl-8 pr-3 text-sm"
+          />
+        </div>
       </header>
 
       <div className="flex-1 overflow-y-auto p-6 space-y-3">
@@ -239,6 +331,10 @@ const SettingsRecipesPage = () => {
           <div className="flex flex-col items-center justify-center py-20 text-muted-foreground">
             <p className="text-sm">먼저 메뉴를 등록해주세요.</p>
           </div>
+        ) : !grouped?.length ? (
+          <div className="flex flex-col items-center justify-center py-20 text-muted-foreground">
+            <p className="text-sm">검색 결과가 없습니다.</p>
+          </div>
         ) : (
           grouped?.map((g) => (
             <RecipeAccordion
@@ -246,174 +342,146 @@ const SettingsRecipesPage = () => {
               menuId={g.menuId}
               menuName={g.menuName}
               recipes={g.recipes}
-              onDelete={deleteRecipe}
+              onEdit={() => openEdit(g.menuId)}
+              onDeleteAll={() => setDeletingMenuId(g.menuId)}
+              onDeleteOne={deleteRecipe}
             />
           ))
         )}
       </div>
 
       <Dialog
-        open={open}
+        open={editingMenuId !== null}
         onOpenChange={(v) => {
           if (!v) closeModal();
-          else setOpen(true);
         }}
       >
         <DialogContent className="flex max-h-[60vh] max-w-xl flex-col overflow-hidden">
-          {/* 헤더 — 고정 */}
           <DialogHeader>
-            <DialogTitle>레시피 추가</DialogTitle>
-            <DialogDescription>메뉴별 식자재 사용량을 설정합니다</DialogDescription>
+            <DialogTitle>레시피 수정</DialogTitle>
+            <DialogDescription>
+              <span className="font-medium text-foreground">{editingMenuName}</span>의 식자재
+              사용량을 수정합니다
+            </DialogDescription>
           </DialogHeader>
 
-          {/* 본문 — 스크롤 */}
           <div className="flex-1 overflow-y-auto pb-2">
-            {/* 메뉴 선택 */}
-            <div className="space-y-1.5">
-              <Label className="text-sm">
-                메뉴 <span className="text-baro-red">*</span>
-              </Label>
-              <Select
-                value={selectedMenuId}
-                onValueChange={(v) => {
-                  setSelectedMenuId(v ?? '');
-                  setPendingItems([]);
-                }}
-              >
-                <SelectTrigger className="w-full">
-                  <SelectValue placeholder="레시피를 추가할 메뉴를 선택하세요">
-                    {selectedMenuName}
-                  </SelectValue>
-                </SelectTrigger>
-                <SelectContent>
-                  {menus?.map((m) => (
-                    <SelectItem key={m.id} value={m.id}>
-                      {m.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
+            <div className="space-y-4 py-2">
+              <div className="flex items-center gap-3">
+                <div className="h-px flex-1 bg-border" />
+                <span className="text-xs font-medium text-muted-foreground">식자재 선택</span>
+                <div className="h-px flex-1 bg-border" />
+              </div>
 
-            {selectedMenuId && (
-              <div className="space-y-4 py-2">
-                {/* 구분선 */}
-                <div className="flex items-center gap-3">
-                  <div className="h-px flex-1 bg-border" />
-                  <span className="text-xs font-medium text-muted-foreground">식자재 선택</span>
-                  <div className="h-px flex-1 bg-border" />
-                </div>
-
-                {/* 식자재 팔레트 */}
-                {!ingredients?.length ? (
-                  <p className="py-4 text-center text-xs text-muted-foreground">
-                    등록된 식자재가 없습니다. 먼저 식자재를 등록해주세요.
-                  </p>
-                ) : (
-                  <div className="rounded-xl border bg-gray-50/60 p-3 dark:bg-muted/20">
-                    <div className="flex flex-wrap gap-2">
-                      {ingredients.map((ing) => (
-                        <IngredientTag
-                          key={ing.id}
-                          ingredient={ing}
-                          added={addedIds.includes(ing.id)}
-                          onClick={() => handleTagClick(ing.id)}
-                        />
-                      ))}
-                    </div>
+              {!ingredients?.length ? (
+                <p className="py-4 text-center text-xs text-muted-foreground">
+                  등록된 식자재가 없습니다. 먼저 식자재를 등록해주세요.
+                </p>
+              ) : (
+                <div className="rounded-xl border bg-gray-50/60 p-3 dark:bg-muted/20">
+                  <div className="flex flex-wrap gap-2">
+                    {ingredients.map((ing) => (
+                      <IngredientTag
+                        key={ing.id}
+                        ingredient={ing}
+                        added={addedIds.includes(ing.id)}
+                        onClick={() => handleTagClick(ing.id)}
+                      />
+                    ))}
                   </div>
-                )}
+                </div>
+              )}
 
-                {/* 재료 목록 (기존 저장 + 새로 추가) */}
-                {hasListItems && (
-                  <div className="space-y-1.5">
-                    <div className="flex items-center justify-between">
-                      <span className="text-xs font-medium text-muted-foreground">사용량</span>
-                      {pendingItems.length > 0 && (
-                        <span className="text-xs font-medium text-baro-blue">
-                          +{pendingItems.length}개 추가 예정
-                        </span>
-                      )}
+              {hasListItems && (
+                <div className="space-y-1.5">
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs font-medium text-muted-foreground">사용량</span>
+                    {pendingItems.length > 0 && (
+                      <span className="text-xs font-medium text-baro-blue">
+                        +{pendingItems.length}개 추가 예정
+                      </span>
+                    )}
+                  </div>
+                  <div className="overflow-hidden rounded-xl border">
+                    <div className="grid grid-cols-[1fr_96px_40px_32px] items-center gap-2 border-b bg-muted/40 px-3.5 py-2 text-xs font-medium text-muted-foreground">
+                      <span>식자재</span>
+                      <span>사용량</span>
+                      <span>단위</span>
+                      <span />
                     </div>
-                    <div className="overflow-hidden rounded-xl border">
-                      <div className="grid grid-cols-[1fr_96px_40px_32px] items-center gap-2 border-b bg-muted/40 px-3.5 py-2 text-xs font-medium text-muted-foreground">
-                        <span>식자재</span>
-                        <span>사용량</span>
-                        <span>단위</span>
-                        <span />
-                      </div>
-                      <div className="divide-y">
-                        {/* 기존 저장된 항목 — 읽기 전용 */}
-                        {existingForMenu.map((recipe) => (
+                    <div className="divide-y">
+                      {visibleRecipes.map((recipe) => (
+                        <div
+                          key={recipe.id}
+                          className="grid grid-cols-[1fr_96px_40px_32px] items-center gap-2 px-3.5 py-2.5"
+                        >
+                          <div className="flex min-w-0 items-center gap-2">
+                            <span className="size-1.5 shrink-0 rounded-full bg-gray-300" />
+                            <span className="truncate text-sm">{recipe.ingredientName}</span>
+                          </div>
+                          <Input
+                            type="number"
+                            placeholder="0"
+                            min={0}
+                            value={editAmounts[recipe.id] ?? String(recipe.amount)}
+                            onChange={(e) =>
+                              handleExistingAmountChange(recipe.id, e.target.value)
+                            }
+                            className="h-8 px-2 text-right text-sm"
+                          />
+                          <span className="text-xs text-muted-foreground">
+                            {recipe.ingredientUnit}
+                          </span>
+                          <button
+                            type="button"
+                            onClick={() => handleRemoveExisting(recipe.id)}
+                            className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-red-50 hover:text-baro-red"
+                          >
+                            <X className="size-3.5" />
+                          </button>
+                        </div>
+                      ))}
+
+                      {pendingItems.map((item) => {
+                        const ing = ingredients?.find((i) => i.id === item.ingredientId);
+                        if (!ing) return null;
+                        return (
                           <div
-                            key={recipe.id}
-                            className="grid grid-cols-[1fr_96px_40px_32px] items-center gap-2 bg-muted/10 px-3.5 py-2.5"
+                            key={item.ingredientId}
+                            className="grid grid-cols-[1fr_96px_40px_32px] items-center gap-2 px-3.5 py-2.5"
                           >
                             <div className="flex min-w-0 items-center gap-2">
-                              <span className="size-1.5 shrink-0 rounded-full bg-gray-300" />
-                              <span className="truncate text-sm text-muted-foreground">
-                                {recipe.ingredientName}
-                              </span>
+                              <span className="size-1.5 shrink-0 rounded-full bg-baro-blue" />
+                              <span className="truncate text-sm">{ing.name}</span>
                             </div>
-                            <span className="pr-1 text-right text-sm text-muted-foreground">
-                              {Number(recipe.amount).toLocaleString()}
-                            </span>
-                            <span className="text-xs text-muted-foreground">
-                              {recipe.ingredientUnit}
-                            </span>
+                            <Input
+                              type="number"
+                              placeholder="0"
+                              min={0}
+                              value={item.amount}
+                              onChange={(e) =>
+                                handlePendingAmountChange(item.ingredientId, e.target.value)
+                              }
+                              className="h-8 px-2 text-right text-sm"
+                            />
+                            <span className="text-xs text-muted-foreground">{ing.unit}</span>
                             <button
                               type="button"
-                              onClick={() => deleteRecipe(recipe.id)}
+                              onClick={() => handleRemovePending(item.ingredientId)}
                               className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-red-50 hover:text-baro-red"
                             >
                               <X className="size-3.5" />
                             </button>
                           </div>
-                        ))}
-
-                        {/* 새로 추가 중인 항목 — 사용량 입력 가능 */}
-                        {pendingItems.map((item) => {
-                          const ing = ingredients?.find((i) => i.id === item.ingredientId);
-                          if (!ing) return null;
-                          return (
-                            <div
-                              key={item.ingredientId}
-                              className="grid grid-cols-[1fr_96px_40px_32px] items-center gap-2 px-3.5 py-2.5"
-                            >
-                              <div className="flex min-w-0 items-center gap-2">
-                                <span className="size-1.5 shrink-0 rounded-full bg-baro-blue" />
-                                <span className="truncate text-sm">{ing.name}</span>
-                              </div>
-                              <Input
-                                type="number"
-                                placeholder="0"
-                                min={0}
-                                value={item.amount}
-                                onChange={(e) =>
-                                  handleAmountChange(item.ingredientId, e.target.value)
-                                }
-                                className="h-8 px-2 text-right text-sm"
-                              />
-                              <span className="text-xs text-muted-foreground">{ing.unit}</span>
-                              <button
-                                type="button"
-                                onClick={() => handleRemovePending(item.ingredientId)}
-                                className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-red-50 hover:text-baro-red"
-                              >
-                                <X className="size-3.5" />
-                              </button>
-                            </div>
-                          );
-                        })}
-                      </div>
+                        );
+                      })}
                     </div>
                   </div>
-                )}
-              </div>
-            )}
+                </div>
+              )}
+            </div>
           </div>
 
-          {/* 푸터 — 고정 */}
           <DialogFooter>
             <Button type="button" variant="outline" onClick={closeModal}>
               취소
@@ -421,13 +489,39 @@ const SettingsRecipesPage = () => {
             <Button
               className="bg-baro-blue text-white hover:bg-baro-blue/80"
               onClick={handleSave}
-              disabled={
-                isCreating ||
-                !selectedMenuId ||
-                pendingItems.every((p) => !p.amount || Number(p.amount) <= 0)
-              }
+              disabled={isCreating || isDeleting}
             >
-              {isCreating ? <Loader2 className="size-4 animate-spin" /> : '저장하기'}
+              {isCreating || isDeleting ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                '저장하기'
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={deletingMenuId !== null} onOpenChange={(v) => { if (!v) setDeletingMenuId(null); }}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>레시피 삭제</DialogTitle>
+            <DialogDescription>
+              <span className="font-medium text-foreground">{deletingMenuName}</span>의 레시피에
+              등록된 식자재를 모두 삭제하시겠습니까?
+              <br />
+              이 작업은 되돌릴 수 없습니다.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setDeletingMenuId(null)}>
+              취소
+            </Button>
+            <Button
+              className="bg-baro-red text-white hover:bg-baro-red/80"
+              onClick={handleDeleteAll}
+              disabled={isDeleting}
+            >
+              {isDeleting ? <Loader2 className="size-4 animate-spin" /> : '삭제'}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/shared/components/IngredientRegisterModal.tsx
+++ b/src/shared/components/IngredientRegisterModal.tsx
@@ -1,13 +1,17 @@
 import { useState } from 'react';
 
-import { PackagePlus, Pencil } from 'lucide-react';
-
 import {
   useCreateIngredient,
   useUpdateIngredient,
 } from '@/features/store-settings/hooks/useIngredients';
 import { Button } from '@/shadcn/ui/button';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/shadcn/ui/dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/shadcn/ui/dialog';
 import { Input } from '@/shadcn/ui/input';
 import { Label } from '@/shadcn/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/shadcn/ui/select';
@@ -66,22 +70,15 @@ const IngredientRegisterModal = ({
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
       <DialogContent className="max-w-sm">
-        <DialogHeader className="gap-0">
+        <DialogHeader>
           <DialogTitle className="text-lg! leading-none! flex items-center gap-2">
-            <div className="w-8 h-8 rounded-lg bg-baro-blue/10 flex items-center justify-center shrink-0">
-              {isEditMode ? (
-                <Pencil className="w-4 h-4 text-baro-blue" />
-              ) : (
-                <PackagePlus className="w-4 h-4 text-baro-blue" />
-              )}
-            </div>
             {isEditMode ? '식자재 수정' : '식자재 등록'}
           </DialogTitle>
-          <p className="text-xs text-muted-foreground">
+          <DialogDescription className="text-xs text-muted-foreground">
             {isEditMode
               ? '식자재 이름과 단위를 수정합니다.'
               : '등록한 단위는 이후 재고 관리에 고정으로 사용됩니다'}
-          </p>
+          </DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="flex flex-col gap-4 pt-1">


### PR DESCRIPTION
## 📌 요약

- 레시피 관리 페이지에서 기존 레시피를 수정·삭제할 수 있는 기능 추가
- 가게 설정 하위 페이지(레시피·식자재·메뉴 관리)에 이름 검색 기능 추가

<br/>

## 🏷️ 관련 이슈

- Closes #67

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- 레시피 관리 헤더의 '레시피 추가' 버튼 제거 → 각 메뉴 카드에 수정/삭제 버튼으로 대체
- 레시피 수정 모달: 식자재 수량 인라인 편집, 식자재 추가·제거 지원
- 레시피 삭제: 전체 식자재 삭제 전 확인 모달 표시 (카드는 유지)
- 레시피·식자재·메뉴 관리 페이지에 이름 검색창 추가

<br/>

### 📂 세부 변경사항

- `SettingsRecipesPage`: 헤더 추가 버튼 제거, 카드별 수정(Pencil)·삭제(Trash2) 버튼 추가, 수정 모달 및 삭제 확인 모달 구현, 메뉴 이름 검색창 추가
- `SettingsIngredientsPage`: 안전 재고 기준 버튼 왼쪽에 식자재 이름 검색창 추가
- `SettingsMenusPage`: 메뉴판으로 등록 버튼 왼쪽에 메뉴 이름 검색창 추가

<br/>

## 📸 Screenshots

| Before | After |
| ------ | ----- |
|        |       |

<br/>

## 🧪 테스트 방법

1. 레시피 관리 페이지 진입 → 각 메뉴 카드 헤더에 수정(연필)/삭제(휴지통) 버튼 확인
2. 수정 버튼 클릭 → 해당 메뉴 식자재 목록이 채워진 모달 열림, 수량 변경·식자재 추가/제거 후 저장
3. 삭제 버튼 클릭 → 확인 모달 표시 → 삭제 후 식자재 제거, 카드(메뉴 행) 유지 확인
4. 레시피·식자재·메뉴 관리 페이지 각각 검색창에서 이름 입력 → 필터링 확인
5. 검색 결과 없을 때 빈 상태 문구 표시 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [x] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- 수량 변경이 필요한 기존 식자재는 PATCH 엔드포인트 대신 delete → recreate 방식으로 처리 (백엔드 PATCH API 미구현 상태)
- 삭제 시 식자재만 제거되고 메뉴 카드(행)는 유지됨