### PR TITLE
✨ (#101) feat: 소급 마감 지원 및 누락 마감 배너 추가

### DIFF
--- a/src/features/closing/api/closing.api.ts
+++ b/src/features/closing/api/closing.api.ts
@@ -7,9 +7,11 @@ import type {
 } from '@/features/closing/types/closing.types';
 import axiosInstance from '@/shared/api/axiosInstance';
 
-export const fetchClosingPreview = (storeId: string): Promise<ClosingPreview> =>
+export const fetchClosingPreview = (storeId: string, date?: string): Promise<ClosingPreview> =>
   axiosInstance
-    .get<{ success: boolean; data: ClosingPreview }>(`/stores/${storeId}/closing/preview`)
+    .get<{ success: boolean; data: ClosingPreview }>(`/stores/${storeId}/closing/preview`, {
+      params: date ? { date } : undefined,
+    })
     .then((res) => res.data.data);
 
 export const submitClosing = (storeId: string, body: ClosingRequest): Promise<ClosingResponse> =>

--- a/src/features/closing/hooks/useClosingPreview.ts
+++ b/src/features/closing/hooks/useClosingPreview.ts
@@ -2,9 +2,9 @@ import { useQuery } from '@tanstack/react-query';
 
 import { fetchClosingPreview } from '@/features/closing/api/closing.api';
 
-export const useClosingPreview = (storeId: string | null) =>
+export const useClosingPreview = (storeId: string | null, date?: string) =>
   useQuery({
-    queryKey: ['closing', 'preview', storeId],
-    queryFn: () => fetchClosingPreview(storeId!),
+    queryKey: ['closing', 'preview', storeId, date],
+    queryFn: () => fetchClosingPreview(storeId!, date),
     enabled: !!storeId,
   });

--- a/src/features/closing/types/closing.types.ts
+++ b/src/features/closing/types/closing.types.ts
@@ -29,7 +29,7 @@ export interface ClosingDeductionItem {
 }
 
 export interface ClosingRequest {
-  date: string;
+  date?: string;
   inventoryDeductions: ClosingDeductionItem[];
 }
 
@@ -43,6 +43,7 @@ export interface ClosingDeductionResult {
 
 export interface ClosingResponse {
   closingId: string;
+  date: string;
   totalRevenue: number;
   deductedIngredients: ClosingDeductionResult[];
 }

--- a/src/features/dashboard/types/dashboard.types.ts
+++ b/src/features/dashboard/types/dashboard.types.ts
@@ -4,6 +4,7 @@ export interface DashboardStats {
   aiOrderRecommendations: number;
   monthlyConsumption: number;
   monthlyConsumptionChange: number;
+  missedClosing: boolean;
   lastUpdated: string;
 }
 

--- a/src/pages/ClosingPage.tsx
+++ b/src/pages/ClosingPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
-import { CalendarDays, CheckCircle, TrendingUp } from 'lucide-react';
+import { AlertTriangle, CalendarDays, CheckCircle, TrendingUp } from 'lucide-react';
+import { useSearchParams } from 'react-router-dom';
 
 import useAuthStore from '@/features/auth/store/authStore';
 import AfterClosingModal from '@/features/closing/components/AfterClosingModal';
@@ -28,7 +29,11 @@ const formatDate = (dateStr: string) => {
 
 const ClosingPage = () => {
   const storeId = useAuthStore((s) => s.storeId);
-  const { data: preview, isLoading, isError } = useClosingPreview(storeId);
+  const [searchParams] = useSearchParams();
+  const dateParam = searchParams.get('date') ?? undefined;
+  const isRetroactive = !!dateParam;
+
+  const { data: preview, isLoading, isError } = useClosingPreview(storeId, dateParam);
 
   const [deductionRows, setDeductionRows] = useState<DeductionRow[]>([]);
   const [afterModalOpen, setAfterModalOpen] = useState(false);
@@ -114,6 +119,17 @@ const ClosingPage = () => {
           </div>
         </div>
 
+        {/* 소급 마감 안내 배너 */}
+        {isRetroactive && (
+          <div className="mx-6 mt-4 flex items-start gap-2.5 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
+            <p>
+              전날 마감을 소급 처리합니다. 오늘 이미 발생한 매출과 재고 차감 순서가 실제와 다를 수
+              있습니다.
+            </p>
+          </div>
+        )}
+
         {/* 스크롤 영역 */}
         <div className="flex-1 flex flex-col gap-6 p-6 pb-28">
           {/* 총 매출 카드 */}
@@ -124,7 +140,9 @@ const ClosingPage = () => {
                   <TrendingUp className="w-5 h-5 text-baro-blue" />
                 </div>
                 <div>
-                  <p className="text-xs text-muted-foreground">오늘 총 매출</p>
+                  <p className="text-xs text-muted-foreground">
+                    {isRetroactive ? '해당일 총 매출' : '오늘 총 매출'}
+                  </p>
                   <p className="text-2xl font-bold text-foreground">
                     {formatCurrency(preview.totalRevenue)}
                   </p>

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,3 +1,6 @@
+import { AlertTriangle } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
 import useAuthStore from '@/features/auth/store/authStore';
 import OrderStatusCard from '@/features/customer-order/components/CustomerOrderStatusCard';
 import MemoCard from '@/features/dashboard/components/MemoCard';
@@ -7,6 +10,12 @@ import StoreStatusCard from '@/features/dashboard/components/StoreStatusCard';
 import { useDashboardSales } from '@/features/dashboard/hooks/useDashboardSales';
 import { useDashboardStats } from '@/features/dashboard/hooks/useDashboardStats';
 import { Skeleton } from '@/shadcn/ui/skeleton';
+
+const getYesterdayKST = () => {
+  const kstNow = new Date(Date.now() + 9 * 60 * 60 * 1000);
+  kstNow.setDate(kstNow.getDate() - 1);
+  return kstNow.toISOString().slice(0, 10);
+};
 
 const DashboardPage = () => {
   const storeId = useAuthStore((s) => s.storeId);
@@ -23,6 +32,19 @@ const DashboardPage = () => {
 
       {/* 오른쪽: 가게 현황 */}
       <div className="flex-1 min-w-0 flex flex-col gap-4">
+        {/* 누락 마감 배너 */}
+        {stats?.missedClosing && (
+          <Link
+            to={`/closing?date=${getYesterdayKST()}`}
+            className="flex items-center gap-2.5 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 hover:bg-amber-100 transition-colors"
+          >
+            <AlertTriangle className="h-4 w-4 shrink-0 text-amber-500" />
+            <span>
+              <span className="font-semibold">전날 마감이 누락되었습니다.</span> 클릭하여 소급
+              마감을 진행하세요.
+            </span>
+          </Link>
+        )}
         {/* 상단: 오늘의 가게 현황 요약 */}
         {statsLoading || !stats ? (
           <Skeleton className="h-[92px] w-full rounded-xl" />


### PR DESCRIPTION
## 📌 요약

- 마감을 깜빡하고 자정이 넘어간 경우를 위한 소급 마감 플로우 구현
- 백엔드 API 변경사항(date 파라미터, missedClosing 필드) 반영

<br/>

## 🏷️ 관련 이슈

- Closes #101

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- 대시보드: `missedClosing === true` 시 "전날 마감이 누락되었습니다" 배너 표시 → 클릭 시 `/closing?date={어제}` 이동
- 마감 페이지: URL `?date=` 파라미터 수신 시 소급 마감 모드로 진입, amber 경고 배너 표시

<br/>

### 📂 세부 변경사항

- `closing.types.ts`: `ClosingRequest.date` optional로 변경, `ClosingResponse`에 `date` 필드 추가
- `dashboard.types.ts`: `DashboardStats`에 `missedClosing: boolean` 추가
- `closing.api.ts`: `fetchClosingPreview`에 선택적 `date` 쿼리 파라미터 추가
- `useClosingPreview.ts`: `date` 파라미터 수신 및 queryKey 반영
- `ClosingPage.tsx`: `useSearchParams`로 `?date=` 읽기, 소급 시 경고 배너 + "해당일 총 매출" 표시
- `DashboardPage.tsx`: `missedClosing` 배너 추가, KST 어제 날짜 계산 유틸 포함

<br/>

## 📸 Screenshots

| Before | After |
| ------ | ----- |
| 마감 누락 시 인지 불가 | 대시보드 amber 배너로 즉시 인지 |
| 자정 이후 전날 마감 불가 | `/closing?date=어제날짜` 로 소급 마감 가능 |

<br/>

## 🧪 테스트 방법

1. 대시보드에서 `stats.missedClosing === true` 응답 시 amber 배너 노출 확인
2. 배너 클릭 → `/closing?date=어제날짜` 이동 확인
3. 마감 페이지에서 소급 경고 배너("전날 소급 처리합니다...") 표시 확인
4. "해당일 총 매출" 레이블 표시 확인
5. 정상 마감(`?date` 없음) 시 기존 UI 동일하게 동작 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [x] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- OCR 관련 파일(`ocr.api.ts`, `ocrInbound.api.types.ts`) 변경은 이 PR에 미포함 (별도 작업)
- 소급 마감은 1일 전까지만 허용 (2일 이상은 서버에서 400 반환, 별도 안내 불필요)