### PR TITLE
✨ (#109) feat: 영업 세션 관리 시스템 구현 (개점+businessDate+라우트 가드)

### DIFF
--- a/src/app/AppInitializer.tsx
+++ b/src/app/AppInitializer.tsx
@@ -1,13 +1,18 @@
 import { useEffect, useState } from 'react';
 
 import useAuthStore from '@/features/auth/store/authStore';
+import { fetchBusinessOpenStatus } from '@/features/closing/api/closing.api';
+import useClosingStore from '@/features/closing/store/closingStore';
+import { fetchStoreSettings } from '@/features/store-settings/api/storeSettings.api';
 import axiosInstance from '@/shared/api/axiosInstance';
 
 const AppInitializer = ({ children }: { children: React.ReactNode }) => {
   const [ready, setReady] = useState(false);
   const setAccessToken = useAuthStore((s) => s.setAccessToken);
   const setStoreId = useAuthStore((s) => s.setStoreId);
+  const setOperatingHours = useAuthStore((s) => s.setOperatingHours);
   const clearAuth = useAuthStore((s) => s.clearAuth);
+  const setBusinessSession = useClosingStore((s) => s.setBusinessSession);
 
   useEffect(() => {
     const { refreshToken } = useAuthStore.getState();
@@ -19,22 +24,39 @@ const AppInitializer = ({ children }: { children: React.ReactNode }) => {
           .catch(() => clearAuth())
       : Promise.resolve();
 
-    const init = tokenInit.then(() => {
+    const init = tokenInit.then(async () => {
       const { accessToken, storeId } = useAuthStore.getState();
-      if (accessToken && !storeId) {
-        return axiosInstance
-          .get('/users/me/store')
-          .then((res) => {
-            if (res.data.data?.storeId) {
-              setStoreId(res.data.data.storeId);
-            }
-          })
-          .catch(() => {});
+      if (!accessToken) return;
+
+      let resolvedStoreId = storeId;
+
+      if (!resolvedStoreId) {
+        const res = await axiosInstance.get('/users/me/store').catch(() => null);
+        resolvedStoreId = res?.data?.data?.storeId ?? null;
+        if (resolvedStoreId) setStoreId(resolvedStoreId);
       }
+
+      if (!resolvedStoreId) return;
+
+      // 가게 영업 시간 + 개점 상태 병렬 fetch
+      await Promise.all([
+        fetchStoreSettings(resolvedStoreId)
+          .then((settings) => setOperatingHours(settings.operatingHours))
+          .catch(() => {}),
+
+        fetchBusinessOpenStatus(resolvedStoreId)
+          .then((status) =>
+            setBusinessSession({
+              isOpen: status.isOpen,
+              businessDate: status.businessDate,
+            }),
+          )
+          .catch(() => {}),
+      ]);
     });
 
     init.finally(() => setReady(true));
-  }, [setAccessToken, setStoreId, clearAuth]);
+  }, [setAccessToken, setStoreId, setOperatingHours, clearAuth, setBusinessSession]);
 
   if (!ready) return null;
 

--- a/src/app/layouts/AppLayout.tsx
+++ b/src/app/layouts/AppLayout.tsx
@@ -2,7 +2,9 @@ import { useEffect, useRef } from 'react';
 
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 
+import { routePaths } from '@/app/routes/routePaths';
 import { useUserInfo } from '@/features/account-settings/hooks/useUserInfo';
+import useClosingStore from '@/features/closing/store/closingStore';
 import { useStoreSettings } from '@/features/store-settings/hooks/useStoreSettings';
 import { SidebarInset, SidebarProvider } from '@/shadcn/ui/sidebar';
 import AppHeader from '@/widgets/AppHeader';
@@ -17,6 +19,15 @@ const AppLayout = () => {
   const scrollRef = useRef<HTMLDivElement>(null);
   const { pathname } = useLocation();
   const navigate = useNavigate();
+
+  const { isOpen } = useClosingStore((s) => s.businessSession);
+
+  // 대시보드만 영업 세션 필수 — 재고·발주·설정 등은 세션 없이 접근 가능
+  useEffect(() => {
+    if (!isOpen && pathname === routePaths.dashboard) {
+      navigate('/system-start', { replace: true });
+    }
+  }, [isOpen, pathname, navigate]);
 
   const { data: storeData, isLoading: isStoreLoading } = useStoreSettings();
   const { data: userData, isLoading: isUserLoading } = useUserInfo();

--- a/src/features/auth/store/authStore.ts
+++ b/src/features/auth/store/authStore.ts
@@ -1,6 +1,8 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
+import type { OperatingHour } from '@/features/initial-setup/types/initialSetup.types';
+
 // TODO: 백엔드와 협의 후 httpOnly 쿠키 방식으로 전환 권장
 // - 현재: localStorage에 저장 → XSS 취약점 존재 (BARO 구조상 현실적 위험은 낮음)
 // - 개선: 백엔드가 Set-Cookie(HttpOnly, Secure, SameSite=Strict)로 토큰 관리
@@ -10,9 +12,11 @@ interface AuthState {
   accessToken: string | null;
   refreshToken: string | null;
   storeId: string | null;
+  operatingHours: OperatingHour[];
   setAccessToken: (token: string) => void;
   setTokens: (accessToken: string, refreshToken: string) => void;
   setStoreId: (storeId: string) => void;
+  setOperatingHours: (hours: OperatingHour[]) => void;
   clearAuth: () => void;
 }
 
@@ -22,10 +26,13 @@ const useAuthStore = create<AuthState>()(
       accessToken: null,
       refreshToken: null,
       storeId: null,
+      operatingHours: [],
       setAccessToken: (token) => set({ accessToken: token }),
       setTokens: (accessToken, refreshToken) => set({ accessToken, refreshToken }),
       setStoreId: (storeId) => set({ storeId }),
-      clearAuth: () => set({ accessToken: null, refreshToken: null, storeId: null }),
+      setOperatingHours: (hours) => set({ operatingHours: hours }),
+      clearAuth: () =>
+        set({ accessToken: null, refreshToken: null, storeId: null, operatingHours: [] }),
     }),
     { name: 'baro-auth' },
   ),

--- a/src/features/closing/api/closing.api.ts
+++ b/src/features/closing/api/closing.api.ts
@@ -1,4 +1,7 @@
 import type {
+  BusinessOpenRequest,
+  BusinessOpenResponse,
+  BusinessOpenStatus,
   ClosingHistory,
   ClosingHistoryItem,
   ClosingPreview,
@@ -26,3 +29,16 @@ export const fetchClosingHistory = (storeId: string): Promise<ClosingHistory> =>
 
 export const cancelClosing = (storeId: string, id: string): Promise<void> =>
   axiosInstance.delete(`/stores/${storeId}/closing/${id}`).then(() => undefined);
+
+export const openBusiness = (
+  storeId: string,
+  body: BusinessOpenRequest,
+): Promise<BusinessOpenResponse> =>
+  axiosInstance
+    .post<{ success: boolean; data: BusinessOpenResponse }>(`/stores/${storeId}/open`, body)
+    .then((res) => res.data.data);
+
+export const fetchBusinessOpenStatus = (storeId: string): Promise<BusinessOpenStatus> =>
+  axiosInstance
+    .get<{ success: boolean; data: BusinessOpenStatus }>(`/stores/${storeId}/open/status`)
+    .then((res) => res.data.data);

--- a/src/features/closing/components/AfterClosingModal.tsx
+++ b/src/features/closing/components/AfterClosingModal.tsx
@@ -20,6 +20,7 @@ import { Dialog, DialogContent } from '@/shadcn/ui/dialog';
 interface AfterClosingModalProps {
   open: boolean;
   totalRevenue: number;
+  closingDate: string; // YYYY-MM-DD
   storeId: string;
   closingId: string;
 }
@@ -52,15 +53,28 @@ const URGENCY_CONFIG: Record<
   },
 };
 
-const ClosingHero = ({ totalRevenue, subtitle }: { totalRevenue: number; subtitle?: string }) => (
+const formatShortDate = (dateStr: string) => {
+  const [, month, day] = dateStr.split('-').map(Number);
+  return `${month}월 ${day}일`;
+};
+
+const ClosingHero = ({
+  totalRevenue,
+  closingDate,
+  subtitle,
+}: {
+  totalRevenue: number;
+  closingDate: string;
+  subtitle?: string;
+}) => (
   <div className="px-6 pt-8 pb-5 text-center bg-baro-blue">
     <div className="w-16 h-16 rounded-full bg-white/20 flex items-center justify-center mx-auto mb-4">
       <CheckCircle2 className="w-8 h-8 text-white" />
     </div>
-    <h2 className="text-xl font-bold text-white">오늘 마감 완료!</h2>
+    <h2 className="text-xl font-bold text-white">{formatShortDate(closingDate)} 마감 완료!</h2>
     {subtitle && <p className="text-sm text-white/70 mt-1">{subtitle}</p>}
     <div className="mt-4 bg-white/15 rounded-xl px-4 py-3">
-      <p className="text-xs text-white/70">오늘 총 매출</p>
+      <p className="text-xs text-white/70">{formatShortDate(closingDate)} 총 매출</p>
       <p className="text-3xl font-bold tabular-nums text-white mt-0.5">
         {formatCurrency(totalRevenue)}
       </p>
@@ -68,7 +82,13 @@ const ClosingHero = ({ totalRevenue, subtitle }: { totalRevenue: number; subtitl
   </div>
 );
 
-const AfterClosingModal = ({ open, totalRevenue, storeId, closingId }: AfterClosingModalProps) => {
+const AfterClosingModal = ({
+  open,
+  totalRevenue,
+  closingDate,
+  storeId,
+  closingId,
+}: AfterClosingModalProps) => {
   const navigate = useNavigate();
   const [step, setStep] = useState<Step>('generating');
   const [guideItems, setGuideItems] = useState<OrderGuideItem[]>([]);
@@ -102,7 +122,7 @@ const AfterClosingModal = ({ open, totalRevenue, storeId, closingId }: AfterClos
         {/* ── 생성 중 ── */}
         {step === 'generating' && (
           <>
-            <ClosingHero totalRevenue={totalRevenue} />
+            <ClosingHero totalRevenue={totalRevenue} closingDate={closingDate} />
             <div className="flex flex-col items-center gap-3 px-6 py-8">
               <div className="h-8 w-8 animate-spin rounded-full border-[3px] border-baro-blue border-t-transparent" />
               <div className="text-center">
@@ -118,7 +138,11 @@ const AfterClosingModal = ({ open, totalRevenue, storeId, closingId }: AfterClos
         {/* ── 발주 가이드 없음 ── */}
         {step === 'no-guide' && (
           <>
-            <ClosingHero totalRevenue={totalRevenue} subtitle="수고하셨습니다" />
+            <ClosingHero
+              totalRevenue={totalRevenue}
+              closingDate={closingDate}
+              subtitle="수고하셨습니다"
+            />
             <div className="px-6 pt-0 pb-5 space-y-4">
               <div className="flex items-start gap-3 rounded-xl bg-baro-green/10 border border-baro-green/25 p-4">
                 <div className="shrink-0 w-8 h-8 rounded-full bg-baro-green/20 flex items-center justify-center">
@@ -145,7 +169,11 @@ const AfterClosingModal = ({ open, totalRevenue, storeId, closingId }: AfterClos
         {/* ── 발주 가이드 있음: 선택 ── */}
         {step === 'choose' && (
           <>
-            <ClosingHero totalRevenue={totalRevenue} subtitle="재고 차감 완료" />
+            <ClosingHero
+              totalRevenue={totalRevenue}
+              closingDate={closingDate}
+              subtitle="재고 차감 완료"
+            />
             <div className="px-6 pt-0 pb-5 space-y-3">
               <p className="text-sm text-muted-foreground text-center pt-1 pb-2">
                 발주 가이드를 언제 확인할까요?

--- a/src/features/closing/hooks/useClosingStatus.ts
+++ b/src/features/closing/hooks/useClosingStatus.ts
@@ -1,22 +1,18 @@
+import useAuthStore from '@/features/auth/store/authStore';
 import { useClosingHistory } from '@/features/closing/hooks/useClosingHistory';
-
-const getTodayDateString = () => {
-  const now = new Date();
-  const year = now.getFullYear();
-  const month = String(now.getMonth() + 1).padStart(2, '0');
-  const day = String(now.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
-};
+import { getBusinessDate } from '@/shared/utils/businessDate';
 
 export const useClosingStatus = (storeId: string | null) => {
+  const operatingHours = useAuthStore((s) => s.operatingHours);
   const { data: history, isLoading, refetch } = useClosingHistory(storeId);
-  const today = getTodayDateString();
 
-  const todayClosing = history?.closings.find((c) => c.date.startsWith(today)) ?? null;
+  const businessDate = getBusinessDate(operatingHours);
+  const todayClosing = history?.closings.find((c) => c.date.startsWith(businessDate)) ?? null;
 
   return {
     isCompleted: !!todayClosing,
     todayClosing,
+    businessDate,
     isLoading,
     refetch,
   };

--- a/src/features/closing/store/closingStore.ts
+++ b/src/features/closing/store/closingStore.ts
@@ -7,10 +7,19 @@ interface TodayClosingRecord {
   totalRevenue: number;
 }
 
+interface BusinessSession {
+  isOpen: boolean;
+  businessDate: string | null; // YYYY-MM-DD
+}
+
 interface ClosingStoreState {
   todayClosing: TodayClosingRecord | null;
   setTodayClosing: (record: TodayClosingRecord) => void;
   clearTodayClosing: () => void;
+
+  businessSession: BusinessSession;
+  setBusinessSession: (session: BusinessSession) => void;
+  clearBusinessSession: () => void;
 }
 
 const useClosingStore = create<ClosingStoreState>()(
@@ -19,6 +28,10 @@ const useClosingStore = create<ClosingStoreState>()(
       todayClosing: null,
       setTodayClosing: (record) => set({ todayClosing: record }),
       clearTodayClosing: () => set({ todayClosing: null }),
+
+      businessSession: { isOpen: false, businessDate: null },
+      setBusinessSession: (session) => set({ businessSession: session }),
+      clearBusinessSession: () => set({ businessSession: { isOpen: false, businessDate: null } }),
     }),
     { name: 'baro-closing' },
   ),

--- a/src/features/closing/types/closing.types.ts
+++ b/src/features/closing/types/closing.types.ts
@@ -54,6 +54,21 @@ export interface ClosingStatus {
   closingId?: string;
 }
 
+export interface BusinessOpenRequest {
+  businessDate: string; // YYYY-MM-DD
+}
+
+export interface BusinessOpenResponse {
+  businessDate: string;
+  openedAt: string;
+}
+
+export interface BusinessOpenStatus {
+  isOpen: boolean;
+  businessDate: string | null;
+  openedAt: string | null;
+}
+
 export interface ClosingHistoryItem {
   id: string;
   date: string;

--- a/src/features/initial-setup/components/steps/StepOperatingHours.tsx
+++ b/src/features/initial-setup/components/steps/StepOperatingHours.tsx
@@ -72,12 +72,12 @@ const StepOperatingHours = ({ data, onChange }: StepOperatingHoursProps) => {
               {hour.isOpen ? (
                 <>
                   <TimeInput
-                    value={hour.openTime}
+                    value={hour.openTime ?? ''}
                     onChange={(v) => handleUpdate(index, { openTime: v })}
                   />
                   <span className="shrink-0 text-[10px] text-muted-foreground">~</span>
                   <TimeInput
-                    value={hour.closeTime}
+                    value={hour.closeTime ?? ''}
                     onChange={(v) => handleUpdate(index, { closeTime: v })}
                   />
                 </>

--- a/src/features/initial-setup/types/initialSetup.types.ts
+++ b/src/features/initial-setup/types/initialSetup.types.ts
@@ -28,8 +28,8 @@ export interface StoreBasicInfo {
 export interface OperatingHour {
   dayOfWeek: DayOfWeek;
   isOpen: boolean;
-  openTime: string;
-  closeTime: string;
+  openTime: string | null;
+  closeTime: string | null;
 }
 
 export interface MenuItem {

--- a/src/features/store-settings/api/storeSettings.api.ts
+++ b/src/features/store-settings/api/storeSettings.api.ts
@@ -17,6 +17,7 @@ export async function fetchStoreSettings(storeId: string): Promise<StoreSettings
     category: d.category,
     memo: d.memo ?? '',
     safetyStockPct: d.safetyStockPct ?? null,
+    operatingHours: d.operatingHours ?? [],
   };
 }
 

--- a/src/features/store-settings/types/store-settings.types.ts
+++ b/src/features/store-settings/types/store-settings.types.ts
@@ -1,3 +1,5 @@
+import type { OperatingHour } from '@/features/initial-setup/types/initialSetup.types';
+
 export interface StoreOwner {
   id: string;
   name: string;
@@ -14,6 +16,7 @@ export interface StoreSettings {
   category: string;
   memo: string;
   safetyStockPct?: number | null;
+  operatingHours: OperatingHour[];
 }
 
 export interface StoreStaff {

--- a/src/pages/ClosingPage.tsx
+++ b/src/pages/ClosingPage.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
 
-import { AlertTriangle, CalendarDays, CheckCircle, TrendingUp } from 'lucide-react';
-import { useSearchParams } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
+import { AlertTriangle, CalendarDays, CheckCircle, MoonStar, TrendingUp } from 'lucide-react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { toast } from 'sonner';
 
 import useAuthStore from '@/features/auth/store/authStore';
 import AfterClosingModal from '@/features/closing/components/AfterClosingModal';
@@ -11,8 +13,17 @@ import ClosingInventoryDeductionSection, {
 import ClosingSoldMenusSection from '@/features/closing/components/ClosingSoldMenusSection';
 import { useClosing } from '@/features/closing/hooks/useClosing';
 import { useClosingPreview } from '@/features/closing/hooks/useClosingPreview';
+import useClosingStore from '@/features/closing/store/closingStore';
 import { Button } from '@/shadcn/ui/button';
 import { Card, CardContent } from '@/shadcn/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/shadcn/ui/dialog';
 import { Skeleton } from '@/shadcn/ui/skeleton';
 
 const formatCurrency = (amount: number) => `${amount.toLocaleString('ko-KR')}원`;
@@ -28,7 +39,10 @@ const formatDate = (dateStr: string) => {
 };
 
 const ClosingPage = () => {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const storeId = useAuthStore((s) => s.storeId);
+  const clearBusinessSession = useClosingStore((s) => s.clearBusinessSession);
   const [searchParams] = useSearchParams();
   const dateParam = searchParams.get('date') ?? undefined;
   const isRetroactive = !!dateParam;
@@ -37,8 +51,10 @@ const ClosingPage = () => {
 
   const [deductionRows, setDeductionRows] = useState<DeductionRow[]>([]);
   const [afterModalOpen, setAfterModalOpen] = useState(false);
+  const [alreadyClosedModalOpen, setAlreadyClosedModalOpen] = useState(false);
   const [finalRevenue, setFinalRevenue] = useState(0);
   const [closingId, setClosingId] = useState('');
+  const [closingDate, setClosingDate] = useState('');
   const [isInitialized, setIsInitialized] = useState(false);
 
   const { mutate: submitClosing, isPending } = useClosing(storeId ?? '');
@@ -62,6 +78,11 @@ const ClosingPage = () => {
   const handleComplete = () => {
     if (!storeId || !preview) return;
 
+    if (preview.isClosed) {
+      setAlreadyClosedModalOpen(true);
+      return;
+    }
+
     submitClosing(
       {
         date: preview.date,
@@ -74,7 +95,13 @@ const ClosingPage = () => {
         onSuccess: (res) => {
           setFinalRevenue(res.totalRevenue);
           setClosingId(res.closingId);
+          setClosingDate(res.date);
+          clearBusinessSession();
+          void queryClient.invalidateQueries({ queryKey: ['closing', 'preview'] });
           setAfterModalOpen(true);
+        },
+        onError: () => {
+          toast.error('마감 처리에 실패했습니다. 잠시 후 다시 시도해 주세요.');
         },
       },
     );
@@ -166,14 +193,24 @@ const ClosingPage = () => {
 
         {/* 고정 하단 버튼 */}
         <div className="fixed bottom-0 left-0 right-0 z-10 bg-background border-t px-6 py-4">
-          <Button
-            onClick={handleComplete}
-            disabled={isPending}
-            className="w-full h-12 text-base font-semibold bg-baro-blue hover:bg-baro-blue/90 text-white flex items-center gap-2"
-          >
-            <CheckCircle className="w-5 h-5" />
-            {isPending ? '마감 처리 중...' : '마감 완료'}
-          </Button>
+          {preview.isClosed ? (
+            <Button
+              onClick={handleComplete}
+              className="w-full h-12 text-base font-semibold bg-slate-200 hover:bg-slate-300 text-slate-500 flex items-center gap-2"
+            >
+              <MoonStar className="w-5 h-5" />
+              마감 완료됨
+            </Button>
+          ) : (
+            <Button
+              onClick={handleComplete}
+              disabled={isPending}
+              className="w-full h-12 text-base font-semibold bg-baro-blue hover:bg-baro-blue/90 text-white flex items-center gap-2"
+            >
+              <CheckCircle className="w-5 h-5" />
+              {isPending ? '마감 처리 중...' : '마감 완료'}
+            </Button>
+          )}
         </div>
       </div>
 
@@ -181,10 +218,38 @@ const ClosingPage = () => {
         <AfterClosingModal
           open={afterModalOpen}
           totalRevenue={finalRevenue}
+          closingDate={closingDate}
           storeId={storeId}
           closingId={closingId}
         />
       )}
+
+      {/* 이미 마감된 날짜에 재시도할 때 안내 모달 */}
+      <Dialog open={alreadyClosedModalOpen} onOpenChange={setAlreadyClosedModalOpen}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <MoonStar className="w-4 h-4 text-slate-400" />
+              이미 마감이 완료된 날짜입니다
+            </DialogTitle>
+            <DialogDescription>
+              {preview && formatDate(preview.date)} 마감은 이미 처리되었습니다. 마감 취소가
+              필요하다면 시스템 시작 페이지에서 진행해 주세요.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="gap-2">
+            <Button variant="outline" onClick={() => setAlreadyClosedModalOpen(false)}>
+              닫기
+            </Button>
+            <Button
+              onClick={() => navigate('/system-start')}
+              className="bg-baro-blue hover:bg-baro-blue/90 text-white"
+            >
+              시스템 시작으로
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   );
 };

--- a/src/pages/SystemStartPage.tsx
+++ b/src/pages/SystemStartPage.tsx
@@ -1,11 +1,14 @@
 import { useState } from 'react';
 
 import {
+  AlertTriangle,
   Archive,
   ChevronRight,
   ClipboardList,
+  Clock,
   History,
   LogIn,
+  MoonStar,
   Settings,
   Trash2,
 } from 'lucide-react';
@@ -13,12 +16,29 @@ import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 
 import useAuthStore from '@/features/auth/store/authStore';
+import { openBusiness } from '@/features/closing/api/closing.api';
 import ClosingCancelModal from '@/features/closing/components/ClosingCancelModal';
-import { useClosingStatus } from '@/features/closing/hooks/useClosingStatus';
+import { useClosingHistory } from '@/features/closing/hooks/useClosingHistory';
+import useClosingStore from '@/features/closing/store/closingStore';
+import { Button } from '@/shadcn/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/shadcn/ui/dialog';
 import { Skeleton } from '@/shadcn/ui/skeleton';
 import baroLogo from '@/shared/assets/images/baro-logo.png';
+import {
+  getBusinessDate,
+  getTodayOpenTime,
+  isTodayBusinessDay,
+  todayKSTString,
+} from '@/shared/utils/businessDate';
 
-const formatToday = () =>
+const formatCalendarDate = () =>
   new Date().toLocaleDateString('ko-KR', {
     year: 'numeric',
     month: 'long',
@@ -26,36 +46,205 @@ const formatToday = () =>
     weekday: 'long',
   });
 
+const formatShortDate = (dateStr: string) => {
+  const [, month, day] = dateStr.split('-').map(Number);
+  const date = new Date(dateStr + 'T00:00:00');
+  const weekday = ['일', '월', '화', '수', '목', '금', '토'][date.getDay()];
+  return `${month}월 ${day}일 (${weekday})`;
+};
+
+type BusinessCase =
+  | 'normal' // A: 정상 영업 시작 가능
+  | 'before-open-closed' // B: 개점 전, 전날 마감 완료
+  | 'before-open-not-closed' // C: 개점 전, 전날 마감 미완료
+  | 'today-closed' // D: 오늘 마감 완료
+  | 'holiday-closed' // E: 휴무일 + 임시 영업 마감 완료
+  | 'holiday'; // F: 휴무일, 임시 영업 가능
+
 const SystemStartPage = () => {
   const navigate = useNavigate();
   const storeId = useAuthStore((s) => s.storeId);
-  const { isCompleted, isLoading, refetch } = useClosingStatus(storeId);
+  const operatingHours = useAuthStore((s) => s.operatingHours);
+  const setBusinessSession = useClosingStore((s) => s.setBusinessSession);
 
+  const businessDate = getBusinessDate(operatingHours);
+  const todayKST = todayKSTString();
+  const isBeforeOpen = businessDate !== todayKST;
+  const isHoliday = !isTodayBusinessDay(operatingHours);
+  const todayOpenTime = getTodayOpenTime(operatingHours);
+
+  const { data: history, isLoading } = useClosingHistory(storeId);
+  const businessDateClosed =
+    history?.closings.some((c) => c.date.startsWith(businessDate)) ?? false;
+
+  const [isStarting, setIsStarting] = useState(false);
   const [showCancelModal, setShowCancelModal] = useState(false);
-  const [isChecking, setIsChecking] = useState(false);
+  const [showHolidayModal, setShowHolidayModal] = useState(false);
 
-  const handleStartBusiness = async () => {
-    setIsChecking(true);
+  const getCase = (): BusinessCase => {
+    if (isHoliday) return businessDateClosed ? 'holiday-closed' : 'holiday';
+    if (isBeforeOpen) return businessDateClosed ? 'before-open-closed' : 'before-open-not-closed';
+    return businessDateClosed ? 'today-closed' : 'normal';
+  };
+
+  const currentCase = getCase();
+
+  const handleStartBusiness = async (targetDate = businessDate) => {
+    if (!storeId) return;
+    setIsStarting(true);
     try {
-      const result = await refetch();
-      const now = new Date();
-      const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
-      const todayClosing = result.data?.closings.find((c) => c.date.startsWith(today));
-
-      if (todayClosing) {
-        toast.error(
-          '이미 오늘 마감이 완료되었습니다. 마감을 취소하면 다시 영업을 시작할 수 있어요.',
-        );
-        return;
-      }
+      await openBusiness(storeId, { businessDate: targetDate });
+      setBusinessSession({ isOpen: true, businessDate: targetDate });
       navigate('/dashboard');
+    } catch {
+      toast.error('영업 시작에 실패했습니다. 잠시 후 다시 시도해 주세요.');
     } finally {
-      setIsChecking(false);
+      setIsStarting(false);
     }
   };
 
-  const handleViewHistory = () => {
-    toast.info('이전 마감 현황 기능은 준비 중이에요.');
+  const renderStatusBanner = () => {
+    switch (currentCase) {
+      case 'before-open-closed':
+        return (
+          <div className="flex items-center gap-3 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800">
+            <Clock className="h-4 w-4 shrink-0 text-blue-500" />
+            <span>
+              오늘 영업은 <span className="font-semibold">{todayOpenTime}</span> 이후에 시작할 수
+              있습니다.
+            </span>
+          </div>
+        );
+      case 'before-open-not-closed':
+        return (
+          <div className="flex items-start gap-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+            <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5 text-amber-500" />
+            <div>
+              <p className="font-semibold">전날 마감이 완료되지 않았습니다.</p>
+              <p className="mt-0.5 text-xs text-amber-700">
+                {formatShortDate(businessDate)} 소급 마감 후 영업을 시작할 수 있습니다.
+              </p>
+            </div>
+          </div>
+        );
+      case 'today-closed':
+        return (
+          <div className="flex items-center gap-3 rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700">
+            <MoonStar className="h-4 w-4 shrink-0 text-slate-400" />
+            <span>오늘 영업이 마감되었습니다.</span>
+          </div>
+        );
+      case 'holiday':
+        return (
+          <div className="flex items-center gap-3 rounded-lg border border-purple-200 bg-purple-50 px-4 py-3 text-sm text-purple-800">
+            <MoonStar className="h-4 w-4 shrink-0 text-purple-400" />
+            <span>오늘은 설정된 휴무일입니다.</span>
+          </div>
+        );
+      case 'holiday-closed':
+        return (
+          <div className="flex items-center gap-3 rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700">
+            <MoonStar className="h-4 w-4 shrink-0 text-slate-400" />
+            <span>오늘 임시 영업이 마감되었습니다.</span>
+          </div>
+        );
+      default:
+        return null;
+    }
+  };
+
+  const renderPrimaryButton = () => {
+    switch (currentCase) {
+      case 'normal':
+        return (
+          <button
+            onClick={() => handleStartBusiness()}
+            disabled={isStarting}
+            className="w-full bg-baro-blue hover:bg-baro-blue/90 disabled:opacity-60 text-white rounded-lg px-8 py-6 flex items-center justify-between transition-colors text-left group"
+          >
+            <div className="flex items-center gap-4">
+              <div className="w-12 h-12 rounded-lg bg-white/15 flex items-center justify-center shrink-0">
+                <LogIn className="w-6 h-6" />
+              </div>
+              <div>
+                <p className="font-bold text-xl">{isStarting ? '시작 중...' : '영업 시작하기'}</p>
+                <p className="text-sm text-white/70 mt-1">
+                  오늘 영업을 시작하고 대시보드로 이동합니다
+                </p>
+              </div>
+            </div>
+            <ChevronRight className="w-6 h-6 opacity-60 shrink-0 group-hover:translate-x-0.5 transition-transform" />
+          </button>
+        );
+
+      case 'before-open-closed':
+        return (
+          <div className="w-full bg-slate-100 text-slate-400 rounded-lg px-8 py-6 flex items-center gap-4 cursor-not-allowed">
+            <div className="w-12 h-12 rounded-lg bg-slate-200 flex items-center justify-center shrink-0">
+              <Clock className="w-6 h-6" />
+            </div>
+            <div>
+              <p className="font-bold text-xl">영업 시작 대기 중</p>
+              <p className="text-sm mt-1">{todayOpenTime} 이후에 영업을 시작할 수 있습니다</p>
+            </div>
+          </div>
+        );
+
+      case 'before-open-not-closed':
+        return (
+          <button
+            onClick={() => navigate(`/closing?date=${businessDate}`)}
+            className="w-full bg-amber-500 hover:bg-amber-600 text-white rounded-lg px-8 py-6 flex items-center justify-between transition-colors text-left group"
+          >
+            <div className="flex items-center gap-4">
+              <div className="w-12 h-12 rounded-lg bg-white/15 flex items-center justify-center shrink-0">
+                <AlertTriangle className="w-6 h-6" />
+              </div>
+              <div>
+                <p className="font-bold text-xl">전날 마감하러 가기</p>
+                <p className="text-sm text-white/80 mt-1">
+                  {formatShortDate(businessDate)} 소급 마감을 진행합니다
+                </p>
+              </div>
+            </div>
+            <ChevronRight className="w-6 h-6 opacity-60 shrink-0 group-hover:translate-x-0.5 transition-transform" />
+          </button>
+        );
+
+      case 'today-closed':
+      case 'holiday-closed':
+        return (
+          <div className="w-full bg-slate-100 text-slate-400 rounded-lg px-8 py-6 flex items-center gap-4 cursor-not-allowed">
+            <div className="w-12 h-12 rounded-lg bg-slate-200 flex items-center justify-center shrink-0">
+              <MoonStar className="w-6 h-6" />
+            </div>
+            <div>
+              <p className="font-bold text-xl">오늘 영업 종료</p>
+              <p className="text-sm mt-1">마감이 완료되었습니다. 내일 다시 만나요</p>
+            </div>
+          </div>
+        );
+
+      case 'holiday':
+        return (
+          <button
+            onClick={() => setShowHolidayModal(true)}
+            disabled={isStarting}
+            className="w-full bg-purple-600 hover:bg-purple-700 disabled:opacity-60 text-white rounded-lg px-8 py-6 flex items-center justify-between transition-colors text-left group"
+          >
+            <div className="flex items-center gap-4">
+              <div className="w-12 h-12 rounded-lg bg-white/15 flex items-center justify-center shrink-0">
+                <LogIn className="w-6 h-6" />
+              </div>
+              <div>
+                <p className="font-bold text-xl">임시 영업 시작하기</p>
+                <p className="text-sm text-white/70 mt-1">휴무일에 임시로 영업을 시작합니다</p>
+              </div>
+            </div>
+            <ChevronRight className="w-6 h-6 opacity-60 shrink-0 group-hover:translate-x-0.5 transition-transform" />
+          </button>
+        );
+    }
   };
 
   return (
@@ -71,10 +260,16 @@ const SystemStartPage = () => {
             </div>
           </div>
           <div className="text-right">
-            <p className="text-sm text-muted-foreground">{formatToday()}</p>
-            {!isLoading && isCompleted && (
+            <p className="text-sm text-muted-foreground">{formatCalendarDate()}</p>
+            {/* 영업 날짜가 캘린더 날짜와 다를 때 (개점 전 구간) 별도 표시 */}
+            {!isLoading && isBeforeOpen && !isHoliday && (
+              <p className="text-xs text-muted-foreground mt-0.5">
+                영업 기준일: {formatShortDate(businessDate)}
+              </p>
+            )}
+            {!isLoading && businessDateClosed && (
               <span className="inline-block mt-1 text-xs font-medium text-amber-700 bg-amber-100 border border-amber-200 px-2 py-0.5 rounded-full">
-                마감 완료
+                {formatShortDate(businessDate)} 마감 완료
               </span>
             )}
           </div>
@@ -83,6 +278,7 @@ const SystemStartPage = () => {
         {/* 카드들 */}
         {isLoading ? (
           <div className="space-y-4">
+            <Skeleton className="h-10 w-full rounded-lg" />
             <Skeleton className="h-28 w-full rounded-lg" />
             <div className="grid grid-cols-3 gap-4">
               <Skeleton className="h-36 rounded-lg" />
@@ -96,25 +292,11 @@ const SystemStartPage = () => {
           </div>
         ) : (
           <div className="space-y-4">
-            {/* 영업 시작하기 */}
-            <button
-              onClick={handleStartBusiness}
-              disabled={isChecking}
-              className="w-full bg-baro-blue hover:bg-baro-blue/90 disabled:opacity-60 text-white rounded-lg px-8 py-6 flex items-center justify-between transition-colors text-left group"
-            >
-              <div className="flex items-center gap-4">
-                <div className="w-12 h-12 rounded-lg bg-white/15 flex items-center justify-center shrink-0">
-                  <LogIn className="w-6 h-6" />
-                </div>
-                <div>
-                  <p className="font-bold text-xl">{isChecking ? '확인 중...' : '영업 시작하기'}</p>
-                  <p className="text-sm text-white/70 mt-1">
-                    오늘 영업을 시작하고 대시보드로 이동합니다
-                  </p>
-                </div>
-              </div>
-              <ChevronRight className="w-6 h-6 opacity-60 shrink-0 group-hover:translate-x-0.5 transition-transform" />
-            </button>
+            {/* 상태 배너 */}
+            {renderStatusBanner()}
+
+            {/* 메인 CTA */}
+            {renderPrimaryButton()}
 
             {/* 3열: 재고 현황, 발주 가이드, 마감 현황 */}
             <div className="grid grid-cols-3 gap-4">
@@ -145,7 +327,7 @@ const SystemStartPage = () => {
               </button>
 
               <button
-                onClick={handleViewHistory}
+                onClick={() => toast.info('이전 마감 현황 기능은 준비 중이에요.')}
                 className="bg-white dark:bg-card border border-border hover:border-baro-blue/40 hover:bg-baro-blue/5 rounded-lg p-5 flex flex-col gap-4 transition-colors text-left"
               >
                 <div className="w-10 h-10 rounded-lg bg-baro-blue/10 flex items-center justify-center">
@@ -190,6 +372,7 @@ const SystemStartPage = () => {
         )}
       </div>
 
+      {/* 마감 취소 모달 */}
       {storeId && (
         <ClosingCancelModal
           open={showCancelModal}
@@ -197,6 +380,37 @@ const SystemStartPage = () => {
           storeId={storeId}
         />
       )}
+
+      {/* 휴무일 임시 영업 확인 모달 */}
+      <Dialog open={showHolidayModal} onOpenChange={setShowHolidayModal}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>임시 영업 시작</DialogTitle>
+            <DialogDescription>
+              오늘은 휴무일로 설정되어 있습니다. 그래도 영업을 시작하시겠습니까?
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="gap-2">
+            <Button
+              variant="outline"
+              onClick={() => setShowHolidayModal(false)}
+              disabled={isStarting}
+            >
+              취소
+            </Button>
+            <Button
+              onClick={() => {
+                setShowHolidayModal(false);
+                handleStartBusiness(todayKST);
+              }}
+              disabled={isStarting}
+              className="bg-purple-600 hover:bg-purple-700 text-white"
+            >
+              {isStarting ? '시작 중...' : '임시 영업 시작'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 };

--- a/src/shared/utils/businessDate.ts
+++ b/src/shared/utils/businessDate.ts
@@ -1,0 +1,83 @@
+import type { DayOfWeek, OperatingHour } from '@/features/initial-setup/types/initialSetup.types';
+
+const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+const toKSTDate = (): Date => new Date(Date.now() + KST_OFFSET_MS);
+
+const formatKSTDate = (date: Date): string => date.toISOString().slice(0, 10);
+
+const KST_DAYS: DayOfWeek[] = [
+  'sunday',
+  'monday',
+  'tuesday',
+  'wednesday',
+  'thursday',
+  'friday',
+  'saturday',
+];
+
+const getDayOfWeek = (date: Date): DayOfWeek => KST_DAYS[date.getUTCDay()];
+
+const addDays = (date: Date, days: number): Date => {
+  const result = new Date(date);
+  result.setUTCDate(result.getUTCDate() + days);
+  return result;
+};
+
+/**
+ * 오늘 요일의 openTime을 기준으로 영업 날짜(businessDate)를 계산한다.
+ * - openTime 이전 → 어제 날짜 반환 (아직 전날 영업 구간)
+ * - openTime 이후 또는 openTime 없음(휴무) → 오늘 날짜 반환
+ * - 어제가 휴무일이면서 businessDate가 어제로 계산된 경우 → 오늘 날짜로 보정
+ */
+export const getBusinessDate = (operatingHours: OperatingHour[]): string => {
+  const kstNow = toKSTDate();
+  const todayDow = getDayOfWeek(kstNow);
+  const todayHours = operatingHours.find((h) => h.dayOfWeek === todayDow);
+
+  const openTime = todayHours?.isOpen ? todayHours.openTime : null;
+
+  if (!openTime) {
+    // 오늘 휴무 → 캘린더 오늘 날짜 그대로
+    return formatKSTDate(kstNow);
+  }
+
+  const [openHour, openMinute] = openTime.split(':').map(Number);
+  const isBeforeOpen =
+    kstNow.getUTCHours() < openHour ||
+    (kstNow.getUTCHours() === openHour && kstNow.getUTCMinutes() < openMinute);
+
+  if (!isBeforeOpen) {
+    return formatKSTDate(kstNow);
+  }
+
+  // 개점 시간 전 → 어제가 영업일인지 확인
+  const yesterday = addDays(kstNow, -1);
+  const yesterdayDow = getDayOfWeek(yesterday);
+  const yesterdayHours = operatingHours.find((h) => h.dayOfWeek === yesterdayDow);
+
+  // 어제도 휴무 → 어제 마감 없음, 오늘 날짜 그대로
+  if (!yesterdayHours?.isOpen) {
+    return formatKSTDate(kstNow);
+  }
+
+  return formatKSTDate(yesterday);
+};
+
+/** 오늘 요일이 영업일인지 여부 */
+export const isTodayBusinessDay = (operatingHours: OperatingHour[]): boolean => {
+  const kstNow = toKSTDate();
+  const todayDow = getDayOfWeek(kstNow);
+  return operatingHours.find((h) => h.dayOfWeek === todayDow)?.isOpen ?? false;
+};
+
+/** 오늘 요일의 개점 시간 (영업일이 아니면 null) */
+export const getTodayOpenTime = (operatingHours: OperatingHour[]): string | null => {
+  const kstNow = toKSTDate();
+  const todayDow = getDayOfWeek(kstNow);
+  const todayHours = operatingHours.find((h) => h.dayOfWeek === todayDow);
+  return todayHours?.isOpen ? todayHours.openTime : null;
+};
+
+/** KST 기준 오늘 날짜 문자열 */
+export const todayKSTString = (): string => formatKSTDate(toKSTDate());

--- a/src/widgets/AppHeader.tsx
+++ b/src/widgets/AppHeader.tsx
@@ -2,6 +2,7 @@ import { ChevronDown } from 'lucide-react';
 
 import useAuthStore from '@/features/auth/store/authStore';
 import { useClosingStatus } from '@/features/closing/hooks/useClosingStatus';
+import useClosingStore from '@/features/closing/store/closingStore';
 import { Button } from '@/shadcn/ui/button';
 import { Skeleton } from '@/shadcn/ui/skeleton';
 
@@ -15,6 +16,10 @@ interface AppHeaderProps {
 const AppHeader = ({ userName, userRole, isLoading = false, onClosingClick }: AppHeaderProps) => {
   const storeId = useAuthStore((s) => s.storeId);
   const { isCompleted } = useClosingStatus(storeId);
+  const { isOpen: isBusinessOpen } = useClosingStore((s) => s.businessSession);
+
+  // 영업 중이 아니거나 이미 마감한 경우 마감 버튼 비활성화
+  const isClosingDisabled = !isBusinessOpen || isCompleted;
 
   return (
     <header className="bg-background h-13 border-b flex items-center justify-end px-6 gap-4 sticky top-0 z-10">
@@ -22,8 +27,14 @@ const AppHeader = ({ userName, userRole, isLoading = false, onClosingClick }: Ap
       <Button
         size="sm"
         onClick={onClosingClick}
-        disabled={isCompleted}
-        title={isCompleted ? '오늘 마감이 완료되었습니다' : undefined}
+        disabled={isClosingDisabled}
+        title={
+          !isBusinessOpen
+            ? '영업을 시작하면 마감할 수 있습니다'
+            : isCompleted
+              ? '오늘 마감이 완료되었습니다'
+              : undefined
+        }
         className="bg-baro-blue text-xs rounded-full hover:bg-baro-blue/80 text-white disabled:opacity-40 disabled:cursor-not-allowed"
       >
         {isCompleted ? '마감 완료' : '마감하기'}

--- a/src/widgets/AppSidebar.tsx
+++ b/src/widgets/AppSidebar.tsx
@@ -1,9 +1,10 @@
-import { LayoutDashboard, Package, Truck, Store, Settings, Home } from 'lucide-react';
+import { LayoutDashboard, MonitorPlay, Package, Truck, Store, Settings, Home } from 'lucide-react';
 import { NavLink, useLocation } from 'react-router-dom';
 
 import { routePaths } from '@/app/routes/routePaths';
 import useAuthStore from '@/features/auth/store/authStore';
 import { useClosingStatus } from '@/features/closing/hooks/useClosingStatus';
+import useClosingStore from '@/features/closing/store/closingStore';
 import {
   Sidebar,
   SidebarContent,
@@ -22,6 +23,7 @@ import BaroLogo from '@/shared/assets/images/baro-logo.png';
 
 const BOTTOM_NAV_ITEMS = [
   { label: '회원 설정', icon: Settings, to: routePaths.settings },
+  { label: '시스템 시작', icon: MonitorPlay, to: routePaths.systemStart },
   // { label: '지원', icon: HelpCircle, to: routePaths.support },
   { label: '랜딩 페이지', icon: Home, to: routePaths.landing },
 ];
@@ -48,6 +50,10 @@ const AppSidebar = ({
   const location = useLocation();
   const storeId = useAuthStore((s) => s.storeId);
   const { isCompleted } = useClosingStatus(storeId);
+  const { isOpen: isBusinessOpen } = useClosingStore((s) => s.businessSession);
+
+  // 영업 중이 아니거나 오늘 마감이 완료된 경우 대시보드 비활성화
+  const isDashboardDisabled = !isBusinessOpen || isCompleted;
 
   return (
     <Sidebar collapsible="icon">
@@ -71,10 +77,16 @@ const AppSidebar = ({
               <SidebarMenuItem>
                 <SidebarMenuButton
                   isActive={location.pathname === routePaths.dashboard}
-                  tooltip={isCompleted ? '오늘 마감이 완료되었습니다' : '대시보드'}
-                  disabled={isCompleted}
-                  render={isCompleted ? undefined : <NavLink to={routePaths.dashboard} />}
-                  className={isCompleted ? 'opacity-40 cursor-not-allowed' : undefined}
+                  tooltip={
+                    !isBusinessOpen
+                      ? '영업을 시작하면 접근할 수 있습니다'
+                      : isCompleted
+                        ? '오늘 마감이 완료되었습니다'
+                        : '대시보드'
+                  }
+                  disabled={isDashboardDisabled}
+                  render={isDashboardDisabled ? undefined : <NavLink to={routePaths.dashboard} />}
+                  className={isDashboardDisabled ? 'opacity-40 cursor-not-allowed' : undefined}
                 >
                   <LayoutDashboard />
                   <span>대시보드</span>


### PR DESCRIPTION
## 📌 요약

- 영업 세션(`businessSession`) 개념 도입 — 개점 API 연동 및 Zustand persist 상태 관리
- `businessDate` 유틸 구현 — 가게 개점 시간 기준으로 영업 날짜를 계산해 자정 이후 날짜 혼동 해소
- SystemStartPage 6가지 케이스 분기 UI 및 휴무일 임시 영업 확인 모달 구현
- 마감 UX 개선 — 이미 마감된 날짜 재클릭 시 안내 모달, 실제 날짜 표시

<br/>

## 🏷️ 관련 이슈

- Closes #109

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- `getBusinessDate(operatingHours)`: 가게 개점 시간 기준 영업 날짜 계산 유틸 추가 (`src/shared/utils/businessDate.ts`)
- `closingStore`에 `businessSession: { isOpen, businessDate }` 추가 (Zustand persist)
- `AppInitializer`에서 `GET /stores/:storeId/open/status` 호출해 다중 기기·새로고침 대응
- SystemStartPage 6가지 BusinessCase 분기: `normal` / `before-open-closed` / `before-open-not-closed` / `today-closed` / `holiday-closed` / `holiday`
- AppLayout `/dashboard` 경로에 한해 `isOpen` 미충족 시 `/system-start` 리다이렉트

<br/>

### 📂 세부 변경사항

- `OperatingHour.openTime/closeTime`: `string → string | null` (휴무일 null 허용)
- `StoreSettings`: `operatingHours: OperatingHour[]` 필드 추가
- `authStore`: `operatingHours` 필드 및 `setOperatingHours` 액션 추가
- `closing.api.ts`: `openBusiness`, `fetchBusinessOpenStatus` API 함수 추가
- `useClosingStatus`: `businessDate` 반환 및 `getBusinessDate()` 기반 마감 여부 판단으로 개선
- `AppSidebar`: 대시보드 비활성화 처리 및 BOTTOM_NAV에 "시스템 시작" 항목 추가
- `AppHeader`: 영업 미시작·마감 완료 시 마감하기 버튼 비활성화
- `ClosingPage`: 이미 마감된 날짜 재클릭 시 안내 모달, 마감 성공 후 `clearBusinessSession()` 호출
- `AfterClosingModal`: `closingDate` prop 추가, "오늘" 대신 실제 날짜(예: 6월 19일) 표시

<br/>

## 📸 Screenshots

| Before | After |
| ------ | ----- |
| 자정 넘으면 날짜 혼동, 영업 상태 미관리 | businessDate 기준 6케이스 분기, 날짜 명확 표시 |

<br/>

## 🧪 테스트 방법

1. 가게 개점 시간 설정 확인 (가게 설정 > 영업 시간)
2. 자정~개점 시간 사이 접근 시 "영업 기준일: M월 D일" 표시 확인
3. 휴무일에 시스템 시작 페이지 진입 → 임시 영업 확인 모달 동작 확인
4. 마감 완료 후 마감하기 페이지 재진입 → "마감 완료됨" 버튼 및 안내 모달 확인
5. 마감 완료 모달에 실제 날짜 표시 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [x] Backend
- [x] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [ ] 빌드 정상 동작 확인
- [ ] 콘솔 에러 없음
- [ ] 불필요한 코드 제거
- [ ] 타입 에러 없음
- [ ] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- `GET /open/status`는 DB에서 매번 계산 (`isOpen = open 기록 있음 AND closing 기록 없음`) — 별도 상태 동기화 불필요
- AppLayout 라우트 가드는 `/dashboard`에만 적용; 재고·설정·발주 가이드는 세션 없이 접근 가능
- 휴무일 임시 영업은 사장님의 명시적 확인 후 개점 처리