### PR TITLE
🐛 (#115) fix: 영업시간 수정 전용 API 엔드포인트로 분리

### DIFF
--- a/src/features/store-settings/api/storeSettings.api.ts
+++ b/src/features/store-settings/api/storeSettings.api.ts
@@ -1,3 +1,4 @@
+import type { OperatingHour } from '@/features/initial-setup/types/initialSetup.types';
 import type { StoreSettings } from '@/features/store-settings/types/store-settings.types';
 import axiosInstance from '@/shared/api/axiosInstance';
 
@@ -23,7 +24,17 @@ export async function fetchStoreSettings(storeId: string): Promise<StoreSettings
 
 export async function updateStoreSettings(
   storeId: string,
-  data: Partial<StoreSettings>,
+  data: Partial<Omit<StoreSettings, 'operatingHours'>>,
 ): Promise<void> {
   await axiosInstance.patch(`/stores/${storeId}`, data);
+}
+
+export async function updateOperatingHours(
+  storeId: string,
+  operatingHours: OperatingHour[],
+): Promise<OperatingHour[]> {
+  const response = await axiosInstance.patch(`/stores/${storeId}/operating-hours`, {
+    operatingHours,
+  });
+  return response.data.data.operatingHours;
 }

--- a/src/features/store-settings/components/sections/OperatingHoursSection.tsx
+++ b/src/features/store-settings/components/sections/OperatingHoursSection.tsx
@@ -7,7 +7,7 @@ import { DAY_OF_WEEK_CONFIG } from '@/features/initial-setup/constants/initialSe
 import type { OperatingHour } from '@/features/initial-setup/types/initialSetup.types';
 import {
   useStoreSettings,
-  useUpdateStoreSettings,
+  useUpdateOperatingHours,
 } from '@/features/store-settings/hooks/useStoreSettings';
 import { Button } from '@/shadcn/ui/button';
 import { Skeleton } from '@/shadcn/ui/skeleton';
@@ -28,7 +28,7 @@ const HoursRow = ({ day, hour }: { day: string; hour: OperatingHour | undefined 
 
 const OperatingHoursSection = () => {
   const { data, isLoading } = useStoreSettings();
-  const { mutate: updateStore, isPending } = useUpdateStoreSettings();
+  const { mutate: updateStore, isPending } = useUpdateOperatingHours();
   const [isEditing, setIsEditing] = useState(false);
   const [form, setForm] = useState<OperatingHour[]>([]);
 
@@ -49,7 +49,7 @@ const OperatingHoursSection = () => {
   };
 
   const handleSave = () => {
-    updateStore({ operatingHours: form }, { onSuccess: () => setIsEditing(false) });
+    updateStore(form, { onSuccess: () => setIsEditing(false) });
   };
 
   const handleCancel = () => {

--- a/src/features/store-settings/hooks/useStoreSettings.ts
+++ b/src/features/store-settings/hooks/useStoreSettings.ts
@@ -1,9 +1,11 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 
 import useAuthStore from '@/features/auth/store/authStore';
+import type { OperatingHour } from '@/features/initial-setup/types/initialSetup.types';
 import {
   fetchStoreSettings,
   updateStoreSettings,
+  updateOperatingHours,
 } from '@/features/store-settings/api/storeSettings.api';
 import type { StoreSettings } from '@/features/store-settings/types/store-settings.types';
 
@@ -22,13 +24,26 @@ export function useUpdateStoreSettings() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (data: Partial<StoreSettings>) => updateStoreSettings(storeId!, data),
+    mutationFn: (data: Partial<Omit<StoreSettings, 'operatingHours'>>) =>
+      updateStoreSettings(storeId!, data),
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: ['storeSettings', storeId] });
       // safetyStockPct 변경 시 백엔드가 전체 식자재 안전재고를 일괄 업데이트하므로 함께 무효화
       if (variables.safetyStockPct !== undefined) {
         queryClient.invalidateQueries({ queryKey: ['ingredients', storeId] });
       }
+    },
+  });
+}
+
+export function useUpdateOperatingHours() {
+  const storeId = useAuthStore((s) => s.storeId);
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (operatingHours: OperatingHour[]) => updateOperatingHours(storeId!, operatingHours),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['storeSettings', storeId] });
     },
   });
 }


### PR DESCRIPTION
## 📌 요약

- 영업시간 수정 시 잘못된 엔드포인트(`PATCH /stores/:storeId`)로 요청하던 버그 수정
- 영업시간 전용 엔드포인트(`PATCH /stores/:storeId/operating-hours`)로 분리

<br/>

## 🏷️ 관련 이슈

- Closes #115

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- 영업시간 전용 API 함수 `updateOperatingHours` 추가
- `useUpdateOperatingHours` 훅 추가 및 `OperatingHoursSection`에 적용

<br/>

### 📂 세부 변경사항

- `storeSettings.api.ts`: `updateOperatingHours()` 함수 추가 → `PATCH /stores/:storeId/operating-hours`
- `storeSettings.api.ts`: `updateStoreSettings()` 타입에서 `operatingHours` 제거(`Omit`)
- `useStoreSettings.ts`: `useUpdateOperatingHours()` 훅 추가
- `OperatingHoursSection.tsx`: `useUpdateStoreSettings` → `useUpdateOperatingHours`로 교체

<br/>

## 📸 Screenshots

| Before | After |
| ------ | ----- |
| 영업시간 저장 시 `PATCH /stores/:storeId`로 요청 (무응답) | 영업시간 저장 시 `PATCH /stores/:storeId/operating-hours`로 요청 |

<br/>

## 🧪 테스트 방법

1. `/settings` 페이지 접근
2. 영업 시간 섹션 "수정" 클릭
3. 영업시간 변경 후 "저장" 클릭
4. 변경사항이 정상 반영되는지 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [x] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- `useUpdateStoreSettings`에서 `operatingHours`를 타입 수준에서 제거해 두어 영업시간이 일반 가게설정 엔드포인트로 실수로 전송되는 것을 방지