### PR TITLE
🐛 (#117) fix: 시스템 시작 페이지 개점 상태 미반영 버그 수정

### DIFF
--- a/src/pages/SystemStartPage.tsx
+++ b/src/pages/SystemStartPage.tsx
@@ -10,6 +10,7 @@ import {
   LogIn,
   MoonStar,
   Settings,
+  Store,
   Trash2,
 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
@@ -54,18 +55,20 @@ const formatShortDate = (dateStr: string) => {
 };
 
 type BusinessCase =
-  | 'normal' // A: 정상 영업 시작 가능
-  | 'before-open-closed' // B: 개점 전, 전날 마감 완료
-  | 'before-open-not-closed' // C: 개점 전, 전날 마감 미완료
-  | 'today-closed' // D: 오늘 마감 완료
-  | 'holiday-closed' // E: 휴무일 + 임시 영업 마감 완료
-  | 'holiday'; // F: 휴무일, 임시 영업 가능
+  | 'already-open' // A: 이미 개점한 상태 (영업 중)
+  | 'normal' // B: 정상 영업 시작 가능
+  | 'before-open-closed' // C: 개점 전, 전날 마감 완료
+  | 'before-open-not-closed' // D: 개점 전, 전날 마감 미완료
+  | 'today-closed' // E: 오늘 마감 완료
+  | 'holiday-closed' // F: 휴무일 + 임시 영업 마감 완료
+  | 'holiday'; // G: 휴무일, 임시 영업 가능
 
 const SystemStartPage = () => {
   const navigate = useNavigate();
   const storeId = useAuthStore((s) => s.storeId);
   const operatingHours = useAuthStore((s) => s.operatingHours);
   const setBusinessSession = useClosingStore((s) => s.setBusinessSession);
+  const businessSession = useClosingStore((s) => s.businessSession);
 
   const businessDate = getBusinessDate(operatingHours);
   const todayKST = todayKSTString();
@@ -82,6 +85,8 @@ const SystemStartPage = () => {
   const [showHolidayModal, setShowHolidayModal] = useState(false);
 
   const getCase = (): BusinessCase => {
+    if (businessSession.isOpen && businessSession.businessDate === businessDate)
+      return 'already-open';
     if (isHoliday) return businessDateClosed ? 'holiday-closed' : 'holiday';
     if (isBeforeOpen) return businessDateClosed ? 'before-open-closed' : 'before-open-not-closed';
     return businessDateClosed ? 'today-closed' : 'normal';
@@ -105,6 +110,13 @@ const SystemStartPage = () => {
 
   const renderStatusBanner = () => {
     switch (currentCase) {
+      case 'already-open':
+        return (
+          <div className="flex items-center gap-3 rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-800">
+            <span className="inline-flex h-2 w-2 shrink-0 rounded-full bg-green-500 animate-pulse" />
+            <span>현재 영업이 진행 중입니다.</span>
+          </div>
+        );
       case 'before-open-closed':
         return (
           <div className="flex items-center gap-3 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800">
@@ -155,6 +167,27 @@ const SystemStartPage = () => {
 
   const renderPrimaryButton = () => {
     switch (currentCase) {
+      case 'already-open':
+        return (
+          <button
+            onClick={() => navigate('/dashboard')}
+            className="w-full bg-baro-blue hover:bg-baro-blue/90 text-white rounded-lg px-8 py-6 flex items-center justify-between transition-colors text-left group"
+          >
+            <div className="flex items-center gap-4">
+              <div className="w-12 h-12 rounded-lg bg-white/15 flex items-center justify-center shrink-0">
+                <Store className="w-6 h-6" />
+              </div>
+              <div>
+                <p className="font-bold text-xl">영업 중 · 대시보드로 이동</p>
+                <p className="text-sm text-white/70 mt-1">
+                  {formatShortDate(businessDate)} 영업이 진행 중입니다
+                </p>
+              </div>
+            </div>
+            <ChevronRight className="w-6 h-6 opacity-60 shrink-0 group-hover:translate-x-0.5 transition-transform" />
+          </button>
+        );
+
       case 'normal':
         return (
           <button


### PR DESCRIPTION
## 📌 요약

- 이미 개점한 상태로 시스템 시작 페이지 재진입 시 '영업 시작하기' 버튼이 뜨던 버그 수정
- 개점 상태에서 전날 마감 이력 삭제 시에도 개점 상태를 정확히 반영

<br/>

## 🏷️ 관련 이슈

- Closes #117

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- `getCase()`에 `already-open` 케이스 추가 — `businessSession.isOpen && businessSession.businessDate === businessDate` 일 때 최우선 반환

<br/>

### 📂 세부 변경사항

- `src/pages/SystemStartPage.tsx`: `already-open` 케이스 배너(초록 점 + "현재 영업이 진행 중입니다") 및 버튼("영업 중 · 대시보드로 이동") 추가

<br/>

## 📸 Screenshots

| Before | After |
| ------ | ----- |
| 개점 후 재진입 시 "영업 시작하기" 버튼 표시 | <img width="1917" height="961" alt="image" src="https://github.com/user-attachments/assets/240952c7-9b7f-41fe-9a30-00c1a72e78fe" /> |

<br/>

## 🧪 테스트 방법

1. 시스템 시작 페이지에서 "영업 시작하기" 클릭 → 대시보드 이동
2. 다시 `/` 로 이동 → "영업 중 · 대시보드로 이동" 버튼과 초록 배너 확인
3. 마감 취소로 전날 마감 이력 삭제 후 시스템 시작 페이지 진입 → 여전히 "영업 중" 상태 표시 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [ ] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- `businessSession`은 Zustand `persist`로 localStorage에 저장되므로 페이지 재진입/새로고침 후에도 상태 유지됨
- `businessSession.businessDate !== businessDate`인 경우(날짜가 바뀐 stale 세션)는 `already-open`으로 분기되지 않으므로 기존 케이스 로직 그대로 동작