### PR TITLE
💄 (#119~#124) ui/fix: 자잘한 UI 개선 및 버그 수정

### DIFF
--- a/src/app/layouts/AppLayout.tsx
+++ b/src/app/layouts/AppLayout.tsx
@@ -4,7 +4,9 @@ import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 
 import { routePaths } from '@/app/routes/routePaths';
 import { useUserInfo } from '@/features/account-settings/hooks/useUserInfo';
+import useAuthStore from '@/features/auth/store/authStore';
 import useClosingStore from '@/features/closing/store/closingStore';
+import { useDashboardStats } from '@/features/dashboard/hooks/useDashboardStats';
 import { useStoreSettings } from '@/features/store-settings/hooks/useStoreSettings';
 import { SidebarInset, SidebarProvider } from '@/shadcn/ui/sidebar';
 import AppHeader from '@/widgets/AppHeader';
@@ -29,8 +31,10 @@ const AppLayout = () => {
     }
   }, [isOpen, pathname, navigate]);
 
+  const storeId = useAuthStore((s) => s.storeId);
   const { data: storeData, isLoading: isStoreLoading } = useStoreSettings();
   const { data: userData, isLoading: isUserLoading } = useUserInfo();
+  const { data: dashboardStats } = useDashboardStats(isOpen ? storeId : null);
 
   useEffect(() => {
     scrollRef.current?.scrollTo(0, 0);
@@ -50,9 +54,12 @@ const AppLayout = () => {
           userRole={ROLE_LABEL[storeData?.myRole ?? ''] ?? ''}
           isLoading={isUserLoading || isStoreLoading}
           onClosingClick={() => navigate('/closing')}
+          missedClosing={dashboardStats?.missedClosing ?? false}
         />
         <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto flex flex-col">
-          <Outlet />
+          <div key={pathname} className="animate-page-fade-in flex-1 flex flex-col min-h-0">
+            <Outlet />
+          </div>
         </div>
       </SidebarInset>
     </SidebarProvider>

--- a/src/app/routes/Router.tsx
+++ b/src/app/routes/Router.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, useLocation } from 'react-router-dom';
 
 import AppLayout from '@/app/layouts/AppLayout';
 import { routePaths } from '@/app/routes/routePaths';
@@ -24,21 +24,60 @@ import StoreSelectionPage from '@/pages/StoreSelectionPage';
 import StoreSettingsPage from '@/pages/StoreSettingsPage';
 import SystemStartPage from '@/pages/SystemStartPage';
 
+const StandalonePageWrapper = ({ element }: { element: React.ReactElement }) => {
+  const { key } = useLocation();
+  return (
+    <div key={key} className="animate-page-fade-in">
+      {element}
+    </div>
+  );
+};
+
 export default function Router() {
   return (
     <Routes>
       {/* 레이아웃 없는 페이지 */}
-      <Route path={routePaths.landing} element={<LandingPage />} />
-      <Route path={routePaths.authCallback} element={<AuthCallbackPage />} />
-      <Route path={routePaths.login} element={<LoginPage />} />
-      <Route path={routePaths.storeSelection} element={<StoreSelectionPage />} />
-      <Route path={routePaths.initialSetup} element={<InitialSetupPage />} />
-      <Route path={routePaths.systemStart} element={<SystemStartPage />} />
-      <Route path={routePaths.dayClosed} element={<DayClosedPage />} />
-      <Route path={routePaths.closingOrderGuideDetail} element={<ClosingOrderGuidePage />} />
-      <Route path={routePaths.ocrInbound} element={<OcrInboundPage />} />
-      <Route path={routePaths.customerOrder} element={<CustomerOrderPage />} />
-      <Route path={routePaths.notFound} element={<NotFoundPage />} />
+      <Route
+        path={routePaths.landing}
+        element={<StandalonePageWrapper element={<LandingPage />} />}
+      />
+      <Route
+        path={routePaths.authCallback}
+        element={<StandalonePageWrapper element={<AuthCallbackPage />} />}
+      />
+      <Route path={routePaths.login} element={<StandalonePageWrapper element={<LoginPage />} />} />
+      <Route
+        path={routePaths.storeSelection}
+        element={<StandalonePageWrapper element={<StoreSelectionPage />} />}
+      />
+      <Route
+        path={routePaths.initialSetup}
+        element={<StandalonePageWrapper element={<InitialSetupPage />} />}
+      />
+      <Route
+        path={routePaths.systemStart}
+        element={<StandalonePageWrapper element={<SystemStartPage />} />}
+      />
+      <Route
+        path={routePaths.dayClosed}
+        element={<StandalonePageWrapper element={<DayClosedPage />} />}
+      />
+      <Route
+        path={routePaths.closingOrderGuideDetail}
+        element={<StandalonePageWrapper element={<ClosingOrderGuidePage />} />}
+      />
+      <Route
+        path={routePaths.ocrInbound}
+        element={<StandalonePageWrapper element={<OcrInboundPage />} />}
+      />
+      <Route
+        path={routePaths.customerOrder}
+        element={<StandalonePageWrapper element={<CustomerOrderPage />} />}
+      />
+      <Route
+        path={routePaths.notFound}
+        element={<StandalonePageWrapper element={<NotFoundPage />} />}
+      />
 
       {/* 사이드바 + 상단바 공통 레이아웃 */}
       <Route element={<AppLayout />}>

--- a/src/features/closing/components/AfterClosingModal.tsx
+++ b/src/features/closing/components/AfterClosingModal.tsx
@@ -23,6 +23,7 @@ interface AfterClosingModalProps {
   closingDate: string; // YYYY-MM-DD
   storeId: string;
   closingId: string;
+  isRetroactive?: boolean;
 }
 
 type Step = 'generating' | 'no-guide' | 'choose' | 'summary' | 'confirm-exit';
@@ -88,6 +89,7 @@ const AfterClosingModal = ({
   closingDate,
   storeId,
   closingId,
+  isRetroactive = false,
 }: AfterClosingModalProps) => {
   const navigate = useNavigate();
   const [step, setStep] = useState<Step>('generating');
@@ -109,7 +111,9 @@ const AfterClosingModal = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, step]);
 
-  const handleExit = () => navigate('/day-closed', { replace: true });
+  // 소급 마감은 오늘 영업이 계속되므로 대시보드로 복귀, 일반 마감은 영업 종료 페이지로
+  const handleExit = () =>
+    navigate(isRetroactive ? '/dashboard' : '/day-closed', { replace: true });
 
   const urgentItems = guideItems.filter((i) => i.urgency === 'critical' || i.urgency === 'warning');
   const displayItems = (urgentItems.length > 0 ? urgentItems : guideItems).slice(0, 5);
@@ -160,7 +164,7 @@ const AfterClosingModal = ({
                 className="w-full h-11 bg-baro-blue hover:bg-baro-blue/90 text-white flex items-center gap-2"
               >
                 <LogOut className="w-4 h-4" />
-                프로그램 종료
+                {isRetroactive ? '대시보드로 돌아가기' : '프로그램 종료'}
               </Button>
             </div>
           </>
@@ -294,9 +298,11 @@ const AfterClosingModal = ({
               <Moon className="w-8 h-8 text-slate-400" />
             </div>
             <div>
-              <h2 className="text-lg font-bold">프로그램을 종료할까요?</h2>
+              <h2 className="text-lg font-bold">
+                {isRetroactive ? '대시보드로 돌아갈까요?' : '프로그램을 종료할까요?'}
+              </h2>
               <p className="text-sm text-muted-foreground mt-1.5 leading-relaxed">
-                발주 가이드는 내일 오픈 때<br />
+                발주 가이드는 {isRetroactive ? '나중에' : '내일 오픈 때'} <br />
                 발주 가이드 메뉴에서 확인할 수 있어요.
               </p>
             </div>
@@ -309,7 +315,7 @@ const AfterClosingModal = ({
                 onClick={handleExit}
               >
                 <LogOut className="w-4 h-4" />
-                종료
+                {isRetroactive ? '돌아가기' : '종료'}
               </Button>
             </div>
           </div>

--- a/src/features/closing/components/ClosingCancelModal.tsx
+++ b/src/features/closing/components/ClosingCancelModal.tsx
@@ -1,10 +1,21 @@
 import { useState } from 'react';
 
-import { CalendarDays, Loader2, Trash2 } from 'lucide-react';
+import { AlertTriangle, CalendarDays, Loader2, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { useCancelClosing } from '@/features/closing/hooks/useCancelClosing';
 import { useClosingHistory } from '@/features/closing/hooks/useClosingHistory';
+import type { ClosingHistoryItem } from '@/features/closing/types/closing.types';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/shadcn/ui/alert-dialog';
 import { Button } from '@/shadcn/ui/button';
 import {
   Dialog,
@@ -33,98 +44,162 @@ const formatDate = (dateStr: string) => {
 
 const formatCurrency = (amount: number) => `${amount.toLocaleString('ko-KR')}원`;
 
+const getDaysAgo = (dateStr: string): number => {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const target = new Date(dateStr);
+  target.setHours(0, 0, 0, 0);
+  return Math.round((today.getTime() - target.getTime()) / (1000 * 60 * 60 * 24));
+};
+
 const ClosingCancelModal = ({ open, onClose, storeId }: ClosingCancelModalProps) => {
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [confirmingItem, setConfirmingItem] = useState<ClosingHistoryItem | null>(null);
   const { data: history, isLoading } = useClosingHistory(storeId);
   const { mutate: cancel, isPending } = useCancelClosing(storeId);
 
-  const handleCancel = () => {
+  const handleCancelRequest = () => {
     if (!selectedId) return;
-    cancel(selectedId, {
+    const item = history?.closings.find((c) => c.id === selectedId);
+    if (!item) return;
+    setConfirmingItem(item);
+  };
+
+  const handleConfirmCancel = () => {
+    if (!confirmingItem) return;
+    cancel(confirmingItem.id, {
       onSuccess: () => {
         toast.success('마감이 취소되었습니다.');
         setSelectedId(null);
+        setConfirmingItem(null);
         onClose();
       },
       onError: () => {
         toast.error('마감 취소에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+        setConfirmingItem(null);
       },
     });
   };
 
   const handleClose = () => {
     setSelectedId(null);
+    setConfirmingItem(null);
     onClose();
   };
 
+  const daysAgo = confirmingItem ? getDaysAgo(confirmingItem.date) : 0;
+
   return (
-    <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent className="sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            <Trash2 className="w-4 h-4 text-baro-red" />
-            마감 취소
-          </DialogTitle>
-          <DialogDescription>
-            취소할 마감 날짜를 선택해 주세요. 해당 날짜의 재고 차감이 원래대로 복구됩니다.
-          </DialogDescription>
-        </DialogHeader>
+    <>
+      <Dialog open={open} onOpenChange={handleClose}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Trash2 className="w-4 h-4 text-baro-red" />
+              마감 취소
+            </DialogTitle>
+            <DialogDescription>
+              취소할 마감 날짜를 선택해 주세요. 해당 날짜의 재고 차감이 원래대로 복구됩니다.
+            </DialogDescription>
+          </DialogHeader>
 
-        <div className="space-y-2 max-h-64 overflow-y-auto">
-          {isLoading ? (
-            <>
-              <Skeleton className="h-14 w-full rounded-lg" />
-              <Skeleton className="h-14 w-full rounded-lg" />
-              <Skeleton className="h-14 w-full rounded-lg" />
-            </>
-          ) : !history?.closings.length ? (
-            <div className="py-8 text-center text-sm text-muted-foreground">
-              취소할 수 있는 마감 이력이 없어요.
-            </div>
-          ) : (
-            history.closings.map((item) => (
-              <button
-                key={item.id}
-                onClick={() => setSelectedId(item.id)}
-                className={`w-full flex items-center justify-between p-3 rounded-lg border text-left transition-colors
-                  ${
-                    selectedId === item.id
-                      ? 'border-baro-red bg-red-50 dark:bg-red-950/20'
-                      : 'border-border hover:bg-muted/50'
-                  }`}
-              >
-                <div className="flex items-center gap-2">
-                  <CalendarDays className="w-4 h-4 text-muted-foreground shrink-0" />
-                  <span className="text-sm font-medium">{formatDate(item.date)}</span>
-                </div>
-                <span className="text-sm text-muted-foreground">
-                  {formatCurrency(item.totalRevenue)}
-                </span>
-              </button>
-            ))
-          )}
-        </div>
-
-        <div className="flex gap-2 pt-1">
-          <Button variant="outline" className="flex-1" onClick={handleClose} disabled={isPending}>
-            닫기
-          </Button>
-          <Button
-            variant="destructive"
-            className="flex-1 flex items-center gap-1.5"
-            onClick={handleCancel}
-            disabled={!selectedId || isPending}
-          >
-            {isPending ? (
-              <Loader2 className="w-4 h-4 animate-spin" />
+          <div className="space-y-2 max-h-64 overflow-y-auto">
+            {isLoading ? (
+              <>
+                <Skeleton className="h-14 w-full rounded-lg" />
+                <Skeleton className="h-14 w-full rounded-lg" />
+                <Skeleton className="h-14 w-full rounded-lg" />
+              </>
+            ) : !history?.closings.length ? (
+              <div className="py-8 text-center text-sm text-muted-foreground">
+                취소할 수 있는 마감 이력이 없어요.
+              </div>
             ) : (
-              <Trash2 className="w-4 h-4" />
+              history.closings.map((item) => (
+                <button
+                  key={item.id}
+                  onClick={() => setSelectedId(item.id)}
+                  className={`w-full flex items-center justify-between p-3 rounded-lg border text-left transition-colors
+                    ${
+                      selectedId === item.id
+                        ? 'border-baro-red bg-red-50 dark:bg-red-950/20'
+                        : 'border-border hover:bg-muted/50'
+                    }`}
+                >
+                  <div className="flex items-center gap-2">
+                    <CalendarDays className="w-4 h-4 text-muted-foreground shrink-0" />
+                    <span className="text-sm font-medium">{formatDate(item.date)}</span>
+                  </div>
+                  <span className="text-sm text-muted-foreground">
+                    {formatCurrency(item.totalRevenue)}
+                  </span>
+                </button>
+              ))
             )}
-            마감 취소하기
-          </Button>
-        </div>
-      </DialogContent>
-    </Dialog>
+          </div>
+
+          <div className="flex gap-2 pt-1">
+            <Button variant="outline" className="flex-1" onClick={handleClose} disabled={isPending}>
+              닫기
+            </Button>
+            <Button
+              variant="destructive"
+              className="flex-1 flex items-center gap-1.5"
+              onClick={handleCancelRequest}
+              disabled={!selectedId || isPending}
+            >
+              {isPending ? (
+                <Loader2 className="w-4 h-4 animate-spin" />
+              ) : (
+                <Trash2 className="w-4 h-4" />
+              )}
+              마감 취소하기
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* 마감 취소 확인 경고 모달 */}
+      <AlertDialog open={!!confirmingItem} onOpenChange={() => setConfirmingItem(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle className="flex items-center gap-2 text-baro-red">
+              <AlertTriangle className="w-4 h-4" />
+              마감 취소 전 확인하세요
+            </AlertDialogTitle>
+            <AlertDialogDescription className="sr-only">마감 취소 경고</AlertDialogDescription>
+            <div className="space-y-3 text-sm">
+              {confirmingItem && (
+                <p className="text-foreground font-medium">
+                  선택한 마감은{' '}
+                  <span className="text-baro-red font-semibold">
+                    현재 날짜로부터 {daysAgo}일 전
+                  </span>{' '}
+                  ({formatDate(confirmingItem.date)})입니다.
+                </p>
+              )}
+              <div className="rounded-lg border border-amber-200 bg-amber-50 dark:bg-amber-950/20 dark:border-amber-900 px-4 py-3 text-amber-800 dark:text-amber-300">
+                <p className="font-semibold mb-1">⚠️ 복구 불가능한 작업입니다</p>
+                <p className="text-xs leading-relaxed">
+                  마감을 취소하면 해당 날짜의 재고 차감이 원상 복구되지만, 이미 개점이 이루어진
+                  이후이므로 <strong>마감 재진행 및 재고 재차감이 불가능합니다.</strong>
+                </p>
+              </div>
+              <p className="text-muted-foreground text-xs">그래도 마감을 취소하시겠습니까?</p>
+            </div>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => setConfirmingItem(null)}>돌아가기</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleConfirmCancel}
+              className="bg-baro-red hover:bg-baro-red-dark text-white"
+            >
+              {isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : '취소 확정'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 };
 

--- a/src/features/customer-order/components/CustomerOrderStatusCard.tsx
+++ b/src/features/customer-order/components/CustomerOrderStatusCard.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import { Clock, ShoppingBag } from 'lucide-react';
 
+import useClosingStore from '@/features/closing/store/closingStore';
 import OrderStatusBadge from '@/features/customer-order/components/CustomerOrderStatusBadge';
 import type { ApiOrder } from '@/features/customer-order/types/customerOrder.api.types';
 import { useOrders, useUpdateOrderStatus } from '@/features/dashboard/hooks/useOrders';
@@ -111,9 +112,15 @@ interface OrderStatusCardProps {
 
 const OrderStatusCard = ({ storeId }: OrderStatusCardProps) => {
   const [activeTab, setActiveTab] = useState<TabKey>('pending');
-  const { data: orders = [], isLoading } = useOrders(storeId);
+  const { data: rawOrders = [], isLoading } = useOrders(storeId);
+  const businessDate = useClosingStore((s) => s.businessSession.businessDate);
 
   useOrderSSE(storeId);
+
+  // 당일 개점 이후 접수된 주문만 표시
+  const orders = businessDate
+    ? rawOrders.filter((o) => o.createdAt.slice(0, 10) === businessDate)
+    : rawOrders;
 
   const pendingCount = orders.filter((o) => o.status === 'pending').length;
   const filteredOrders = orders.filter((o) => o.status === activeTab);

--- a/src/index.css
+++ b/src/index.css
@@ -221,6 +221,20 @@ code {
   }
 }
 
+/* 페이지 전환 애니메이션 */
+@keyframes page-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.animate-page-fade-in {
+  animation: page-fade-in 0.2s ease-out both;
+}
+
 /* 스크롤바 디자인 */
 ::-webkit-scrollbar {
   @apply w-1 h-1; /* 4px */

--- a/src/pages/ClosingPage.tsx
+++ b/src/pages/ClosingPage.tsx
@@ -96,7 +96,8 @@ const ClosingPage = () => {
           setFinalRevenue(res.totalRevenue);
           setClosingId(res.closingId);
           setClosingDate(res.date);
-          clearBusinessSession();
+          // 소급 마감은 오늘 영업 세션과 무관하므로 세션을 유지
+          if (!isRetroactive) clearBusinessSession();
           void queryClient.invalidateQueries({ queryKey: ['closing', 'preview'] });
           setAfterModalOpen(true);
         },
@@ -134,9 +135,9 @@ const ClosingPage = () => {
 
   return (
     <>
-      <div className="flex flex-col min-h-full">
-        {/* 고정 헤더 */}
-        <div className="sticky top-0 z-10 bg-background border-b px-6 py-4 flex items-center justify-between shrink-0">
+      <div className="flex-1 flex flex-col overflow-hidden">
+        {/* 헤더 */}
+        <div className="shrink-0 bg-background border-b px-6 py-4 flex items-center justify-between">
           <div>
             <h1 className="text-lg font-bold">마감하기</h1>
             <div className="flex items-center gap-1.5 text-xs text-muted-foreground mt-0.5">
@@ -158,7 +159,7 @@ const ClosingPage = () => {
         )}
 
         {/* 스크롤 영역 */}
-        <div className="flex-1 flex flex-col gap-6 p-6 pb-28">
+        <div className="flex-1 overflow-y-auto flex flex-col gap-6 p-6">
           {/* 총 매출 카드 */}
           <Card>
             <CardContent className="px-6 flex items-center justify-between">
@@ -191,8 +192,8 @@ const ClosingPage = () => {
           <ClosingInventoryDeductionSection rows={deductionRows} onChange={handleDeductionChange} />
         </div>
 
-        {/* 고정 하단 버튼 */}
-        <div className="fixed bottom-0 left-0 right-0 z-10 bg-background border-t px-6 py-4">
+        {/* 하단 버튼 */}
+        <div className="shrink-0 bg-background border-t px-6 py-4">
           {preview.isClosed ? (
             <Button
               onClick={handleComplete}
@@ -221,6 +222,7 @@ const ClosingPage = () => {
           closingDate={closingDate}
           storeId={storeId}
           closingId={closingId}
+          isRetroactive={isRetroactive}
         />
       )}
 

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,6 +1,3 @@
-import { AlertTriangle } from 'lucide-react';
-import { Link } from 'react-router-dom';
-
 import useAuthStore from '@/features/auth/store/authStore';
 import OrderStatusCard from '@/features/customer-order/components/CustomerOrderStatusCard';
 import MemoCard from '@/features/dashboard/components/MemoCard';
@@ -10,12 +7,6 @@ import StoreStatusCard from '@/features/dashboard/components/StoreStatusCard';
 import { useDashboardSales } from '@/features/dashboard/hooks/useDashboardSales';
 import { useDashboardStats } from '@/features/dashboard/hooks/useDashboardStats';
 import { Skeleton } from '@/shadcn/ui/skeleton';
-
-const getYesterdayKST = () => {
-  const kstNow = new Date(Date.now() + 9 * 60 * 60 * 1000);
-  kstNow.setDate(kstNow.getDate() - 1);
-  return kstNow.toISOString().slice(0, 10);
-};
 
 const DashboardPage = () => {
   const storeId = useAuthStore((s) => s.storeId);
@@ -32,22 +23,9 @@ const DashboardPage = () => {
 
       {/* 오른쪽: 가게 현황 */}
       <div className="flex-1 min-w-0 flex flex-col gap-4">
-        {/* 누락 마감 배너 */}
-        {stats?.missedClosing && (
-          <Link
-            to={`/closing?date=${getYesterdayKST()}`}
-            className="flex items-center gap-2.5 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 hover:bg-amber-100 transition-colors"
-          >
-            <AlertTriangle className="h-4 w-4 shrink-0 text-amber-500" />
-            <span>
-              <span className="font-semibold">전날 마감이 누락되었습니다.</span> 클릭하여 소급
-              마감을 진행하세요.
-            </span>
-          </Link>
-        )}
         {/* 상단: 오늘의 가게 현황 요약 */}
         {statsLoading || !stats ? (
-          <Skeleton className="h-[92px] w-full rounded-xl" />
+          <Skeleton className="h-23 w-full rounded-xl" />
         ) : (
           <StoreStatusCard stats={stats} storeId={storeId} />
         )}

--- a/src/pages/SystemStartPage.tsx
+++ b/src/pages/SystemStartPage.tsx
@@ -13,7 +13,7 @@ import {
   Store,
   Trash2,
 } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 
 import useAuthStore from '@/features/auth/store/authStore';
@@ -21,6 +21,7 @@ import { openBusiness } from '@/features/closing/api/closing.api';
 import ClosingCancelModal from '@/features/closing/components/ClosingCancelModal';
 import { useClosingHistory } from '@/features/closing/hooks/useClosingHistory';
 import useClosingStore from '@/features/closing/store/closingStore';
+import { useDashboardStats } from '@/features/dashboard/hooks/useDashboardStats';
 import { Button } from '@/shadcn/ui/button';
 import {
   Dialog,
@@ -38,6 +39,12 @@ import {
   isTodayBusinessDay,
   todayKSTString,
 } from '@/shared/utils/businessDate';
+
+const getYesterdayKST = () => {
+  const kstNow = new Date(Date.now() + 9 * 60 * 60 * 1000);
+  kstNow.setDate(kstNow.getDate() - 1);
+  return kstNow.toISOString().slice(0, 10);
+};
 
 const formatCalendarDate = () =>
   new Date().toLocaleDateString('ko-KR', {
@@ -79,6 +86,11 @@ const SystemStartPage = () => {
   const { data: history, isLoading } = useClosingHistory(storeId);
   const businessDateClosed =
     history?.closings.some((c) => c.date.startsWith(businessDate)) ?? false;
+
+  // 개점 시간 이후(휴무일 제외)에만 전날 마감 누락 여부 조회
+  const { data: dashboardStats } = useDashboardStats(
+    !isLoading && !isBeforeOpen && !isHoliday ? storeId : null,
+  );
 
   const [isStarting, setIsStarting] = useState(false);
   const [showCancelModal, setShowCancelModal] = useState(false);
@@ -305,6 +317,18 @@ const SystemStartPage = () => {
                 {formatShortDate(businessDate)} 마감 완료
               </span>
             )}
+            {/* 전날 마감 누락 알림 — already-open / normal 케이스 */}
+            {!isLoading &&
+              dashboardStats?.missedClosing &&
+              (currentCase === 'already-open' || currentCase === 'normal') && (
+                <Link
+                  to={`/closing?date=${getYesterdayKST()}`}
+                  className="inline-flex items-center gap-1 mt-1 text-xs font-medium text-amber-700 bg-amber-100 border border-amber-300 px-2 py-0.5 rounded-full hover:bg-amber-200 transition-colors"
+                >
+                  <AlertTriangle className="h-3 w-3 shrink-0" />
+                  전날 마감 누락
+                </Link>
+              )}
           </div>
         </div>
 

--- a/src/widgets/AppHeader.tsx
+++ b/src/widgets/AppHeader.tsx
@@ -1,4 +1,5 @@
-import { ChevronDown } from 'lucide-react';
+import { AlertTriangle } from 'lucide-react';
+import { Link } from 'react-router-dom';
 
 import useAuthStore from '@/features/auth/store/authStore';
 import { useClosingStatus } from '@/features/closing/hooks/useClosingStatus';
@@ -11,9 +12,22 @@ interface AppHeaderProps {
   userRole: string;
   isLoading?: boolean;
   onClosingClick?: () => void;
+  missedClosing?: boolean;
 }
 
-const AppHeader = ({ userName, userRole, isLoading = false, onClosingClick }: AppHeaderProps) => {
+const getYesterdayKST = () => {
+  const kstNow = new Date(Date.now() + 9 * 60 * 60 * 1000);
+  kstNow.setDate(kstNow.getDate() - 1);
+  return kstNow.toISOString().slice(0, 10);
+};
+
+const AppHeader = ({
+  userName,
+  userRole,
+  isLoading = false,
+  onClosingClick,
+  missedClosing = false,
+}: AppHeaderProps) => {
   const storeId = useAuthStore((s) => s.storeId);
   const { isCompleted } = useClosingStatus(storeId);
   const { isOpen: isBusinessOpen } = useClosingStore((s) => s.businessSession);
@@ -22,7 +36,18 @@ const AppHeader = ({ userName, userRole, isLoading = false, onClosingClick }: Ap
   const isClosingDisabled = !isBusinessOpen || isCompleted;
 
   return (
-    <header className="bg-background h-13 border-b flex items-center justify-end px-6 gap-4 sticky top-0 z-10">
+    <header className="bg-background h-13 border-b flex items-center justify-end px-6 gap-3 sticky top-0 z-10">
+      {/* 전날 마감 누락 알림 */}
+      {missedClosing && (
+        <Link
+          to={`/closing?date=${getYesterdayKST()}`}
+          className="flex items-center gap-1.5 rounded-full border border-amber-300 bg-amber-50 px-3 py-1 text-xs font-medium text-amber-700 hover:bg-amber-100 transition-colors"
+        >
+          <AlertTriangle className="h-3 w-3 shrink-0" />
+          전날 마감 누락
+        </Link>
+      )}
+
       {/* 마감하기 */}
       <Button
         size="sm"
@@ -51,10 +76,9 @@ const AppHeader = ({ userName, userRole, isLoading = false, onClosingClick }: Ap
             <Skeleton className="h-3 w-16" />
             <Skeleton className="h-3 w-8" />
           </div>
-          <ChevronDown className="w-4 h-4 text-gray-400" />
         </div>
       ) : (
-        <div className="flex items-center gap-4 cursor-pointer rounded-lg transition-colors">
+        <div className="flex items-center gap-4 rounded-lg">
           <div className="w-7 h-7 rounded-full bg-baro-blue flex items-center justify-center">
             <span className="text-xs font-semibold text-white">{userName.charAt(0)}</span>
           </div>
@@ -62,7 +86,6 @@ const AppHeader = ({ userName, userRole, isLoading = false, onClosingClick }: Ap
             <span className="text-xs font-semibold leading-tight">{userName}</span>
             <span className="text-xs leading-tight text-muted-foreground">{userRole}</span>
           </div>
-          <ChevronDown className="w-4 h-4 text-gray-400" />
         </div>
       )}
     </header>


### PR DESCRIPTION
## 📌 요약

- 페이지 전환 시 부드러운 fade-in 애니메이션 추가
- 전날 마감 누락 알림을 AppHeader 배지로 이동 (대시보드 레이아웃 깨짐 해소)
- 주문 현황 카드에 영업 기준일 기준 필터링 적용
- 마감 취소 전 AlertDialog 확인 단계 추가
- 소급 마감 완료 후 오늘 영업 세션을 유지하고 대시보드로 복귀

<br/>

## 🏷️ 관련 이슈

- Closes #119
- Closes #120
- Closes #121
- Closes #122
- Closes #123
- Closes #124

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- **#119** `index.css`에 `@keyframes page-fade-in` 추가, 모든 라우트에 `StandalonePageWrapper`/`key` 래퍼로 fade-in 적용
- **#120 + #124** AppHeader에 amber pill 배지로 전날 마감 누락 표시, DashboardPage 배너 제거로 레이아웃 안정화
- **#121** `CustomerOrderStatusCard`에서 `businessDate` 기준 주문 필터링
- **#122** `ClosingCancelModal`에 `AlertDialog` 확인 단계 추가 (날짜 표시 + 되돌릴 수 없음 경고)
- **#123** 소급 마감 시 `clearBusinessSession` 건너뛰고 `/dashboard`로 복귀

<br/>

### 📂 세부 변경사항

- `src/index.css` — page-fade-in keyframe 정의
- `src/app/routes/Router.tsx` — StandalonePageWrapper 추가
- `src/app/layouts/AppLayout.tsx` — Outlet에 key 래퍼 + missedClosing 조회
- `src/widgets/AppHeader.tsx` — missedClosing 배지 + ChevronDown 제거
- `src/pages/DashboardPage.tsx` — 마감 누락 배너 제거
- `src/pages/SystemStartPage.tsx` — already-open/normal 케이스 날짜 옆 인라인 배지 추가
- `src/features/customer-order/components/CustomerOrderStatusCard.tsx` — businessDate 필터링
- `src/features/closing/components/ClosingCancelModal.tsx` — AlertDialog 확인 단계
- `src/pages/ClosingPage.tsx` — isRetroactive 조건 clearBusinessSession 스킵
- `src/features/closing/components/AfterClosingModal.tsx` — 소급 마감 시 대시보드 복귀

<br/>

## 🧪 테스트 방법

1. 페이지 간 이동 시 fade-in 애니메이션 확인
2. 전날 마감 누락 상태에서 AppHeader 배지 표시 여부 확인
3. 개점 후 시스템 시작 페이지 날짜 옆 배지 표시 확인
4. 주문 현황 카드에 당일 영업 기준일 외 주문 미표시 확인
5. 마감 취소 버튼 클릭 시 AlertDialog 확인 단계 노출 확인
6. 소급 마감(/closing?date=YYYY-MM-DD) 완료 후 대시보드 복귀 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [ ] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- `StoreStatusCard`의 `aiOrderRecommendations` (#125)는 백엔드 수정으로 해결되어 프론트엔드 변경 없음
- `getYesterdayKST()` 헬퍼가 AppHeader와 SystemStartPage에 각각 존재 (공통 유틸 추출은 추후 리팩토링)