### PR TITLE
💄 (#127) ui: 대시보드 이번 달 현황 도넛 차트 UI 개선

### DIFF
--- a/src/features/dashboard/components/SalesConsumptionCard.tsx
+++ b/src/features/dashboard/components/SalesConsumptionCard.tsx
@@ -9,10 +9,10 @@ interface SalesConsumptionCardProps {
 
 /* ── SVG 도넛 차트 ── */
 interface DonutChartProps {
-  consumptionRatio: number; // 0 ~ 1
+  salesRatio: number; // 매출 / (매출 + 소비), 0 ~ 1
 }
 
-const DonutChart = ({ consumptionRatio }: DonutChartProps) => {
+const DonutChart = ({ salesRatio }: DonutChartProps) => {
   const r = 52;
   const cx = 70;
   const cy = 70;
@@ -20,17 +20,28 @@ const DonutChart = ({ consumptionRatio }: DonutChartProps) => {
   const C = 2 * Math.PI * r;
   const GAP = C * 0.015;
 
-  const ratio = Math.min(1, Math.max(0, consumptionRatio));
+  const ratio = Math.min(1, Math.max(0, salesRatio));
   const hasBoth = ratio > 0 && ratio < 1;
-  const consumptionArc = hasBoth ? C * ratio - GAP : C * ratio;
-  const profitArc = hasBoth ? C * (1 - ratio) - GAP : C * (1 - ratio);
+  // 초록 = 매출 아크
+  const salesArc = hasBoth ? C * ratio - GAP : C * ratio;
+  // 파랑 = 소비 아크
+  const consumptionArc = hasBoth ? C * (1 - ratio) - GAP : C * (1 - ratio);
+
+  // 데이터 없으면 회색 원만 표시
+  if (salesRatio === 0.5 && salesArc === 0 && consumptionArc === 0) {
+    return (
+      <svg viewBox="0 0 140 140" className="w-full h-full">
+        <circle cx={cx} cy={cy} r={r} fill="none" stroke="#f3f4f6" strokeWidth={sw} />
+      </svg>
+    );
+  }
 
   return (
-    <svg viewBox="0 0 140 140" className="w-full h-full">
+    <svg viewBox="0 0 140 140" className="w-full h-full drop-shadow-md">
       <circle cx={cx} cy={cy} r={r} fill="none" stroke="#f3f4f6" strokeWidth={sw} />
 
       <g transform={`rotate(-90 ${cx} ${cy})`}>
-        {consumptionArc > 0 && (
+        {salesArc > 0 && (
           <circle
             cx={cx}
             cy={cy}
@@ -39,11 +50,11 @@ const DonutChart = ({ consumptionRatio }: DonutChartProps) => {
             stroke="#679436"
             strokeWidth={sw}
             strokeLinecap="butt"
-            strokeDasharray={`${consumptionArc} ${C}`}
+            strokeDasharray={`${salesArc} ${C}`}
             strokeDashoffset={0}
           />
         )}
-        {profitArc > 0 && (
+        {consumptionArc > 0 && (
           <circle
             cx={cx}
             cy={cy}
@@ -52,7 +63,7 @@ const DonutChart = ({ consumptionRatio }: DonutChartProps) => {
             stroke="#449CD4"
             strokeWidth={sw}
             strokeLinecap="butt"
-            strokeDasharray={`${profitArc} ${C}`}
+            strokeDasharray={`${consumptionArc} ${C}`}
             strokeDashoffset={hasBoth ? -(C * ratio) : 0}
           />
         )}
@@ -66,57 +77,82 @@ const SalesConsumptionCard = ({ data }: SalesConsumptionCardProps) => {
   const latest = data[data.length - 1];
   const rawProfit = latest.sales - latest.consumption;
   const isDeficit = rawProfit < 0;
-  const profit = Math.max(0, rawProfit);
-  const consumptionRatio = latest.sales > 0 ? latest.consumption / latest.sales : 0;
-  const profitRatio = latest.sales > 0 ? profit / latest.sales : 0;
+  const total = latest.sales + latest.consumption;
+  const rawSalesRatio = total > 0 ? latest.sales / total : 0;
+  // 둘 다 값이 있을 때 최소 5% 아크 보장 (비율이 극단적이어도 양쪽 다 보이게)
+  const MIN_VISIBLE = 0.05;
+  const salesRatio =
+    rawSalesRatio === 0
+      ? 0
+      : rawSalesRatio === 1
+        ? 1
+        : Math.max(MIN_VISIBLE, Math.min(1 - MIN_VISIBLE, rawSalesRatio));
+  // 소비 비율은 (매출+소비) 합계 대비로 계산 (매출보다 소비가 크면 /매출 기준은 100% 초과)
+  const consumptionRatio = total > 0 ? latest.consumption / total : 0;
 
   return (
     <Card size="sm" className="h-full">
-      <CardHeader className="border-b px-4 ">
+      <CardHeader className="border-b px-4">
         <CardTitle className="text-sm flex items-center gap-2">
           <PieChart className="w-4 h-4 text-muted-foreground" />
           이번 달 현황
         </CardTitle>
       </CardHeader>
 
-      {/* 가로 배치: 도넛 차트 (좌) + 범례 (우) — 세로 중앙 정렬 */}
-      <CardContent className="flex-1 flex items-center gap-4 px-4 py-3">
+      <CardContent className="flex-1 flex items-center gap-5 px-4 py-3">
         {/* 도넛 차트 */}
         <div className="relative w-28 h-28 shrink-0">
-          <DonutChart consumptionRatio={consumptionRatio} />
-          <div className="absolute inset-0 flex flex-col items-center justify-center gap-0.5">
-            <p className="text-[10px] text-muted-foreground">{latest.month} 매출</p>
-            <p className="text-sm font-bold leading-none">{(latest.sales / 10000).toFixed(1)}만</p>
+          <DonutChart salesRatio={salesRatio} />
+          <div className="absolute inset-0 flex items-center justify-center">
+            <p className="text-xs text-muted-foreground">{latest.month}</p>
           </div>
         </div>
 
-        {/* 범례 — 가로 배치 */}
-        <div className="flex-1 flex gap-2">
-          <div className="flex-1 rounded-lg bg-muted/40 px-3 py-2.5">
-            <div className="flex items-center gap-1.5 mb-0.5">
+        {/* 수치 목록 */}
+        <div className="flex-1 flex flex-col justify-center gap-3">
+          {/* 매출 */}
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-1.5">
               <span className="size-2 rounded-full bg-baro-green shrink-0" />
-              <span className="text-xs text-muted-foreground">소비</span>
+              <span className="text-xs text-muted-foreground">매출</span>
             </div>
-            <p className="text-sm font-bold ">{(latest.consumption / 10000).toFixed(0)}만원</p>
-            <p className="text-xs text-muted-foreground mt-0.5">
-              {(consumptionRatio * 100).toFixed(1)}%
-            </p>
+            <div className="flex items-center gap-1.5">
+              <span className="text-xs text-muted-foreground">
+                {((1 - consumptionRatio) * 100).toFixed(1)}%
+              </span>
+              <span className="text-sm font-bold">{(latest.sales / 10000).toFixed(0)}만원</span>
+            </div>
           </div>
 
-          <div className="flex-1 rounded-lg bg-muted/40 px-3 py-2.5">
-            <div className="flex items-center gap-1.5 mb-0.5">
+          {/* 소비 */}
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-1.5">
               <span className="size-2 rounded-full bg-baro-blue shrink-0" />
-              <span className="text-xs text-muted-foreground">순이익</span>
+              <span className="text-xs text-muted-foreground">소비</span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span className="text-xs text-muted-foreground">
+                {(consumptionRatio * 100).toFixed(1)}%
+              </span>
+              <span className="text-sm font-bold">
+                {(latest.consumption / 10000).toFixed(0)}만원
+              </span>
+            </div>
+          </div>
+
+          {/* 구분선 + 순이익 */}
+          <div className="border-t pt-2.5 flex items-center justify-between">
+            <span className="text-xs text-muted-foreground">순이익</span>
+            <div className="flex items-center gap-1.5">
               {isDeficit && (
                 <span className="text-[10px] text-baro-red bg-red-50 border border-red-200/60 px-1.5 py-0.5 rounded-full leading-none">
                   적자
                 </span>
               )}
+              <span className={`text-sm font-bold ${isDeficit ? 'text-baro-red' : ''}`}>
+                {(rawProfit / 10000).toFixed(0)}만원
+              </span>
             </div>
-            <p className="text-sm font-bold">{(profit / 10000).toFixed(0)}만원</p>
-            <p className="text-xs text-muted-foreground mt-0.5">
-              {(profitRatio * 100).toFixed(1)}%
-            </p>
           </div>
         </div>
       </CardContent>


### PR DESCRIPTION
## 📌 요약

- 도넛 차트 색상 재정의: 초록 = 매출, 파랑 = 소비
- 순이익을 차트 아크 대신 별도 텍스트로 분리
- 범례 레이아웃을 박스 그리드 → 수직 리스트로 개선

<br/>

## 🏷️ 관련 이슈

- Closes #127

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- 도넛 아크: 매출/(매출+소비) 비율로 초록·파랑 분할
- 비율 극단 시 최소 5% 아크 보장 (매출 5만 vs 소비 297만 케이스 대응)
- 소비% 기준을 `소비/매출` → `소비/(매출+소비)`로 변경, 100% 초과 버그 제거
- 도넛 중앙 텍스트를 월 표시만으로 단순화
- drop-shadow-md 추가로 입체감 부여

### 📂 세부 변경사항

- `SalesConsumptionCard.tsx`: DonutChart props `consumptionRatio` → `salesRatio`로 변경, 범례 레이아웃 리팩토링, 순이익 분리 표시

<br/>

## 📸 Screenshots

| Before | After |
| ------ | ----- |
| 초록=소비, 파랑=순이익 아크 / 박스 그리드 범례 | <img width="557" height="347" alt="image" src="https://github.com/user-attachments/assets/1f024a7a-8c64-426e-b936-a9d14ddc8475" /> |

<br/>

## 🧪 테스트 방법

1. 대시보드 접속
2. 이번 달 현황 카드에서 도넛 차트 확인 (초록=매출, 파랑=소비)
3. 매출·소비 비율이 합산 100%인지 확인
4. 순이익이 구분선 아래 텍스트로 분리되어 있는지 확인

<br/>

## 🚨 영향 범위

- [x] Frontend

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- 매출이 0일 때(신규 영업일 등) 초록 아크 미표시 → 회색 원만 유지되도록 처리