### PR TITLE
✨ (#129) feat: 아이디 로그인·회원가입 및 UI 개선 배치

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@base-ui/react": "^1.4.1",
     "@fontsource-variable/geist": "^5.2.8",
+    "@hookform/resolvers": "^5.4.0",
     "@tailwindcss/vite": "^4.2.4",
     "@tanstack/react-query": "^5.101.0",
     "axios": "^1.16.1",
@@ -33,12 +34,14 @@
     "react": "^19.2.5",
     "react-day-picker": "^10.0.1",
     "react-dom": "^19.2.5",
+    "react-hook-form": "^7.80.0",
     "react-router-dom": "^7.15.0",
     "shadcn": "^4.6.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.4",
     "tw-animate-css": "^1.4.0",
+    "zod": "^4.4.3",
     "zustand": "^5.0.13"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@fontsource-variable/geist':
         specifier: ^5.2.8
         version: 5.2.8
+      '@hookform/resolvers':
+        specifier: ^5.4.0
+        version: 5.4.0(react-hook-form@7.80.0(react@19.2.5))
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.2.4(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1)(yaml@2.8.3))
@@ -50,6 +53,9 @@ importers:
       react-dom:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
+      react-hook-form:
+        specifier: ^7.80.0
+        version: 7.80.0(react@19.2.5)
       react-router-dom:
         specifier: ^7.15.0
         version: 7.15.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -68,6 +74,9 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
       zustand:
         specifier: ^5.0.13
         version: 5.0.13(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
@@ -382,6 +391,11 @@ packages:
     peerDependencies:
       hono: ^4
 
+  '@hookform/resolvers@5.4.0':
+    resolution: {integrity: sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw==}
+    peerDependencies:
+      react-hook-form: ^7.55.0
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -620,6 +634,9 @@ packages:
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@tailwindcss/node@4.2.4':
     resolution: {integrity: sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==}
@@ -2423,6 +2440,12 @@ packages:
     peerDependencies:
       react: ^19.2.5
 
+  react-hook-form@7.80.0:
+    resolution: {integrity: sha512-4P+fk6oXsxY+6xSj7Euhc2sumQD8zQqCuVHoJwoyp9EchP+IUW9OESB7uHFJOKsIBQ4MQqYE84INJFqUCYNoOg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
   react-router-dom@7.15.0:
     resolution: {integrity: sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==}
     engines: {node: '>=20.0.0'}
@@ -2996,8 +3019,8 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zustand@5.0.13:
     resolution: {integrity: sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==}
@@ -3340,6 +3363,11 @@ snapshots:
     dependencies:
       hono: 4.12.15
 
+  '@hookform/resolvers@5.4.0(react-hook-form@7.80.0(react@19.2.5))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.80.0(react@19.2.5)
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -3533,6 +3561,8 @@ snapshots:
   '@sec-ant/readable-stream@0.4.1': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@tailwindcss/node@4.2.4':
     dependencies:
@@ -4284,8 +4314,8 @@ snapshots:
       '@babel/parser': 7.29.2
       eslint: 9.39.4(jiti@2.6.1)
       hermes-parser: 0.25.1
-      zod: 4.3.6
-      zod-validation-error: 4.0.2(zod@4.3.6)
+      zod: 4.4.3
+      zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -5361,6 +5391,10 @@ snapshots:
       react: 19.2.5
       scheduler: 0.27.0
 
+  react-hook-form@7.80.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+
   react-router-dom@7.15.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       react: 19.2.5
@@ -6008,13 +6042,13 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
-  zod-validation-error@4.0.2(zod@4.3.6):
+  zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
-      zod: 4.3.6
+      zod: 4.4.3
 
   zod@3.25.76: {}
 
-  zod@4.3.6: {}
+  zod@4.4.3: {}
 
   zustand@5.0.13(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5)):
     optionalDependencies:

--- a/src/app/layouts/AppLayout.tsx
+++ b/src/app/layouts/AppLayout.tsx
@@ -5,6 +5,7 @@ import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { routePaths } from '@/app/routes/routePaths';
 import { useUserInfo } from '@/features/account-settings/hooks/useUserInfo';
 import useAuthStore from '@/features/auth/store/authStore';
+import { useClosingHistory } from '@/features/closing/hooks/useClosingHistory';
 import useClosingStore from '@/features/closing/store/closingStore';
 import { useDashboardStats } from '@/features/dashboard/hooks/useDashboardStats';
 import { useStoreSettings } from '@/features/store-settings/hooks/useStoreSettings';
@@ -35,6 +36,7 @@ const AppLayout = () => {
   const { data: storeData, isLoading: isStoreLoading } = useStoreSettings();
   const { data: userData, isLoading: isUserLoading } = useUserInfo();
   const { data: dashboardStats } = useDashboardStats(isOpen ? storeId : null);
+  const { data: closingHistory } = useClosingHistory(isOpen ? storeId : null);
 
   useEffect(() => {
     scrollRef.current?.scrollTo(0, 0);
@@ -54,7 +56,9 @@ const AppLayout = () => {
           userRole={ROLE_LABEL[storeData?.myRole ?? ''] ?? ''}
           isLoading={isUserLoading || isStoreLoading}
           onClosingClick={() => navigate('/closing')}
-          missedClosing={dashboardStats?.missedClosing ?? false}
+          missedClosing={
+            (dashboardStats?.missedClosing ?? false) && (closingHistory?.closings.length ?? 0) > 0
+          }
         />
         <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto flex flex-col">
           <div key={pathname} className="animate-page-fade-in flex-1 flex flex-col min-h-0">

--- a/src/app/routes/Router.tsx
+++ b/src/app/routes/Router.tsx
@@ -6,6 +6,7 @@ import SettingsPage from '@/pages/AccountSettingsPage';
 import AuthCallbackPage from '@/pages/AuthCallbackPage';
 import ClosingOrderGuidePage from '@/pages/ClosingOrderGuidePage';
 import ClosingPage from '@/pages/ClosingPage';
+import CredentialLoginPage from '@/pages/CredentialLoginPage';
 import CustomerOrderPage from '@/pages/CustomerOrderPage';
 import DashboardPage from '@/pages/DashboardPage';
 import DayClosedPage from '@/pages/DayClosedPage';
@@ -16,6 +17,7 @@ import LoginPage from '@/pages/LoginPage';
 import NotFoundPage from '@/pages/NotFoundPage';
 import OcrInboundPage from '@/pages/OcrInboundPage';
 import OrderGuidePage from '@/pages/OrderGuidePage';
+import RegisterPage from '@/pages/RegisterPage';
 import SettingsIngredientsPage from '@/pages/SettingsIngredientsPage';
 import SettingsMenuBoardPage from '@/pages/SettingsMenuBoardPage';
 import SettingsMenusPage from '@/pages/SettingsMenusPage';
@@ -46,6 +48,14 @@ export default function Router() {
         element={<StandalonePageWrapper element={<AuthCallbackPage />} />}
       />
       <Route path={routePaths.login} element={<StandalonePageWrapper element={<LoginPage />} />} />
+      <Route
+        path={routePaths.credentialLogin}
+        element={<StandalonePageWrapper element={<CredentialLoginPage />} />}
+      />
+      <Route
+        path={routePaths.register}
+        element={<StandalonePageWrapper element={<RegisterPage />} />}
+      />
       <Route
         path={routePaths.storeSelection}
         element={<StandalonePageWrapper element={<StoreSelectionPage />} />}

--- a/src/app/routes/routePaths.ts
+++ b/src/app/routes/routePaths.ts
@@ -1,6 +1,8 @@
 export const routePaths = {
   landing: '/',
   login: '/login',
+  credentialLogin: '/credential-login',
+  register: '/register',
   storeSelection: '/store-selection',
   initialSetup: '/initial-setup',
   systemStart: '/system-start',

--- a/src/features/account-settings/components/AccountSettingsContent.tsx
+++ b/src/features/account-settings/components/AccountSettingsContent.tsx
@@ -4,7 +4,7 @@ import ThemeSection from '@/features/account-settings/components/sections/ThemeS
 
 const AccountSettingsContent = () => {
   return (
-    <div className="space-y-5 p-6">
+    <div className="space-y-5 p-4">
       <div>
         <p className="text-sm font-semibold leading-tight">회원 설정</p>
         <p className="text-xs text-muted-foreground">계정 및 앱 환경을 관리합니다.</p>

--- a/src/features/auth/api/authApi.ts
+++ b/src/features/auth/api/authApi.ts
@@ -1,8 +1,21 @@
+import type {
+  CredentialAuthResponse,
+  CredentialLoginRequest,
+  RegisterRequest,
+} from '@/features/auth/types/auth.api.types';
 import axiosInstance from '@/shared/api/axiosInstance';
 
 export const getKakaoLoginUrl = (callbackUrl: string): string => {
   const base = `${import.meta.env.VITE_API_BASE_URL}/auth/kakao`;
   return `${base}?returnUrl=${encodeURIComponent(callbackUrl)}`;
+};
+
+export const credentialLogin = (data: CredentialLoginRequest): Promise<CredentialAuthResponse> => {
+  return axiosInstance.post('/auth/login', data).then((res) => res.data.data);
+};
+
+export const register = (data: RegisterRequest): Promise<CredentialAuthResponse> => {
+  return axiosInstance.post('/auth/register', data).then((res) => res.data.data);
 };
 
 export const logout = (): Promise<void> => {

--- a/src/features/auth/components/CredentialLoginCard.tsx
+++ b/src/features/auth/components/CredentialLoginCard.tsx
@@ -1,0 +1,35 @@
+import { Link } from 'react-router-dom';
+
+import { routePaths } from '@/app/routes/routePaths';
+import CredentialLoginForm from '@/features/auth/components/CredentialLoginForm';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shadcn/ui/card';
+import baroLogo from '@/shared/assets/images/baro-logo.png';
+
+const CredentialLoginCard = () => {
+  return (
+    <Card className="rounded-3xl border-border/60 py-6">
+      <CardHeader className="text-center">
+        <div className="flex items-center justify-center gap-3 pr-4">
+          <img src={baroLogo} alt="BARO Logo" className="h-10 w-auto" />
+          <CardTitle className="text-3xl font-black tracking-tight">아이디로 로그인</CardTitle>
+        </div>
+        <CardDescription className="mt-2 text-sm text-muted-foreground">
+          발급받은 계정으로 로그인하세요.
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="space-y-4 px-6">
+        <CredentialLoginForm />
+
+        <p className="text-center text-xs text-muted-foreground">
+          계정이 없으신가요?{' '}
+          <Link to={routePaths.register} className="font-semibold text-baro-blue hover:underline">
+            회원가입
+          </Link>
+        </p>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default CredentialLoginCard;

--- a/src/features/auth/components/CredentialLoginForm.tsx
+++ b/src/features/auth/components/CredentialLoginForm.tsx
@@ -1,0 +1,116 @@
+import { useState } from 'react';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Eye, EyeOff, LogIn } from 'lucide-react';
+import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+import { z } from 'zod';
+
+import { routePaths } from '@/app/routes/routePaths';
+import { credentialLogin } from '@/features/auth/api/authApi';
+import useAuthStore from '@/features/auth/store/authStore';
+import { Button } from '@/shadcn/ui/button';
+import { Input } from '@/shadcn/ui/input';
+import { Label } from '@/shadcn/ui/label';
+import axiosInstance from '@/shared/api/axiosInstance';
+
+const schema = z.object({
+  username: z.string().min(1, '아이디를 입력해주세요.'),
+  password: z.string().min(1, '비밀번호를 입력해주세요.'),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+const CredentialLoginForm = () => {
+  const navigate = useNavigate();
+  const { setTokens, setStoreId } = useAuthStore();
+  const [showPassword, setShowPassword] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<FormValues>({ resolver: zodResolver(schema) });
+
+  const onSubmit = async (values: FormValues) => {
+    try {
+      const { accessToken, refreshToken, isNewUser } = await credentialLogin(values);
+      setTokens(accessToken, refreshToken);
+
+      if (isNewUser) {
+        navigate(routePaths.initialSetup, { replace: true });
+        return;
+      }
+
+      axiosInstance
+        .get('/users/me/store')
+        .then((res) => {
+          if (res.data.data?.storeId) {
+            setStoreId(res.data.data.storeId);
+          }
+        })
+        .catch(() => {})
+        .finally(() => navigate(routePaths.systemStart, { replace: true }));
+    } catch (err: unknown) {
+      const status = (err as { response?: { status?: number } })?.response?.status;
+      if (status === 401) {
+        toast.error('아이디 또는 비밀번호가 올바르지 않습니다.');
+      } else {
+        toast.error('로그인에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+      }
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-3">
+      <div className="space-y-1.5">
+        <Label htmlFor="login-username">아이디</Label>
+        <Input
+          id="login-username"
+          placeholder="아이디를 입력하세요"
+          autoComplete="username"
+          aria-invalid={!!errors.username}
+          className="h-11"
+          {...register('username')}
+        />
+        {errors.username && <p className="text-xs text-destructive">{errors.username.message}</p>}
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="login-password">비밀번호</Label>
+        <div className="relative">
+          <Input
+            id="login-password"
+            type={showPassword ? 'text' : 'password'}
+            placeholder="비밀번호를 입력하세요"
+            autoComplete="current-password"
+            aria-invalid={!!errors.password}
+            className="h-11 pr-10"
+            {...register('password')}
+          />
+          <button
+            type="button"
+            onClick={() => setShowPassword((v) => !v)}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            tabIndex={-1}
+          >
+            {showPassword ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+          </button>
+        </div>
+        {errors.password && <p className="text-xs text-destructive">{errors.password.message}</p>}
+      </div>
+
+      <Button
+        type="submit"
+        className="h-11 w-full bg-baro-blue text-white hover:bg-baro-blue/90"
+        disabled={isSubmitting}
+      >
+        <LogIn className="size-4" />
+        {isSubmitting ? '로그인 중...' : '로그인'}
+      </Button>
+    </form>
+  );
+};
+
+export default CredentialLoginForm;

--- a/src/features/auth/components/RegisterForm.tsx
+++ b/src/features/auth/components/RegisterForm.tsx
@@ -1,0 +1,161 @@
+import { useState } from 'react';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Eye, EyeOff, UserPlus } from 'lucide-react';
+import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+import { z } from 'zod';
+
+import { routePaths } from '@/app/routes/routePaths';
+import { register as registerApi } from '@/features/auth/api/authApi';
+import useAuthStore from '@/features/auth/store/authStore';
+import { Button } from '@/shadcn/ui/button';
+import { Input } from '@/shadcn/ui/input';
+import { Label } from '@/shadcn/ui/label';
+import axiosInstance from '@/shared/api/axiosInstance';
+
+const schema = z.object({
+  username: z
+    .string()
+    .min(3, '아이디는 3자 이상이어야 합니다.')
+    .max(30, '아이디는 30자 이하여야 합니다.')
+    .regex(/^[a-zA-Z0-9_]+$/, '영문, 숫자, 언더스코어(_)만 사용 가능합니다.'),
+  password: z.string().min(6, '비밀번호는 6자 이상이어야 합니다.'),
+  name: z.string().min(1, '이름을 입력해주세요.'),
+  inviteCode: z.string().min(1, '초대 코드를 입력해주세요.'),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+const RegisterForm = () => {
+  const navigate = useNavigate();
+  const { setTokens, setStoreId } = useAuthStore();
+  const [showPassword, setShowPassword] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<FormValues>({ resolver: zodResolver(schema) });
+
+  const onSubmit = async (values: FormValues) => {
+    try {
+      const { accessToken, refreshToken, isNewUser } = await registerApi(values);
+      setTokens(accessToken, refreshToken);
+
+      if (isNewUser) {
+        navigate(routePaths.initialSetup, { replace: true });
+        return;
+      }
+
+      axiosInstance
+        .get('/users/me/store')
+        .then((res) => {
+          if (res.data.data?.storeId) {
+            setStoreId(res.data.data.storeId);
+          }
+        })
+        .catch(() => {})
+        .finally(() => navigate(routePaths.systemStart, { replace: true }));
+    } catch (err: unknown) {
+      const status = (err as { response?: { status?: number } })?.response?.status;
+      if (status === 403) {
+        toast.error('초대 코드가 올바르지 않습니다.');
+      } else if (status === 409) {
+        toast.error('이미 사용 중인 아이디입니다.');
+      } else {
+        toast.error('회원가입에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+      }
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+      <div className="space-y-1.5">
+        <Label htmlFor="reg-username">
+          아이디 <span className="text-destructive">*</span>
+        </Label>
+        <Input
+          id="reg-username"
+          placeholder="영문, 숫자, _ 조합 3~30자"
+          autoComplete="username"
+          aria-invalid={!!errors.username}
+          className="h-11"
+          {...register('username')}
+        />
+        {errors.username && <p className="text-xs text-destructive">{errors.username.message}</p>}
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="reg-password">
+          비밀번호 <span className="text-destructive">*</span>
+        </Label>
+        <div className="relative">
+          <Input
+            id="reg-password"
+            type={showPassword ? 'text' : 'password'}
+            placeholder="최소 6자 이상"
+            autoComplete="new-password"
+            aria-invalid={!!errors.password}
+            className="h-11 pr-10"
+            {...register('password')}
+          />
+          <button
+            type="button"
+            onClick={() => setShowPassword((v) => !v)}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            tabIndex={-1}
+          >
+            {showPassword ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+          </button>
+        </div>
+        {errors.password && <p className="text-xs text-destructive">{errors.password.message}</p>}
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-1.5">
+          <Label htmlFor="reg-name">
+            이름 <span className="text-destructive">*</span>
+          </Label>
+          <Input
+            id="reg-name"
+            placeholder="실명"
+            autoComplete="name"
+            aria-invalid={!!errors.name}
+            className="h-11"
+            {...register('name')}
+          />
+          {errors.name && <p className="text-xs text-destructive">{errors.name.message}</p>}
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="reg-invite-code">
+            초대 코드 <span className="text-destructive">*</span>
+          </Label>
+          <Input
+            id="reg-invite-code"
+            placeholder="초대 코드"
+            aria-invalid={!!errors.inviteCode}
+            className="h-11"
+            {...register('inviteCode')}
+          />
+          {errors.inviteCode && (
+            <p className="text-xs text-destructive">{errors.inviteCode.message}</p>
+          )}
+        </div>
+      </div>
+
+      <Button
+        type="submit"
+        className="h-11 w-full bg-baro-blue text-white hover:bg-baro-blue/90"
+        disabled={isSubmitting}
+      >
+        <UserPlus className="size-4" />
+        {isSubmitting ? '가입 중...' : '회원가입'}
+      </Button>
+    </form>
+  );
+};
+
+export default RegisterForm;

--- a/src/features/auth/types/auth.api.types.ts
+++ b/src/features/auth/types/auth.api.types.ts
@@ -3,3 +3,21 @@ export interface KakaoLoginResponse {
   refreshToken: string;
   registered: boolean;
 }
+
+export interface CredentialLoginRequest {
+  username: string;
+  password: string;
+}
+
+export interface RegisterRequest {
+  username: string;
+  password: string;
+  name: string;
+  inviteCode: string;
+}
+
+export interface CredentialAuthResponse {
+  accessToken: string;
+  refreshToken: string;
+  isNewUser: boolean;
+}

--- a/src/features/closing/components/ClosingInventoryDeductionSection.tsx
+++ b/src/features/closing/components/ClosingInventoryDeductionSection.tsx
@@ -35,87 +35,95 @@ const ClosingInventoryDeductionSection = ({
         </div>
       </CardHeader>
       <CardContent className="p-0">
-        <div className="hidden md:grid grid-cols-[2fr_1fr_1fr_1fr_1fr] gap-4 px-5 py-2.5 bg-muted/40 border-t border-b text-xs font-semibold text-muted-foreground uppercase tracking-wide">
-          <span>식자재명</span>
-          <span className="text-right">현재 재고</span>
-          <span className="text-right">이론 사용량</span>
-          <span className="text-center">실제 사용량</span>
-          <span className="text-right">차감 후 재고</span>
-        </div>
-        <div className="divide-y">
-          {rows.map((row) => {
-            const remaining = row.currentStock - row.actualUsage;
-            const isNegative = remaining < 0;
+        {rows.length === 0 ? (
+          <div className="flex items-center justify-center min-h-24 text-sm text-muted-foreground">
+            차감할 재고 항목이 없어요.
+          </div>
+        ) : (
+          <>
+            <div className="hidden md:grid grid-cols-[2fr_1fr_1fr_1fr_1fr] gap-4 px-5 py-2.5 bg-muted/40 border-t border-b text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+              <span>식자재명</span>
+              <span className="text-right">현재 재고</span>
+              <span className="text-right">이론 사용량</span>
+              <span className="text-center">실제 사용량</span>
+              <span className="text-right">차감 후 재고</span>
+            </div>
+            <div className="divide-y">
+              {rows.map((row) => {
+                const remaining = row.currentStock - row.actualUsage;
+                const isNegative = remaining < 0;
 
-            return (
-              <div
-                key={row.ingredientId}
-                className="grid grid-cols-2 md:grid-cols-[2fr_1fr_1fr_1fr_1fr] gap-3 md:gap-4 px-5 py-4 hover:bg-muted/20 transition-colors"
-              >
-                {/* 식자재명 */}
-                <div className="col-span-2 md:col-span-1">
-                  <span className="text-sm font-medium">{row.ingredientName}</span>
-                  <span className="ml-1.5 text-xs text-muted-foreground">({row.unit})</span>
-                </div>
-
-                {/* 현재 재고 */}
-                <div className="flex justify-between md:contents">
-                  <span className="text-xs text-muted-foreground md:hidden self-center">
-                    현재 재고
-                  </span>
-                  <span className="text-sm text-muted-foreground md:text-right self-center">
-                    {row.currentStock.toLocaleString()}
-                    {row.unit}
-                  </span>
-                </div>
-
-                {/* 이론 사용량 */}
-                <div className="flex justify-between md:contents">
-                  <span className="text-xs text-muted-foreground md:hidden self-center">
-                    이론 사용량
-                  </span>
-                  <span className="text-sm text-muted-foreground md:text-right self-center">
-                    {row.theoreticalUsage.toLocaleString()}
-                    {row.unit}
-                  </span>
-                </div>
-
-                {/* 실제 사용량 (편집 가능) */}
-                <div className="flex justify-between md:contents items-center">
-                  <span className="text-xs text-muted-foreground md:hidden">실제 사용량</span>
-                  <div className="flex items-center gap-1 md:justify-center">
-                    <Input
-                      type="number"
-                      min={0}
-                      value={row.actualUsage}
-                      onChange={(e) =>
-                        onChange(row.ingredientId, Math.max(0, Number(e.target.value)))
-                      }
-                      className="h-8 w-24 text-sm text-center"
-                    />
-                    <span className="text-xs text-muted-foreground">{row.unit}</span>
-                  </div>
-                </div>
-
-                {/* 차감 후 재고 */}
-                <div className="flex justify-between md:contents items-center">
-                  <span className="text-xs text-muted-foreground md:hidden">차감 후 재고</span>
-                  <span
-                    className={`text-sm font-semibold md:text-right ${
-                      isNegative ? 'text-baro-red' : 'text-foreground'
-                    }`}
+                return (
+                  <div
+                    key={row.ingredientId}
+                    className="grid grid-cols-2 md:grid-cols-[2fr_1fr_1fr_1fr_1fr] gap-3 md:gap-4 px-5 py-4 hover:bg-muted/20 transition-colors"
                   >
-                    {remaining.toLocaleString()}
-                    {row.unit}
-                    {isNegative && (
-                      <span className="ml-1 text-xs font-normal text-baro-red">(부족)</span>
-                    )}
-                  </span>
-                </div>
-              </div>
-            );
-          })}
-        </div>
+                    {/* 식자재명 */}
+                    <div className="col-span-2 md:col-span-1">
+                      <span className="text-sm font-medium">{row.ingredientName}</span>
+                      <span className="ml-1.5 text-xs text-muted-foreground">({row.unit})</span>
+                    </div>
+
+                    {/* 현재 재고 */}
+                    <div className="flex justify-between md:contents">
+                      <span className="text-xs text-muted-foreground md:hidden self-center">
+                        현재 재고
+                      </span>
+                      <span className="text-sm text-muted-foreground md:text-right self-center">
+                        {row.currentStock.toLocaleString()}
+                        {row.unit}
+                      </span>
+                    </div>
+
+                    {/* 이론 사용량 */}
+                    <div className="flex justify-between md:contents">
+                      <span className="text-xs text-muted-foreground md:hidden self-center">
+                        이론 사용량
+                      </span>
+                      <span className="text-sm text-muted-foreground md:text-right self-center">
+                        {row.theoreticalUsage.toLocaleString()}
+                        {row.unit}
+                      </span>
+                    </div>
+
+                    {/* 실제 사용량 (편집 가능) */}
+                    <div className="flex justify-between md:contents items-center">
+                      <span className="text-xs text-muted-foreground md:hidden">실제 사용량</span>
+                      <div className="flex items-center gap-1 md:justify-center">
+                        <Input
+                          type="number"
+                          min={0}
+                          value={row.actualUsage}
+                          onChange={(e) =>
+                            onChange(row.ingredientId, Math.max(0, Number(e.target.value)))
+                          }
+                          className="h-8 w-24 text-sm text-center"
+                        />
+                        <span className="text-xs text-muted-foreground">{row.unit}</span>
+                      </div>
+                    </div>
+
+                    {/* 차감 후 재고 */}
+                    <div className="flex justify-between md:contents items-center">
+                      <span className="text-xs text-muted-foreground md:hidden">차감 후 재고</span>
+                      <span
+                        className={`text-sm font-semibold md:text-right ${
+                          isNegative ? 'text-baro-red' : 'text-foreground'
+                        }`}
+                      >
+                        {remaining.toLocaleString()}
+                        {row.unit}
+                        {isNegative && (
+                          <span className="ml-1 text-xs font-normal text-baro-red">(부족)</span>
+                        )}
+                      </span>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/features/closing/components/ClosingSoldMenusSection.tsx
+++ b/src/features/closing/components/ClosingSoldMenusSection.tsx
@@ -20,38 +20,48 @@ const ClosingSoldMenusSection = ({ menus }: ClosingSoldMenusSectionProps) => {
         </CardTitle>
       </CardHeader>
       <CardContent className="p-0">
-        <div className="hidden md:grid grid-cols-[2fr_1fr_1fr_1fr] gap-4 px-5 py-2.5 bg-muted/40 border-t border-b text-xs font-semibold text-muted-foreground uppercase tracking-wide">
-          <span>메뉴명</span>
-          <span className="text-right">단가</span>
-          <span className="text-right">수량</span>
-          <span className="text-right">소계</span>
-        </div>
-        <div className="divide-y">
-          {menus.map((menu) => (
-            <div
-              key={menu.menuId}
-              className="grid grid-cols-2 md:grid-cols-[2fr_1fr_1fr_1fr] gap-2 md:gap-4 px-5 py-3.5 hover:bg-muted/20 transition-colors"
-            >
-              <span className="text-sm font-medium col-span-2 md:col-span-1">{menu.menuName}</span>
-              <div className="flex justify-between md:contents">
-                <span className="text-xs text-muted-foreground md:hidden">단가</span>
-                <span className="text-sm text-muted-foreground md:text-right">
-                  {formatCurrency(menu.unitPrice)}
-                </span>
-              </div>
-              <div className="flex justify-between md:contents">
-                <span className="text-xs text-muted-foreground md:hidden">수량</span>
-                <span className="text-sm font-medium md:text-right">{menu.quantity}개</span>
-              </div>
-              <div className="flex justify-between md:contents">
-                <span className="text-xs text-muted-foreground md:hidden">소계</span>
-                <span className="text-sm font-semibold text-foreground md:text-right">
-                  {formatCurrency(menu.subtotal)}
-                </span>
-              </div>
+        {menus.length === 0 ? (
+          <div className="flex items-center justify-center min-h-24 text-sm text-muted-foreground">
+            오늘 판매된 메뉴가 없어요.
+          </div>
+        ) : (
+          <>
+            <div className="hidden md:grid grid-cols-[2fr_1fr_1fr_1fr] gap-4 px-5 py-2.5 bg-muted/40 border-t border-b text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+              <span>메뉴명</span>
+              <span className="text-right">단가</span>
+              <span className="text-right">수량</span>
+              <span className="text-right">소계</span>
             </div>
-          ))}
-        </div>
+            <div className="divide-y">
+              {menus.map((menu) => (
+                <div
+                  key={menu.menuId}
+                  className="grid grid-cols-2 md:grid-cols-[2fr_1fr_1fr_1fr] gap-2 md:gap-4 px-5 py-3.5 hover:bg-muted/20 transition-colors"
+                >
+                  <span className="text-sm font-medium col-span-2 md:col-span-1">
+                    {menu.menuName}
+                  </span>
+                  <div className="flex justify-between md:contents">
+                    <span className="text-xs text-muted-foreground md:hidden">단가</span>
+                    <span className="text-sm text-muted-foreground md:text-right">
+                      {formatCurrency(menu.unitPrice)}
+                    </span>
+                  </div>
+                  <div className="flex justify-between md:contents">
+                    <span className="text-xs text-muted-foreground md:hidden">수량</span>
+                    <span className="text-sm font-medium md:text-right">{menu.quantity}개</span>
+                  </div>
+                  <div className="flex justify-between md:contents">
+                    <span className="text-xs text-muted-foreground md:hidden">소계</span>
+                    <span className="text-sm font-semibold text-foreground md:text-right">
+                      {formatCurrency(menu.subtotal)}
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/features/dashboard/components/SalesConsumptionCard.tsx
+++ b/src/features/dashboard/components/SalesConsumptionCard.tsx
@@ -10,9 +10,10 @@ interface SalesConsumptionCardProps {
 /* ── SVG 도넛 차트 ── */
 interface DonutChartProps {
   salesRatio: number; // 매출 / (매출 + 소비), 0 ~ 1
+  hasData: boolean;
 }
 
-const DonutChart = ({ salesRatio }: DonutChartProps) => {
+const DonutChart = ({ salesRatio, hasData }: DonutChartProps) => {
   const r = 52;
   const cx = 70;
   const cy = 70;
@@ -20,21 +21,21 @@ const DonutChart = ({ salesRatio }: DonutChartProps) => {
   const C = 2 * Math.PI * r;
   const GAP = C * 0.015;
 
-  const ratio = Math.min(1, Math.max(0, salesRatio));
-  const hasBoth = ratio > 0 && ratio < 1;
-  // 초록 = 매출 아크
-  const salesArc = hasBoth ? C * ratio - GAP : C * ratio;
-  // 파랑 = 소비 아크
-  const consumptionArc = hasBoth ? C * (1 - ratio) - GAP : C * (1 - ratio);
-
   // 데이터 없으면 회색 원만 표시
-  if (salesRatio === 0.5 && salesArc === 0 && consumptionArc === 0) {
+  if (!hasData) {
     return (
       <svg viewBox="0 0 140 140" className="w-full h-full">
         <circle cx={cx} cy={cy} r={r} fill="none" stroke="#f3f4f6" strokeWidth={sw} />
       </svg>
     );
   }
+
+  const ratio = Math.min(1, Math.max(0, salesRatio));
+  const hasBoth = ratio > 0 && ratio < 1;
+  // 초록 = 매출 아크
+  const salesArc = hasBoth ? C * ratio - GAP : C * ratio;
+  // 파랑 = 소비 아크
+  const consumptionArc = hasBoth ? C * (1 - ratio) - GAP : C * (1 - ratio);
 
   return (
     <svg viewBox="0 0 140 140" className="w-full h-full drop-shadow-md">
@@ -102,7 +103,7 @@ const SalesConsumptionCard = ({ data }: SalesConsumptionCardProps) => {
       <CardContent className="flex-1 flex items-center gap-5 px-4 py-3">
         {/* 도넛 차트 */}
         <div className="relative w-28 h-28 shrink-0">
-          <DonutChart salesRatio={salesRatio} />
+          <DonutChart salesRatio={salesRatio} hasData={total > 0} />
           <div className="absolute inset-0 flex items-center justify-center">
             <p className="text-xs text-muted-foreground">{latest.month}</p>
           </div>
@@ -118,7 +119,7 @@ const SalesConsumptionCard = ({ data }: SalesConsumptionCardProps) => {
             </div>
             <div className="flex items-center gap-1.5">
               <span className="text-xs text-muted-foreground">
-                {((1 - consumptionRatio) * 100).toFixed(1)}%
+                {(total > 0 ? (1 - consumptionRatio) * 100 : 0).toFixed(1)}%
               </span>
               <span className="text-sm font-bold">{(latest.sales / 10000).toFixed(0)}만원</span>
             </div>

--- a/src/features/order-guide/components/OrderGuideList.tsx
+++ b/src/features/order-guide/components/OrderGuideList.tsx
@@ -1,12 +1,21 @@
 import { useState } from 'react';
 
-import { AlertTriangle, CalendarDays, Clock, Package, ShoppingCart, Siren } from 'lucide-react';
+import {
+  AlertTriangle,
+  CalendarDays,
+  Clock,
+  ClipboardList,
+  Package,
+  ShoppingCart,
+  Siren,
+} from 'lucide-react';
 
 import type { OrderGuideItem, UrgencyLevel } from '@/features/order-guide/types/orderGuide.types';
 import { Card, CardContent, CardHeader, CardTitle } from '@/shadcn/ui/card';
 
 interface OrderGuideListProps {
   items: OrderGuideItem[];
+  generatedAt?: string | null;
 }
 
 type FilterTab = 'all' | UrgencyLevel;
@@ -47,7 +56,7 @@ const URGENCY_CONFIG: Record<
 
 const formatStock = (qty: number, unit: string) => `${qty.toLocaleString()} ${unit}`;
 
-const OrderGuideList = ({ items }: OrderGuideListProps) => {
+const OrderGuideList = ({ items, generatedAt }: OrderGuideListProps) => {
   const [activeTab, setActiveTab] = useState<FilterTab>('all');
 
   const filteredItems =
@@ -112,8 +121,18 @@ const OrderGuideList = ({ items }: OrderGuideListProps) => {
       {/* 스크롤 영역 */}
       <CardContent className="p-0 flex-1 min-h-0 overflow-y-auto flex flex-col">
         {filteredItems.length === 0 ? (
-          <div className="flex-1 flex items-center justify-center py-16 text-sm text-muted-foreground">
-            해당 조건의 발주 항목이 없어요.
+          <div className="flex-1 flex flex-col items-center justify-center py-16 text-center">
+            {generatedAt === null ? (
+              <>
+                <ClipboardList className="w-8 h-8 text-muted-foreground mb-3" />
+                <p className="text-sm font-medium text-foreground">아직 발주 가이드가 없어요</p>
+                <p className="text-xs text-muted-foreground mt-1">
+                  마감을 완료하면 AI가 자동으로 발주 가이드를 생성해 드려요.
+                </p>
+              </>
+            ) : (
+              <span className="text-sm text-muted-foreground">해당 조건의 발주 항목이 없어요.</span>
+            )}
           </div>
         ) : (
           <>

--- a/src/features/store-settings/components/StoreSettingsContent.tsx
+++ b/src/features/store-settings/components/StoreSettingsContent.tsx
@@ -5,7 +5,7 @@ import StoreOperationSection from '@/features/store-settings/components/sections
 
 const StoreSettingsContent = () => {
   return (
-    <div className="space-y-5 p-6">
+    <div className="space-y-5 p-4">
       <div>
         <p className="text-sm font-semibold leading-tight">가게 설정</p>
         <p className="text-xs text-muted-foreground">가게 정보 및 운영 데이터를 관리합니다.</p>

--- a/src/pages/ClosingOrderGuidePage.tsx
+++ b/src/pages/ClosingOrderGuidePage.tsx
@@ -43,7 +43,7 @@ const ClosingOrderGuidePage = () => {
       </div>
 
       {/* 콘텐츠 */}
-      <div className="flex flex-col flex-1 p-6 min-h-0">
+      <div className="flex flex-col flex-1 p-4 min-h-0">
         {!stateItems && isLoading ? (
           <div className="flex flex-col gap-4">
             <Skeleton className="h-12 w-full rounded-xl" />

--- a/src/pages/ClosingPage.tsx
+++ b/src/pages/ClosingPage.tsx
@@ -110,7 +110,7 @@ const ClosingPage = () => {
 
   if (isLoading) {
     return (
-      <div className="flex flex-col gap-6 p-6">
+      <div className="flex flex-col gap-4 p-4">
         <Skeleton className="h-10 w-64" />
         <Skeleton className="h-24 w-full rounded-xl" />
         <Skeleton className="h-64 w-full rounded-xl" />
@@ -121,7 +121,7 @@ const ClosingPage = () => {
 
   if (isError || !preview) {
     return (
-      <div className="flex flex-col gap-6 p-6">
+      <div className="flex flex-col gap-4 p-4">
         <Card>
           <CardContent className="py-16 text-center">
             <p className="text-sm text-muted-foreground">
@@ -159,7 +159,7 @@ const ClosingPage = () => {
         )}
 
         {/* 스크롤 영역 */}
-        <div className="flex-1 overflow-y-auto flex flex-col gap-6 p-6">
+        <div className="flex-1 overflow-y-auto flex flex-col gap-4 p-4">
           {/* 총 매출 카드 */}
           <Card>
             <CardContent className="px-6 flex items-center justify-between">

--- a/src/pages/CredentialLoginPage.tsx
+++ b/src/pages/CredentialLoginPage.tsx
@@ -1,0 +1,25 @@
+import { useNavigate } from 'react-router-dom';
+
+import { routePaths } from '@/app/routes/routePaths';
+import CredentialLoginCard from '@/features/auth/components/CredentialLoginCard';
+import BackButton from '@/shared/components/BackButton';
+
+const CredentialLoginPage = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="relative flex min-h-screen items-center justify-center px-4">
+      <BackButton onClick={() => navigate(routePaths.login)} />
+
+      <div className="w-full max-w-md">
+        <CredentialLoginCard />
+
+        <p className="mt-6 pt-3 text-center text-xs text-muted-foreground">
+          © 2026 BARO. All rights reserved.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default CredentialLoginPage;

--- a/src/pages/InventoryPage.tsx
+++ b/src/pages/InventoryPage.tsx
@@ -2,7 +2,7 @@ import InventoryTable from '@/features/inventory/components/InventoryTable';
 
 const InventoryPage = () => {
   return (
-    <div className="flex flex-col h-full min-h-0 overflow-hidden p-6">
+    <div className="flex flex-col h-full min-h-0 overflow-hidden p-4">
       <InventoryTable />
     </div>
   );

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
 import { routePaths } from '@/app/routes/routePaths';
 import { getKakaoLoginUrl } from '@/features/auth/api/authApi';
@@ -13,20 +13,21 @@ const LoginPage = () => {
     window.location.href = getKakaoLoginUrl(callbackUrl);
   };
 
-  const handleGoBackClick = () => {
-    navigate(routePaths.landing);
-  };
-
   return (
     <div className="relative flex min-h-screen items-center justify-center px-4">
-      <BackButton onClick={handleGoBackClick} />
+      <BackButton onClick={() => navigate(routePaths.landing)} />
 
       <div className="w-full max-w-md">
         <LoginCard onKakaoLoginClick={handleKakaoLoginClick} />
 
-        <p className="mt-6 pt-3 text-center text-xs text-muted-foreground">
-          © 2026 BARO. All rights reserved.
-        </p>
+        <div className="mt-4 flex justify-center">
+          <Link
+            to={routePaths.credentialLogin}
+            className="rounded-full border border-border px-5 py-2 text-xs text-muted-foreground transition-colors hover:border-foreground/30 hover:text-foreground"
+          >
+            빠른 데모 시연이 필요하신가요? →
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/OrderGuidePage.tsx
+++ b/src/pages/OrderGuidePage.tsx
@@ -1,4 +1,4 @@
-import { ClipboardList, Package } from 'lucide-react';
+import { Package } from 'lucide-react';
 
 import useAuthStore from '@/features/auth/store/authStore';
 import OrderGuideList from '@/features/order-guide/components/OrderGuideList';
@@ -12,7 +12,7 @@ const OrderGuidePage = () => {
 
   if (isLoading) {
     return (
-      <div className="flex flex-col gap-4 p-6">
+      <div className="flex flex-col gap-4 p-4">
         <Skeleton className="h-12 w-full rounded-xl" />
         <Skeleton className="h-96 w-full rounded-xl" />
       </div>
@@ -21,7 +21,7 @@ const OrderGuidePage = () => {
 
   if (isError || !data) {
     return (
-      <div className="p-6">
+      <div className="p-4">
         <Card>
           <CardContent className="py-16 text-center">
             <Package className="w-10 h-10 text-muted-foreground mx-auto mb-3" />
@@ -34,25 +34,9 @@ const OrderGuidePage = () => {
     );
   }
 
-  if (data.generatedAt === null) {
-    return (
-      <div className="p-6">
-        <Card>
-          <CardContent className="py-16 text-center">
-            <ClipboardList className="w-10 h-10 text-muted-foreground mx-auto mb-3" />
-            <p className="text-sm font-medium text-foreground">아직 발주 가이드가 없어요</p>
-            <p className="text-xs text-muted-foreground mt-1">
-              마감을 완료하면 AI가 자동으로 발주 가이드를 생성해 드려요.
-            </p>
-          </CardContent>
-        </Card>
-      </div>
-    );
-  }
-
   return (
-    <div className="flex flex-col h-full p-6">
-      <OrderGuideList items={data.items} />
+    <div className="flex flex-col h-full p-4">
+      <OrderGuideList items={data.items} generatedAt={data.generatedAt} />
     </div>
   );
 };

--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -1,0 +1,50 @@
+import { Link, useNavigate } from 'react-router-dom';
+
+import { routePaths } from '@/app/routes/routePaths';
+import RegisterForm from '@/features/auth/components/RegisterForm';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shadcn/ui/card';
+import baroLogo from '@/shared/assets/images/baro-logo.png';
+import BackButton from '@/shared/components/BackButton';
+
+const RegisterPage = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="relative flex min-h-screen items-center justify-center px-4">
+      <BackButton onClick={() => navigate(routePaths.login)} />
+
+      <div className="w-full max-w-md">
+        <Card className="rounded-3xl border-border/60 py-6">
+          <CardHeader className="text-center">
+            <div className="flex items-center justify-center gap-3 pr-4">
+              <img src={baroLogo} alt="BARO Logo" className="h-10 w-auto" />
+              <CardTitle className="text-3xl font-black tracking-tight">BARO 회원가입</CardTitle>
+            </div>
+
+            <CardDescription className="mt-3 text-sm leading-relaxed text-muted-foreground">
+              초대 코드가 있는 분만 가입할 수 있습니다.
+            </CardDescription>
+          </CardHeader>
+
+          <CardContent className="px-6">
+            <RegisterForm />
+
+            <div className="h-6" />
+            <p className="text-center text-xs text-muted-foreground">
+              이미 계정이 있으신가요?{' '}
+              <Link to={routePaths.login} className="font-semibold text-baro-blue hover:underline">
+                로그인
+              </Link>
+            </p>
+          </CardContent>
+        </Card>
+
+        <p className="mt-6 pt-3 text-center text-xs text-muted-foreground">
+          © 2026 BARO. All rights reserved.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default RegisterPage;

--- a/src/pages/SettingsIngredientsPage.tsx
+++ b/src/pages/SettingsIngredientsPage.tsx
@@ -160,7 +160,7 @@ const SettingsIngredientsPage = () => {
         </div>
       </header>
 
-      <div className="flex-1 overflow-y-auto p-6 space-y-2">
+      <div className="flex-1 overflow-y-auto p-4 space-y-2">
         {isLoading ? (
           Array.from({ length: 3 }).map((_, i) => (
             <Skeleton key={i} className="h-14 w-full rounded-xl" />

--- a/src/pages/SettingsMenuBoardPage.tsx
+++ b/src/pages/SettingsMenuBoardPage.tsx
@@ -111,7 +111,7 @@ const SettingsMenuBoardPage = () => {
         </Button>
       </header>
 
-      <div className="flex-1 overflow-y-auto p-6">
+      <div className="flex-1 overflow-y-auto p-4">
         <div className="overflow-hidden rounded-xl border bg-card">
           {isLoading ? (
             <div className="space-y-3 p-4">

--- a/src/pages/SettingsMenusPage.tsx
+++ b/src/pages/SettingsMenusPage.tsx
@@ -664,7 +664,7 @@ const SettingsMenusPage = () => {
         </div>
       </header>
 
-      <div className="flex-1 overflow-y-auto p-6">
+      <div className="flex-1 overflow-y-auto p-4">
         <CategorySection />
 
         {isLoading ? (

--- a/src/pages/SettingsRecipesPage.tsx
+++ b/src/pages/SettingsRecipesPage.tsx
@@ -320,7 +320,7 @@ const SettingsRecipesPage = () => {
         </div>
       </header>
 
-      <div className="flex-1 overflow-y-auto p-6 space-y-3">
+      <div className="flex-1 overflow-y-auto p-4 space-y-3">
         {isLoading ? (
           Array.from({ length: 2 }).map((_, i) => (
             <Skeleton key={i} className="h-24 w-full rounded-xl" />

--- a/src/pages/SystemStartPage.tsx
+++ b/src/pages/SystemStartPage.tsx
@@ -320,6 +320,7 @@ const SystemStartPage = () => {
             {/* 전날 마감 누락 알림 — already-open / normal 케이스 */}
             {!isLoading &&
               dashboardStats?.missedClosing &&
+              (history?.closings.length ?? 0) > 0 &&
               (currentCase === 'already-open' || currentCase === 'normal') && (
                 <Link
                   to={`/closing?date=${getYesterdayKST()}`}


### PR DESCRIPTION
## 📌 요약

- 데모 발표용 아이디/비밀번호 기반 로그인·회원가입 기능 추가
- 신규 사용자 마감 누락 경고 오표시 버그 수정
- 매출·소비 데이터 없을 때 도넛 차트 100% 표시 버그 수정
- 발주 가이드·마감 페이지 빈 상태 UI 개선 및 전체 페이지 패딩 통일

<br/>

## 🏷️ 관련 이슈

- Closes #129
- Closes #130
- Closes #131
- Closes #132

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- `POST /v1/auth/login`, `POST /v1/auth/register` 엔드포인트 연동 (`authApi.ts`)
- `/credential-login` — 아이디 로그인 페이지 신설 (Zod 폼 검증, 에러 처리 포함)
- `/register` — 회원가입 페이지 신설 (username·password·name·inviteCode 4개 필드)
- 기존 `/login` 카드 하단에 "빠른 데모 시연이 필요하신가요?" 아웃라인 버튼 추가

<br/>

### 📂 세부 변경사항

- **#130 버그**: `AppLayout`, `SystemStartPage`에 `closingHistory.closings.length > 0` 가드 추가 — 마감 이력 없는 신규 사용자에게 경고 미표시
- **#131 버그**: `SalesConsumptionCard` — `hasData` prop으로 데이터 없을 때 회색 원만 렌더, 매출% 계산에 `total > 0` 가드 추가
- **#132 UI**: 발주 가이드·마감(판매 메뉴·재고 차감) 섹션에 빈 상태 안내 문구 추가 (flex 수직 중앙 정렬)
- **#132 UI**: 전체 페이지 콘텐츠 영역 `p-6`/`gap-6` → `p-4`/`gap-4` 통일 (10개 파일)
- **#132 UI**: 아이디 로그인 카드에 BARO 로고 추가 (회원가입·카카오 로그인 페이지와 통일)

<br/>

## 📸 Screenshots

| Before | After |
| ------ | ----- |
| 도넛 차트 데이터 없을 때 매출 100% 표시 | 회색 빈 원 표시, 퍼센트 0.0% |
| 신규 사용자 마감 누락 경고 노출 | 마감 이력 없으면 경고 미표시 |
| 발주 가이드·마감 빈 목록 어색한 레이아웃 | 중앙 안내 문구 표시 |

<br/>

## 🧪 테스트 방법

1. `/credential-login` 접속 후 아이디/비밀번호 로그인 시도 (성공/실패 케이스)
2. `/register` 접속 후 4개 필드 입력 회원가입 (초대코드 오류·중복 아이디 케이스)
3. 신규 계정으로 로그인 후 대시보드 진입 — 마감 누락 경고 미표시 확인
4. 매출·소비 데이터 없는 상태에서 대시보드 — 도넛 차트 회색 원 확인
5. 발주 가이드 페이지 (가이드 없는 상태) — 빈 상태 안내 문구 확인
6. 마감 페이지 (판매 메뉴·재고 차감 없는 상태) — 빈 상태 안내 문구 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [x] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- `react-hook-form`, `@hookform/resolvers`, `zod` 패키지 신규 추가 (`pnpm add`)
- 아이디 로그인·회원가입은 데모 목적 전용이므로 기존 카카오 로그인 플로우에는 영향 없음
- 헤더/푸터 바의 `px-6 py-4`와 카드 내부 `px-6`은 변경 대상에서 제외
