### PR TITLE
💄 (#134) ui: 랜딩 페이지 UI 개선 및 신규 섹션 추가

### DIFF
--- a/src/features/landing/components/CTASection.tsx
+++ b/src/features/landing/components/CTASection.tsx
@@ -1,0 +1,46 @@
+import { useNavigate } from 'react-router-dom';
+
+import { routePaths } from '@/app/routes/routePaths';
+import { cn } from '@/lib/utils';
+import { Button } from '@/shadcn/ui/button';
+import { useScrollReveal } from '@/shared/hooks/useScrollReveal';
+
+const CTASection = () => {
+  const navigate = useNavigate();
+  const { ref, isVisible } = useScrollReveal();
+
+  return (
+    <section ref={ref} className="py-20 overflow-hidden mb-20">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8  ">
+        <div
+          className={cn(
+            'flex flex-col items-center text-center transition-[opacity,transform] duration-700',
+            isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8',
+          )}
+        >
+          <p className="text-baro-blue text-xs font-bold uppercase tracking-[0.2em] mb-6">
+            무료로 시작하기
+          </p>
+          <h2 className="text-2xl lg:text-4xl font-black text-baro-black dark:text-white leading-tight mb-4">
+            지금 바로,
+            <br />
+            <span className="text-baro-blue">BARO</span>와 함께 시작하세요
+          </h2>
+          <p className="text-baro-black-muted text-sm lg:text-base leading-relaxed mb-8">
+            설치 없이 바로 시작하고,
+            <br />
+            매일 반복되는 비효율에서 벗어나세요.
+          </p>
+          <Button
+            onClick={() => navigate(routePaths.login)}
+            className="mt-8 bg-baro-blue hover:bg-baro-blue/90 text-white font-bold p-4 py-5 rounded-full text-sm"
+          >
+            BARO 무료로 시작하기
+          </Button>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default CTASection;

--- a/src/features/landing/components/FeatureSection.tsx
+++ b/src/features/landing/components/FeatureSection.tsx
@@ -16,9 +16,7 @@ const FeatureSection = () => {
             isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10',
           )}
         >
-          <h2 className="text-3xl lg:text-5xl font-black text-baro-black mb-6">
-            스마트한 가게 운영의 시작
-          </h2>
+          <h2 className="text-3xl lg:text-5xl mb-6">스마트한 가게 운영의 시작</h2>
           <p className="text-baro-black-muted max-w-2xl text-lg">
             매일 반복되는 지루한 재고 관리 업무, <br className="block sm:hidden" />
             이제 BARO에게 맡기고 장사에만 집중하세요.

--- a/src/features/landing/components/HeroSection.tsx
+++ b/src/features/landing/components/HeroSection.tsx
@@ -104,13 +104,13 @@ const HeroSection = () => {
             )}
           >
             {/* Main Decorative Card */}
-            <div className="relative w-full z-10 p-7 rounded-[3rem] border border-baro-ivory-dark/30 dark:border-baro-black shadow-md backdrop-blur-sm group">
+            <div className="relative w-full z-10 p-7 rounded-[3rem] dark:bg-baro-black/20 border border-baro-ivory-dark/30 dark:border-baro-black shadow-md backdrop-blur-sm group">
               <div className="absolute top-0 right-0 w-32 h-32 bg-baro-blue/10 rounded-full blur-3xl -mr-16 -mt-16 group-hover:scale-150 transition-transform duration-700" />
 
               {/* Floating Items Container */}
               <div className="space-y-6 relative z-20">
                 {/* Visual Item 1 */}
-                <div className="p-5 rounded-2xl shadow-md border border-baro-ivory-dark dark:border-baro-black flex items-center gap-4 transform transition-transform hover:-translate-y-2 relative z-10">
+                <div className="p-5 rounded-2xl shadow-md dark:bg-baro-black-muted/10 border border-baro-ivory-dark dark:border-baro-black flex items-center gap-4 transform transition-transform hover:-translate-y-2 relative z-10">
                   <div className="w-12 h-12 bg-baro-blue/10 rounded-xl flex items-center justify-center text-baro-blue font-black text-[10px] uppercase">
                     OCR
                   </div>
@@ -136,8 +136,8 @@ const HeroSection = () => {
                 </div>
 
                 {/* Visual Item 3 */}
-                <div className="p-5 rounded-2xl shadow-md border border-baro-ivory-dark dark:border-baro-black flex items-center gap-4 transform transition-transform hover:-translate-y-2 relative z-10">
-                  <div className="w-12 h-12 bg-baro-ivory rounded-xl flex items-center justify-center text-baro-black">
+                <div className="p-5 rounded-2xl dark:bg-baro-black-muted/10 shadow-md border border-baro-ivory-dark dark:border-baro-black flex items-center gap-4 transform transition-transform hover:-translate-y-2 relative z-10">
+                  <div className="w-12 h-12 bg-baro-blue/10 rounded-xl flex items-center justify-center text-baro-blue">
                     <ClipboardCheck size={22} />
                   </div>
                   <div>

--- a/src/features/landing/components/HowItWorksSection.tsx
+++ b/src/features/landing/components/HowItWorksSection.tsx
@@ -1,0 +1,113 @@
+import { Package, QrCode, Bot, ClipboardCheck } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import { useScrollReveal } from '@/shared/hooks/useScrollReveal';
+
+const timeline = [
+  {
+    time: '오전 9:00',
+    icon: <Package size={20} />,
+    title: '거래명세서가 도착했어요',
+    description:
+      '카메라로 한 번 찍으면 15개 품목이 재고에 자동 등록됩니다. 손으로 옮겨 적는 건 이제 그만.',
+    color: 'bg-baro-green',
+  },
+  {
+    time: '오후 12:30',
+    icon: <QrCode size={20} />,
+    title: '점심 주문이 쏟아져요',
+    description:
+      '손님이 QR을 스캔하면 주문이 실시간으로 들어옵니다. 사장님은 응대 대신 운영에만 집중하세요.',
+    color: 'bg-baro-blue',
+  },
+  {
+    time: '오후 5:00',
+    icon: <Bot size={20} />,
+    title: 'AI가 발주를 추천해요',
+    description:
+      '재고 데이터를 분석해 내일 필요한 품목과 적정 발주량을 알려줍니다. 이제 감으로 주문하지 않아도 돼요.',
+    color: 'bg-baro-red',
+  },
+  {
+    time: '오후 10:00',
+    icon: <ClipboardCheck size={20} />,
+    title: '마감, 1분이면 끝',
+    description: '당일 판매 메뉴 기반으로 재고가 자동 차감됩니다. 30분짜리 손계산은 이제 없어요.',
+    color: 'bg-baro-black dark:bg-neutral-600',
+  },
+];
+
+const HowItWorksSection = () => {
+  const { ref, isVisible } = useScrollReveal();
+
+  return (
+    <section id="how-it-works" ref={ref} className="py-28 overflow-hidden">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        {/* Header */}
+        <div
+          className={cn(
+            'text-center mb-20 transition-[opacity,transform] duration-700',
+            isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-6',
+          )}
+        >
+          <p className="text-baro-blue text-xs font-bold uppercase tracking-[0.2em] mb-4">
+            사장님의 하루
+          </p>
+          <h2 className="text-2xl lg:text-3xl font-black text-baro-black dark:text-white">
+            BARO와 함께하면
+            <br />
+            하루가 이렇게 달라져요
+          </h2>
+        </div>
+
+        {/* Timeline */}
+        <div className="flex justify-center">
+          <div className="relative w-full max-w-xl">
+            {/* Vertical line */}
+            <div className="absolute left-5.5 top-2 bottom-2 w-px bg-baro-black/10 dark:bg-white/10" />
+
+            <div className="flex flex-col gap-10">
+              {timeline.map((item, i) => (
+                <div
+                  key={i}
+                  className={cn(
+                    'flex gap-6 transition-[opacity,transform] duration-700',
+                    isVisible ? 'opacity-100 translate-x-0' : 'opacity-0 -translate-x-6',
+                  )}
+                  style={{ transitionDelay: isVisible ? `${i * 180}ms` : '0ms' }}
+                >
+                  {/* Dot */}
+                  <div className="shrink-0 z-10">
+                    <div
+                      className={cn(
+                        'w-11 h-11 rounded-full flex items-center justify-center text-white',
+                        item.color,
+                      )}
+                    >
+                      {item.icon}
+                    </div>
+                  </div>
+
+                  {/* Content */}
+                  <div className="pb-2">
+                    <span className="text-xs font-bold text-baro-black-muted dark:text-neutral-500 tracking-wider">
+                      {item.time}
+                    </span>
+                    <h3 className="text-lg font-black text-baro-black dark:text-white mt-1 mb-2">
+                      {item.title}
+                    </h3>
+                    <p className="text-sm text-baro-black-muted dark:text-neutral-400 leading-relaxed">
+                      {item.description}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default HowItWorksSection;

--- a/src/features/landing/components/Navbar.tsx
+++ b/src/features/landing/components/Navbar.tsx
@@ -33,7 +33,7 @@ const Navbar = () => {
   };
 
   return (
-    <nav className="fixed top-0 left-0 right-0 z-50 backdrop-blur-md border-b border-baro-ivory-dark dark:border-baro-black">
+    <nav className="fixed top-0 left-0 right-0 z-50 bg-white dark:bg-neutral-900 border-b border-baro-ivory-dark dark:border-baro-black">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           {/* Logo */}
@@ -44,6 +44,20 @@ const Navbar = () => {
 
           {/* Desktop Menu */}
           <div className="hidden md:flex items-center gap-8">
+            <a
+              href="#problem"
+              onClick={(e) => handleNavLinkClick(e, 'problem')}
+              className="text-sm font-medium text-baro-black-muted hover:text-baro-blue transition-colors"
+            >
+              서비스 배경
+            </a>
+            <a
+              href="#how-it-works"
+              onClick={(e) => handleNavLinkClick(e, 'how-it-works')}
+              className="text-sm font-medium text-baro-black-muted hover:text-baro-blue transition-colors"
+            >
+              사용흐름
+            </a>
             <a
               href="#features"
               onClick={(e) => handleNavLinkClick(e, 'features')}
@@ -75,6 +89,20 @@ const Navbar = () => {
       {isMenuOpen && (
         <div className="md:hidden border-b border-baro-ivory-dark dark:border-baro-black animate-in slide-in-from-top duration-300">
           <div className="px-4 pt-2 pb-6 space-y-2 text-center">
+            <a
+              href="#problem"
+              onClick={(e) => handleNavLinkClick(e, 'problem')}
+              className="block px-3 py-2 text-base font-medium text-baro-black-muted"
+            >
+              서비스 배경
+            </a>
+            <a
+              href="#how-it-works"
+              onClick={(e) => handleNavLinkClick(e, 'how-it-works')}
+              className="block px-3 py-2 text-base font-medium text-baro-black-muted"
+            >
+              사용흐름
+            </a>
             <a
               href="#features"
               onClick={(e) => handleNavLinkClick(e, 'features')}

--- a/src/features/landing/components/ProblemSection.tsx
+++ b/src/features/landing/components/ProblemSection.tsx
@@ -1,0 +1,161 @@
+import { cn } from '@/lib/utils';
+import { useScrollReveal } from '@/shared/hooks/useScrollReveal';
+
+type MessageItem = {
+  text: string;
+  delay: number;
+  hasTyping: boolean;
+};
+
+const leftMessages: MessageItem[] = [
+  {
+    text: '거래명세서 받을 때마다 손으로 다시 옮겨 적느라 너무 오래 걸려요.',
+    delay: 0,
+    hasTyping: true,
+  },
+  {
+    text: '발주량 감이 안 와요.',
+    delay: 500,
+    hasTyping: false,
+  },
+  {
+    text: '마감하고 재고 차감 계산하느라 매일 밤 30분씩 잡아먹혀요.',
+    delay: 900,
+    hasTyping: true,
+  },
+];
+
+const rightMessages: MessageItem[] = [
+  {
+    text: '직원한테 "이거 재고 얼마 남았어?" 물어보면 아무도 몰라요.',
+    delay: 200,
+    hasTyping: true,
+  },
+  {
+    text: '오늘 식재료 얼마나 썼는지 모르겠어요.',
+    delay: 700,
+    hasTyping: false,
+  },
+  {
+    text: '재고가 바닥난 걸 손님 앞에서 알았어요.',
+    delay: 1100,
+    hasTyping: true,
+  },
+];
+
+const TypingDots = () => (
+  <div className="inline-flex items-center gap-1 px-4 py-3">
+    {[0, 150, 300].map((d) => (
+      <span
+        key={d}
+        className="w-2 h-2 bg-white/80 rounded-full animate-bounce"
+        style={{ animationDelay: `${d}ms`, animationDuration: '1.2s' }}
+      />
+    ))}
+  </div>
+);
+
+const ChatBubble = ({
+  msg,
+  side,
+  isVisible,
+}: {
+  msg: MessageItem;
+  side: 'left' | 'right';
+  isVisible: boolean;
+}) => {
+  const isLeft = side === 'left';
+  const translate = isLeft ? 'opacity-0 -translate-x-6' : 'opacity-0 translate-x-6';
+  const visible = 'opacity-100 translate-x-0';
+
+  return (
+    <div className={cn('flex flex-col gap-1.5', isLeft ? 'items-start' : 'items-end')}>
+      {msg.hasTyping && (
+        <div
+          className={cn(
+            'transition-[opacity,transform] duration-500 bg-baro-blue rounded-2xl',
+            isLeft ? 'rounded-bl-sm' : 'rounded-br-sm',
+            isVisible ? visible : translate,
+          )}
+          style={{ transitionDelay: isVisible ? `${msg.delay}ms` : '0ms' }}
+        >
+          <TypingDots />
+        </div>
+      )}
+      <div
+        className={cn(
+          'transition-[opacity,transform] duration-500 bg-baro-blue text-white px-5 py-3.5 rounded-2xl text-sm font-medium leading-relaxed max-w-[260px] lg:max-w-[300px]',
+          isLeft ? 'rounded-tl-sm text-left' : 'rounded-tr-sm text-right',
+          isVisible ? visible : translate,
+        )}
+        style={{
+          transitionDelay: isVisible ? `${msg.delay + (msg.hasTyping ? 200 : 0)}ms` : '0ms',
+        }}
+      >
+        {msg.text}
+      </div>
+    </div>
+  );
+};
+
+const ProblemSection = () => {
+  const { ref, isVisible } = useScrollReveal();
+
+  return (
+    <section id="problem" ref={ref} className="py-28 overflow-hidden">
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+        {/* Header */}
+        <div
+          className={cn(
+            'text-center mb-20 transition-[opacity,transform] duration-700',
+            isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-6',
+          )}
+        >
+          <p className="text-baro-blue text-xs font-bold uppercase tracking-[0.2em] mb-4">
+            왜 만들었나요
+          </p>
+          <h3 className="text-2xl lg:text-3xl font-black text-baro-black dark:text-white leading-tight">
+            사장님들의 하루는
+            <br />
+            <span className="text-baro-blue">이런 불편함</span>의 연속이었습니다
+          </h3>
+        </div>
+
+        {/* Chat UI */}
+        <div className="grid grid-cols-2 gap-4 lg:gap-12 mb-24 max-w-3xl mx-auto">
+          <div className="flex flex-col gap-4">
+            {leftMessages.map((msg, i) => (
+              <ChatBubble key={i} msg={msg} side="left" isVisible={isVisible} />
+            ))}
+          </div>
+          <div className="flex flex-col gap-4 mt-10">
+            {rightMessages.map((msg, i) => (
+              <ChatBubble key={i} msg={msg} side="right" isVisible={isVisible} />
+            ))}
+          </div>
+        </div>
+
+        {/* Conclusion */}
+        <div
+          className={cn(
+            'flex flex-col items-center transition-[opacity,transform] duration-700',
+            isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-6',
+          )}
+          style={{ transitionDelay: isVisible ? '1400ms' : '0ms' }}
+        >
+          <div className="w-12 h-0.5 bg-baro-blue/40 mb-15" />
+          <h3 className="text-2xl lg:text-3xl font-black text-baro-black dark:text-white mb-5 text-center">
+            그래서 BARO가 탄생했습니다
+          </h3>
+          <p className="text-baro-black-muted dark:text-neutral-400 max-w-xl text-base leading-loose text-center">
+            거래명세서 수기 입력, 실시간 재고 파악 실패, 발주량 감 부재, 손계산 마감—
+            <br />
+            매일 반복되는 이 비효율을 없애기 위해 BARO를 만들었습니다.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default ProblemSection;

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,7 +1,10 @@
+import CTASection from '@/features/landing/components/CTASection';
 import FeatureSection from '@/features/landing/components/FeatureSection';
 import Footer from '@/features/landing/components/Footer';
 import HeroSection from '@/features/landing/components/HeroSection';
+import HowItWorksSection from '@/features/landing/components/HowItWorksSection';
 import Navbar from '@/features/landing/components/Navbar';
+import ProblemSection from '@/features/landing/components/ProblemSection';
 
 const LandingPage = () => {
   return (
@@ -9,8 +12,10 @@ const LandingPage = () => {
       <Navbar />
       <main>
         <HeroSection />
+        <ProblemSection />
+        <HowItWorksSection />
         <FeatureSection />
-        {/* Additional sections like Analytics or Testimonials can be added here */}
+        <CTASection />
       </main>
       <Footer />
     </div>


### PR DESCRIPTION
## 📌 요약

- 랜딩 페이지 Navbar 단색 배경 처리
- HeroSection 마감 카드 아이콘 색상 개선
- 서비스 탄생 배경 설명 섹션(ProblemSection) 추가
- 사장님의 하루 타임라인 섹션(HowItWorksSection) 추가
- 전환 유도 섹션(CTASection) 추가

<br/>

## 🏷️ 관련 이슈

- Closes #134

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- **ProblemSection**: 사장님들의 불편함을 채팅 버블 UI로 표현, 서비스 탄생 배경 설명
- **HowItWorksSection**: 오전 9시~오후 10시 사장님의 하루 타임라인으로 사용 흐름 스토리텔링
- **CTASection**: Footer 전 전환 유도 섹션

<br/>

### 📂 세부 변경사항

- Navbar: `backdrop-blur` 전용 → `bg-white dark:bg-neutral-900` 단색 배경
- HeroSection: 마감 카드 아이콘 `bg-baro-ivory` → `bg-baro-blue/10`
- Navbar: 서비스 배경·사용흐름·기능소개 링크 추가
- LandingPage: Hero → Problem → HowItWorks → Feature → CTA → Footer 순서 구성

<br/>

## 🧪 테스트 방법

1. 랜딩 페이지(`/`) 접속
2. 스크롤하며 각 섹션 애니메이션 확인
3. Navbar 링크 클릭 시 해당 섹션으로 스크롤 확인
4. 다크모드 전환 후 각 섹션 확인

<br/>

## 🚨 영향 범위

- [x] Frontend

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음