### PR TITLE
💄 (#136) ui: 메뉴판 OCR 등록 모달 UI 개선

### DIFF
--- a/src/features/store-settings/components/MenuOcrModal.tsx
+++ b/src/features/store-settings/components/MenuOcrModal.tsx
@@ -97,7 +97,7 @@ const MenuOcrModal = ({
 
   return (
     <Dialog open={open} onOpenChange={(v) => !v && handleClose()}>
-      <DialogContent className="max-w-2xl">
+      <DialogContent className="sm:max-w-3xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>{titleMap[step]}</DialogTitle>
         </DialogHeader>

--- a/src/features/store-settings/components/MenuOcrReviewStep.tsx
+++ b/src/features/store-settings/components/MenuOcrReviewStep.tsx
@@ -85,12 +85,7 @@ const MenuOcrReviewStep = ({
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-center justify-between">
-        <div>
-          <p className="text-sm font-semibold">인식 결과 확인</p>
-          <p className="text-xs text-muted-foreground mt-0.5">
-            내용을 확인하고 수정한 후 등록해주세요
-          </p>
-        </div>
+        <p className="text-xs text-muted-foreground">내용을 확인하고 수정한 후 등록해주세요</p>
         <button
           type="button"
           onClick={onReset}


### PR DESCRIPTION
## 📌 요약

- 메뉴판 OCR 등록 모달 너비가 좁아 인식 결과 데이터가 잘려 보이던 문제 수정
- 항목이 많을 때 모달이 화면 밖으로 넘치던 문제 수정
- 인식 결과 확인 단계에서 중복 노출되던 제목 제거

<br/>

## 🏷️ 관련 이슈

- Closes #136

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- `MenuOcrModal` 너비를 `sm:max-w-3xl`(768px)로 올바르게 적용 — 기존 `max-w-2xl`은 DialogContent 기본값 `sm:max-w-sm`에 묻혀 실제로 반영되지 않았음
- 모달에 `max-h-[90vh] overflow-y-auto` 추가 — 항목이 많아도 화면 영역 내에 모달 유지

<br/>

### 📂 세부 변경사항

- `MenuOcrReviewStep` 내부 "인식 결과 확인" 제목 제거 — DialogHeader와 중복 표시되던 텍스트

<br/>

## 📸 Screenshots

| Before | After |
| ------ | ----- |
| 모달 너비 약 384px, 메뉴명·설명 열 잘림 | 모달 너비 768px, 전체 데이터 가시성 확보 |

<br/>

## 🧪 테스트 방법

1. 설정 > 메뉴 관리 > **메뉴판으로 등록** 버튼 클릭
2. 메뉴판 이미지 업로드 후 인식 결과 확인 단계로 진입
3. 모달 너비가 넓어져 메뉴명·가격·설명 컬럼이 잘리지 않는지 확인
4. 항목이 10개 이상일 때 모달이 화면 밖으로 넘치지 않고 스크롤되는지 확인

<br/>

## 🚨 영향 범위

- [x] Frontend

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- `DialogContent`의 `sm:max-w-sm` 기본값과 충돌하는 `max-w-2xl`을 `sm:max-w-3xl`로 교체 — tailwind-merge가 동일 반응형 prefix끼리 충돌을 올바르게 해소함