### PR TITLE
✨ (#139) feat: OCR 검수 화면 단위 변환 factor 연동

### DIFF
--- a/src/features/ocr-inbound/api/ocr.api.ts
+++ b/src/features/ocr-inbound/api/ocr.api.ts
@@ -24,17 +24,28 @@ export async function uploadOcrImage(storeId: string, file: File): Promise<OcrUp
 
   return {
     metadata,
-    items: items.map((item, i) => ({
-      id: `ocr-${Date.now()}-${i}`,
-      name: item.name,
-      quantity: item.amount,
-      unit: item.unit,
-      unitPrice: item.unitPrice ?? null,
-      supplyPrice: item.supplyPrice ?? null,
-      expiryDate: null,
-      memo: item.memo ?? null,
-      isMatched: item.ingredientId !== null,
-      matchedInventoryId: item.ingredientId ?? undefined,
-    })),
+    items: items.map((item, i) => {
+      const isNonStandard = item.amount === null;
+      return {
+        id: `ocr-${Date.now()}-${i}`,
+        name: item.name,
+        quantity: item.amount ?? 0,
+        unit: item.unit ?? 'g',
+        unitPrice: item.unitPrice ?? null,
+        supplyPrice: item.supplyPrice ?? null,
+        expiryDate: null,
+        memo: item.memo ?? null,
+        isMatched: item.ingredientId !== null,
+        matchedInventoryId: item.ingredientId ?? undefined,
+        isWarning: item.is_warning,
+        warningReason: item.warningReason,
+        // 비표준 단위: 사용자가 변환 계수 직접 입력
+        ...(isNonStandard && {
+          purchaseUnit: item.purchaseUnit,
+          purchaseQuantity: item.purchaseAmount,
+          purchaseUnitPrice: item.unitPrice ?? undefined,
+        }),
+      };
+    }),
   };
 }

--- a/src/features/ocr-inbound/api/unitConversions.api.ts
+++ b/src/features/ocr-inbound/api/unitConversions.api.ts
@@ -1,0 +1,28 @@
+import type { UnitConversionDto } from '@/features/ocr-inbound/types/ocrInbound.api.types';
+import type { OcrUnit } from '@/features/ocr-inbound/types/ocrInbound.types';
+import axiosInstance from '@/shared/api/axiosInstance';
+
+export interface UnitConversionSaveDto {
+  ingredientId: string;
+  purchaseUnit: string;
+  baseUnit: OcrUnit;
+  factor: number;
+}
+
+export async function fetchUnitConversions(storeId: string): Promise<UnitConversionDto[]> {
+  const res = await axiosInstance.get<{ success: boolean; data: UnitConversionDto[] }>(
+    `/stores/${storeId}/unit-conversions`,
+  );
+  return res.data.data;
+}
+
+export async function saveUnitConversions(
+  storeId: string,
+  conversions: UnitConversionSaveDto[],
+): Promise<void> {
+  await axiosInstance.put(`/stores/${storeId}/unit-conversions`, conversions);
+}
+
+export async function deleteUnitConversion(storeId: string, conversionId: string): Promise<void> {
+  await axiosInstance.delete(`/stores/${storeId}/unit-conversions/${conversionId}`);
+}

--- a/src/features/ocr-inbound/components/OcrReviewStep.tsx
+++ b/src/features/ocr-inbound/components/OcrReviewStep.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 
 import {
+  AlertCircle,
   Building2,
   CalendarIcon,
   CheckCircle2,
@@ -10,6 +11,7 @@ import {
   Plus,
   RotateCcw,
   Trash2,
+  TriangleAlert,
   ZoomIn,
   ZoomOut,
 } from 'lucide-react';
@@ -28,6 +30,7 @@ import { Calendar } from '@/shadcn/ui/calendar';
 import { Input } from '@/shadcn/ui/input';
 import { Popover, PopoverContent, PopoverTrigger } from '@/shadcn/ui/popover';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/shadcn/ui/select';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/shadcn/ui/tooltip';
 import IngredientRegisterModal from '@/shared/components/IngredientRegisterModal';
 
 const UNITS: OcrUnit[] = ['g', 'ml', '개'];
@@ -114,6 +117,21 @@ const OcrReviewStep = ({
     onItemsChange(items.map((item) => (item.id === id ? { ...item, [field]: value } : item)));
   };
 
+  const handleFactorChange = (id: string, value: string) => {
+    const factor = value === '' ? undefined : Math.max(0, Number(value));
+    onItemsChange(
+      items.map((item) => {
+        if (item.id !== id || !item.purchaseUnit) return item;
+        const quantity =
+          factor !== undefined && item.purchaseQuantity !== undefined
+            ? item.purchaseQuantity * factor
+            : 0;
+        return { ...item, conversionFactor: factor, quantity };
+        // unitPrice는 state에 저장하지 않고 렌더 시 purchaseUnitPrice / factor로 계산
+      }),
+    );
+  };
+
   const handleDelete = (id: string) => {
     onItemsChange(items.filter((item) => item.id !== id));
   };
@@ -131,12 +149,18 @@ const OcrReviewStep = ({
         expiryDate: null,
         memo: null,
         isMatched: false,
+        isWarning: false,
+        warningReason: null,
       },
     ]);
   };
 
   const matchedCount = items.filter((i) => i.isMatched).length;
   const newCount = items.length - matchedCount;
+  const needsFactorCount = items.filter(
+    (i) => i.purchaseUnit && i.conversionFactor === undefined,
+  ).length;
+  const warningCount = items.filter((i) => i.isWarning).length;
 
   const metadataFields = metadata
     ? (
@@ -253,6 +277,17 @@ const OcrReviewStep = ({
                 신규 {newCount}개
               </span>
             )}
+            {needsFactorCount > 0 && (
+              <span className="text-xs bg-amber-50 text-amber-600 px-2 py-0.5 rounded-full border border-amber-200/60">
+                변환 필요 {needsFactorCount}개
+              </span>
+            )}
+            {warningCount > 0 && (
+              <span className="text-xs bg-red-50 text-red-600 px-2 py-0.5 rounded-full border border-red-200/60 flex items-center gap-1">
+                <TriangleAlert className="w-3 h-3" />
+                확인 필요 {warningCount}개
+              </span>
+            )}
           </div>
           <button
             onClick={onReset}
@@ -292,144 +327,230 @@ const OcrReviewStep = ({
         </div>
 
         <div className="flex-1 overflow-y-auto">
-          {items.map((item, index) => (
-            <div
-              key={item.id}
-              className={cn(
-                'grid grid-cols-[24px_2fr_1.2fr_80px_1fr_1.4fr_1fr_1.2fr_36px] gap-3 px-4 py-2.5 items-center border-b hover:bg-muted/10 transition-colors',
-                !item.isMatched && 'bg-green-50/20',
-              )}
-            >
-              <span className="text-xs text-muted-foreground/50 text-center">{index + 1}</span>
-              <Input
-                value={item.name}
-                onChange={(e) => handleChange(item.id, 'name', e.target.value)}
-                className="h-8 text-sm"
-                placeholder="식자재명"
-              />
-              <Input
-                type="number"
-                value={item.quantity || ''}
-                onChange={(e) => handleChange(item.id, 'quantity', Number(e.target.value))}
-                className="h-8 text-sm"
-                min={0}
-                placeholder="0"
-              />
-              {item.isMatched ? (
-                <span className="h-8 flex items-center px-3 rounded-md border bg-muted text-sm text-muted-foreground">
-                  {item.unit}
-                </span>
-              ) : (
-                <Select
-                  value={item.unit}
-                  onValueChange={(v) => handleChange(item.id, 'unit', v as OcrUnit)}
-                >
-                  <SelectTrigger className="h-8 text-sm">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {UNITS.map((u) => (
-                      <SelectItem key={u} value={u}>
-                        {u}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              )}
-              <Input
-                type="number"
-                value={item.unitPrice ?? ''}
-                onChange={(e) =>
-                  onItemsChange(
-                    items.map((i) =>
-                      i.id === item.id
-                        ? { ...i, unitPrice: e.target.value === '' ? null : Number(e.target.value) }
-                        : i,
-                    ),
-                  )
-                }
-                className="h-8 text-sm"
-                min={0}
-                placeholder="미입력"
-              />
-              <Popover>
-                <PopoverTrigger
+          <TooltipProvider>
+            {items.map((item, index) => (
+              <div key={item.id} className="border-b">
+                <div
                   className={cn(
-                    'h-8 w-full flex items-center gap-1.5 px-2.5 rounded-md border text-sm transition-colors hover:bg-muted/50',
-                    item.expiryDate ? 'text-foreground' : 'text-muted-foreground',
+                    'grid grid-cols-[24px_2fr_1.2fr_80px_1fr_1.4fr_1fr_1.2fr_36px] gap-3 px-4 py-2.5 items-center hover:bg-muted/10 transition-colors',
+                    item.isWarning && 'bg-red-50/40',
+                    !item.isWarning && !item.isMatched && 'bg-green-50/20',
+                    !item.isWarning &&
+                      item.purchaseUnit &&
+                      !item.conversionFactor &&
+                      'bg-amber-50/20',
                   )}
                 >
-                  <CalendarIcon className="w-3.5 h-3.5 shrink-0" />
-                  <span className="truncate">{item.expiryDate ?? '미입력'}</span>
-                </PopoverTrigger>
-                <PopoverContent className="w-auto p-0" align="start">
-                  <Calendar
-                    mode="single"
-                    selected={item.expiryDate ? new Date(item.expiryDate) : undefined}
-                    onSelect={(date) =>
-                      handleChange(
-                        item.id,
-                        'expiryDate',
-                        date ? date.toLocaleDateString('sv') : null,
-                      )
-                    }
+                  <div className="flex items-center justify-center">
+                    {item.isWarning ? (
+                      <Tooltip>
+                        <TooltipTrigger className="flex items-center justify-center cursor-default">
+                          <TriangleAlert className="w-3.5 h-3.5 text-red-500" />
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          {item.warningReason ?? '인식 결과가 불확실합니다. 내용을 확인해 주세요.'}
+                        </TooltipContent>
+                      </Tooltip>
+                    ) : (
+                      <span className="text-xs text-muted-foreground/50">{index + 1}</span>
+                    )}
+                  </div>
+                  <Input
+                    value={item.name}
+                    onChange={(e) => handleChange(item.id, 'name', e.target.value)}
+                    className="h-8 text-sm"
+                    placeholder="식자재명"
                   />
-                </PopoverContent>
-              </Popover>
-              <div className="flex items-center gap-1 justify-center flex-wrap">
-                {item.isMatched ? (
-                  <span className="inline-flex items-center gap-1 text-xs text-baro-blue bg-blue-50 px-2 py-0.5 rounded-full border border-blue-200/60 whitespace-nowrap">
-                    <CheckCircle2 className="w-3 h-3" />
-                    기존
+                  {item.purchaseUnit ? (
+                    <div className="h-8 flex items-center px-3 rounded-md border bg-muted text-sm text-muted-foreground tabular-nums">
+                      {item.quantity > 0 ? item.quantity.toLocaleString() : '—'}
+                    </div>
+                  ) : (
+                    <Input
+                      type="number"
+                      value={item.quantity || ''}
+                      onChange={(e) => handleChange(item.id, 'quantity', Number(e.target.value))}
+                      className="h-8 text-sm"
+                      min={0}
+                      placeholder="0"
+                    />
+                  )}
+                  {item.isMatched ? (
+                    <span className="h-8 flex items-center px-3 rounded-md border bg-muted text-sm text-muted-foreground">
+                      {item.unit}
+                    </span>
+                  ) : (
+                    <Select
+                      value={item.unit}
+                      onValueChange={(v) => handleChange(item.id, 'unit', v as OcrUnit)}
+                    >
+                      <SelectTrigger className="h-8 text-sm">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {UNITS.map((u) => (
+                          <SelectItem key={u} value={u}>
+                            {u}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  )}
+                  {(() => {
+                    const derivedUnitPrice =
+                      item.purchaseUnit &&
+                      item.conversionFactor !== undefined &&
+                      item.conversionFactor > 0 &&
+                      item.purchaseUnitPrice !== undefined
+                        ? Math.round((item.purchaseUnitPrice / item.conversionFactor) * 10) / 10
+                        : null;
+                    return (
+                      <Input
+                        type="number"
+                        value={derivedUnitPrice ?? item.unitPrice ?? ''}
+                        onChange={(e) => {
+                          if (derivedUnitPrice !== null) return; // factor 기반 항목은 단가 직접 수정 불가
+                          onItemsChange(
+                            items.map((i) =>
+                              i.id === item.id
+                                ? {
+                                    ...i,
+                                    unitPrice:
+                                      e.target.value === '' ? null : Number(e.target.value),
+                                  }
+                                : i,
+                            ),
+                          );
+                        }}
+                        readOnly={derivedUnitPrice !== null}
+                        className="h-8 text-sm"
+                        min={0}
+                        placeholder="미입력"
+                      />
+                    );
+                  })()}
+                  <Popover>
+                    <PopoverTrigger
+                      className={cn(
+                        'h-8 w-full flex items-center gap-1.5 px-2.5 rounded-md border text-sm transition-colors hover:bg-muted/50',
+                        item.expiryDate ? 'text-foreground' : 'text-muted-foreground',
+                      )}
+                    >
+                      <CalendarIcon className="w-3.5 h-3.5 shrink-0" />
+                      <span className="truncate">{item.expiryDate ?? '미입력'}</span>
+                    </PopoverTrigger>
+                    <PopoverContent className="w-auto p-0" align="start">
+                      <Calendar
+                        mode="single"
+                        selected={item.expiryDate ? new Date(item.expiryDate) : undefined}
+                        onSelect={(date) =>
+                          handleChange(
+                            item.id,
+                            'expiryDate',
+                            date ? date.toLocaleDateString('sv') : null,
+                          )
+                        }
+                      />
+                    </PopoverContent>
+                  </Popover>
+                  <div className="flex items-center gap-1 justify-center flex-wrap">
+                    {item.isMatched ? (
+                      <span className="inline-flex items-center gap-1 text-xs text-baro-blue bg-blue-50 px-2 py-0.5 rounded-full border border-blue-200/60 whitespace-nowrap">
+                        <CheckCircle2 className="w-3 h-3" />
+                        기존
+                      </span>
+                    ) : (
+                      <>
+                        <button
+                          onClick={() =>
+                            setRegisterModal({
+                              open: true,
+                              itemId: item.id,
+                              name: item.name,
+                              unit: item.unit,
+                            })
+                          }
+                          className="inline-flex items-center gap-0.5 text-xs text-baro-green bg-green-50 hover:bg-green-100 px-1.5 py-0.5 rounded-full border border-green-200/60 whitespace-nowrap transition-colors cursor-pointer"
+                        >
+                          <Plus className="w-3 h-3" />
+                          신규
+                        </button>
+                        <button
+                          onClick={() =>
+                            setLinkModal({ open: true, itemId: item.id, name: item.name })
+                          }
+                          className="inline-flex items-center gap-0.5 text-xs text-baro-blue bg-blue-50 hover:bg-blue-100 px-1.5 py-0.5 rounded-full border border-blue-200/60 whitespace-nowrap transition-colors cursor-pointer"
+                        >
+                          <Link className="w-3 h-3" />
+                          연결
+                        </button>
+                      </>
+                    )}
+                  </div>
+                  <span className="text-xs text-muted-foreground truncate" title={item.memo ?? ''}>
+                    {item.memo ?? '—'}
                   </span>
-                ) : (
-                  <>
-                    <button
-                      onClick={() =>
-                        setRegisterModal({
-                          open: true,
-                          itemId: item.id,
-                          name: item.name,
-                          unit: item.unit,
-                        })
-                      }
-                      className="inline-flex items-center gap-0.5 text-xs text-baro-green bg-green-50 hover:bg-green-100 px-1.5 py-0.5 rounded-full border border-green-200/60 whitespace-nowrap transition-colors cursor-pointer"
-                    >
-                      <Plus className="w-3 h-3" />
-                      신규
-                    </button>
-                    <button
-                      onClick={() => setLinkModal({ open: true, itemId: item.id, name: item.name })}
-                      className="inline-flex items-center gap-0.5 text-xs text-baro-blue bg-blue-50 hover:bg-blue-100 px-1.5 py-0.5 rounded-full border border-blue-200/60 whitespace-nowrap transition-colors cursor-pointer"
-                    >
-                      <Link className="w-3 h-3" />
-                      연결
-                    </button>
-                  </>
+                  <button
+                    onClick={() => handleDelete(item.id)}
+                    className="flex items-center justify-center w-8 h-8 rounded-md text-muted-foreground hover:text-baro-red hover:bg-red-50 transition-colors"
+                    aria-label="항목 삭제"
+                  >
+                    <Trash2 className="w-3.5 h-3.5" />
+                  </button>
+                </div>
+
+                {/* 비표준 단위 변환 계수 입력 행 */}
+                {item.purchaseUnit && (
+                  <div className="flex items-center gap-2 px-4 py-2 bg-amber-50/60 text-xs">
+                    <AlertCircle className="w-3.5 h-3.5 text-amber-500 shrink-0" />
+                    <span className="text-muted-foreground">명세서 원본:</span>
+                    <span className="font-medium text-foreground">
+                      {item.purchaseQuantity} {item.purchaseUnit}
+                    </span>
+                    <span className="text-muted-foreground">→ 1 {item.purchaseUnit} =</span>
+                    <Input
+                      type="number"
+                      value={item.conversionFactor ?? ''}
+                      onChange={(e) => handleFactorChange(item.id, e.target.value)}
+                      className="h-6 w-24 text-xs"
+                      min={0.001}
+                      step="any"
+                      placeholder="변환 계수"
+                    />
+                    <span className="text-muted-foreground">{item.unit}</span>
+                    {item.conversionFactor !== undefined && item.purchaseQuantity !== undefined && (
+                      <>
+                        <span className="text-amber-700 font-medium">
+                          → 합계 {(item.purchaseQuantity * item.conversionFactor).toLocaleString()}{' '}
+                          {item.unit}
+                        </span>
+                        {item.purchaseUnitPrice !== undefined && (
+                          <span className="ml-2 text-muted-foreground">
+                            (단가 {item.purchaseUnitPrice.toLocaleString()}원/{item.purchaseUnit}
+                            {' → '}
+                            {(
+                              Math.round((item.purchaseUnitPrice / item.conversionFactor) * 10) / 10
+                            ).toLocaleString()}
+                            원/{item.unit})
+                          </span>
+                        )}
+                      </>
+                    )}
+                  </div>
                 )}
               </div>
-              <span className="text-xs text-muted-foreground truncate" title={item.memo ?? ''}>
-                {item.memo ?? '—'}
-              </span>
+            ))}
+
+            <div className="px-4 py-3">
               <button
-                onClick={() => handleDelete(item.id)}
-                className="flex items-center justify-center w-8 h-8 rounded-md text-muted-foreground hover:text-baro-red hover:bg-red-50 transition-colors"
-                aria-label="항목 삭제"
+                onClick={handleAdd}
+                className="w-full flex items-center justify-center gap-2 py-2.5 border-2 border-dashed rounded-lg text-sm text-muted-foreground hover:text-foreground hover:border-foreground/30 transition-colors"
               >
-                <Trash2 className="w-3.5 h-3.5" />
+                <Plus className="w-4 h-4" />
+                항목 직접 추가
               </button>
             </div>
-          ))}
-
-          <div className="px-4 py-3">
-            <button
-              onClick={handleAdd}
-              className="w-full flex items-center justify-center gap-2 py-2.5 border-2 border-dashed rounded-lg text-sm text-muted-foreground hover:text-foreground hover:border-foreground/30 transition-colors"
-            >
-              <Plus className="w-4 h-4" />
-              항목 직접 추가
-            </button>
-          </div>
+          </TooltipProvider>
         </div>
 
         <div className="border-t px-4 py-3 shrink-0 flex items-center justify-between bg-card">

--- a/src/features/ocr-inbound/hooks/useUnitConversions.ts
+++ b/src/features/ocr-inbound/hooks/useUnitConversions.ts
@@ -1,0 +1,69 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import useAuthStore from '@/features/auth/store/authStore';
+import {
+  deleteUnitConversion,
+  fetchUnitConversions,
+  saveUnitConversions,
+  type UnitConversionSaveDto,
+} from '@/features/ocr-inbound/api/unitConversions.api';
+import type { UnitConversionDto } from '@/features/ocr-inbound/types/ocrInbound.api.types';
+
+export type UnitConversionMap = Map<string, UnitConversionDto>;
+
+export interface UnitConversionData {
+  list: UnitConversionDto[];
+  map: UnitConversionMap;
+}
+
+export const makeConversionKey = (ingredientId: string, purchaseUnit: string) =>
+  `${ingredientId}:${purchaseUnit.toUpperCase()}`;
+
+export function useUnitConversions() {
+  const storeId = useAuthStore((s) => s.storeId);
+
+  return useQuery({
+    queryKey: ['unitConversions', storeId],
+    queryFn: async (): Promise<UnitConversionData> => {
+      if (!storeId) return { list: [], map: new Map() };
+      const list = await fetchUnitConversions(storeId);
+      const map: UnitConversionMap = new Map();
+      list.forEach((conv) => {
+        map.set(makeConversionKey(conv.ingredientId, conv.purchaseUnit), conv);
+      });
+      return { list, map };
+    },
+    enabled: !!storeId,
+    staleTime: Infinity,
+  });
+}
+
+export function useUpdateUnitConversion() {
+  const storeId = useAuthStore((s) => s.storeId);
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: (dto: UnitConversionSaveDto) => {
+      if (!storeId) throw new Error('storeId 없음');
+      return saveUnitConversions(storeId, [dto]);
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['unitConversions', storeId] });
+    },
+  });
+}
+
+export function useDeleteUnitConversion() {
+  const storeId = useAuthStore((s) => s.storeId);
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: (conversionId: string) => {
+      if (!storeId) throw new Error('storeId 없음');
+      return deleteUnitConversion(storeId, conversionId);
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['unitConversions', storeId] });
+    },
+  });
+}

--- a/src/features/ocr-inbound/types/ocrInbound.api.types.ts
+++ b/src/features/ocr-inbound/types/ocrInbound.api.types.ts
@@ -11,16 +11,28 @@ export interface OcrMetadata {
 
 export interface OcrApiItem {
   name: string;
-  amount: number;
-  unit: OcrUnit;
+  purchaseUnit: string; // 명세서 원본 단위 (KG, BOX, BTL 등)
+  purchaseAmount: number; // 명세서 원본 수량
+  amount: number | null; // 변환된 수량 (null = 비표준 단위, 변환 계수 필요)
+  unit: OcrUnit | null; // 변환된 기본 단위 (null = 비표준 단위)
   unitPrice: number | null;
   supplyPrice: number | null;
   memo: string | null;
   ingredientId: string | null;
+  is_warning: boolean;
+  warningReason: string | null;
 }
 
 export interface OcrApiResponse {
   metadata: OcrMetadata;
   items: OcrApiItem[];
   rawText: string;
+}
+
+export interface UnitConversionDto {
+  id: string;
+  ingredientId: string;
+  purchaseUnit: string;
+  baseUnit: OcrUnit;
+  factor: number;
 }

--- a/src/features/ocr-inbound/types/ocrInbound.types.ts
+++ b/src/features/ocr-inbound/types/ocrInbound.types.ts
@@ -12,6 +12,12 @@ export interface OcrInboundItem {
   isMatched: boolean;
   matchedInventoryId?: string;
   newIngredientId?: string;
+  isWarning: boolean;
+  warningReason: string | null;
+  purchaseUnit?: string; // 명세서 원본 단위 (BOX, BTL 등 비표준 단위일 때만 세팅)
+  purchaseQuantity?: number; // 명세서 원본 수량 (purchaseUnit과 함께 세팅)
+  purchaseUnitPrice?: number; // 명세서 원본 단가 (1 purchaseUnit당 가격, factor 변경 시 재계산 기준)
+  conversionFactor?: number; // 변환 계수: 1 purchaseUnit = conversionFactor baseUnit
 }
 
 export interface ExistingIngredient {

--- a/src/pages/OcrInboundPage.tsx
+++ b/src/pages/OcrInboundPage.tsx
@@ -9,8 +9,17 @@ import { toast } from 'sonner';
 import { routePaths } from '@/app/routes/routePaths';
 import useAuthStore from '@/features/auth/store/authStore';
 import { uploadOcrImage } from '@/features/ocr-inbound/api/ocr.api';
+import {
+  saveUnitConversions,
+  type UnitConversionSaveDto,
+} from '@/features/ocr-inbound/api/unitConversions.api';
 import OcrReviewStep from '@/features/ocr-inbound/components/OcrReviewStep';
 import OcrUploadStep from '@/features/ocr-inbound/components/OcrUploadStep';
+import {
+  makeConversionKey,
+  useUnitConversions,
+  type UnitConversionMap,
+} from '@/features/ocr-inbound/hooks/useUnitConversions';
 import type { OcrMetadata } from '@/features/ocr-inbound/types/ocrInbound.api.types';
 import type { OcrInboundItem } from '@/features/ocr-inbound/types/ocrInbound.types';
 import { confirmInbound } from '@/features/store-settings/api/ingredients.api';
@@ -54,18 +63,35 @@ const loadDraft = (): SessionDraft | null => {
   }
 };
 
+// 저장된 변환 계수를 items에 적용 (이미 계수가 있는 항목은 스킵)
+function applyStoredConversions(items: OcrInboundItem[], map: UnitConversionMap): OcrInboundItem[] {
+  return items.map((item) => {
+    if (!item.purchaseUnit || item.conversionFactor !== undefined || !item.matchedInventoryId)
+      return item;
+    const conv = map.get(makeConversionKey(item.matchedInventoryId, item.purchaseUnit));
+    if (!conv) return item;
+    return {
+      ...item,
+      unit: conv.baseUnit,
+      quantity: (item.purchaseQuantity ?? 0) * conv.factor,
+      conversionFactor: conv.factor,
+    };
+  });
+}
+
 const OcrInboundPage = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const storeId = useAuthStore((s) => s.storeId);
   const qc = useQueryClient();
   const { data: storeSettings } = useStoreSettings();
+  const { data: conversionData } = useUnitConversions();
+  const conversionMap = conversionData?.map;
   const safetyStockPct = storeSettings?.safetyStockPct ?? 0;
 
   const locationState = location.state as { file?: File } | null;
   const hasNewFile = !!locationState?.file;
 
-  // 새 파일이 없는 경우에만 sessionStorage에서 초기 상태 복원 (lazy 초기화로 setState-in-effect 회피)
   const [{ initialImageBase64, initialStep, initialItems, initialMetadata }] = useState(() => {
     if (hasNewFile) {
       return {
@@ -99,12 +125,32 @@ const OcrInboundPage = () => {
   const [metadata, setMetadata] = useState<OcrMetadata | null>(initialMetadata);
   const [isConfirming, setIsConfirming] = useState(false);
   const handledInitialFile = useRef(false);
+  const conversionApplied = useRef(false);
 
   // 검수 중 아이템·메타데이터 변경 시 sessionStorage 동기화
   useEffect(() => {
     if (step !== 'review' || !imageBase64) return;
     saveDraft({ imageBase64, metadata, items });
   }, [items, metadata, step, imageBase64]);
+
+  // 변환 계수 맵이 로드되면 비표준 단위 항목에 자동 채움 (1회만 실행)
+  useEffect(() => {
+    if (conversionApplied.current || !conversionMap || step !== 'review') return;
+    conversionApplied.current = true;
+    setItems((prev) => applyStoredConversions(prev, conversionMap));
+  }, [conversionMap, step]);
+
+  // onItemsChange: items 변경 시 연결된 항목에 저장된 변환 계수 자동 채움
+  const handleItemsChange = useCallback(
+    (newItems: OcrInboundItem[]) => {
+      if (!conversionMap) {
+        setItems(newItems);
+        return;
+      }
+      setItems(applyStoredConversions(newItems, conversionMap));
+    },
+    [conversionMap],
+  );
 
   const handleFileSelect = useCallback(
     async (file: File) => {
@@ -120,11 +166,15 @@ const OcrInboundPage = () => {
           uploadOcrImage(storeId, file),
           fileToBase64(file),
         ]);
+        const processedItems = conversionMap
+          ? applyStoredConversions(result.items, conversionMap)
+          : result.items;
+        conversionApplied.current = true;
         setImageBase64(base64);
         setMetadata(result.metadata);
-        setItems(result.items);
+        setItems(processedItems);
         setStep('review');
-        saveDraft({ imageBase64: base64, metadata: result.metadata, items: result.items });
+        saveDraft({ imageBase64: base64, metadata: result.metadata, items: processedItems });
       } catch (err) {
         const message =
           axios.isAxiosError(err) && err.response?.data?.error?.message
@@ -136,7 +186,7 @@ const OcrInboundPage = () => {
         setImageUrl(null);
       }
     },
-    [storeId],
+    [storeId, conversionMap],
   );
 
   useEffect(() => {
@@ -149,6 +199,7 @@ const OcrInboundPage = () => {
   const handleReset = () => {
     if (imageUrl?.startsWith('blob:')) URL.revokeObjectURL(imageUrl);
     clearDraft();
+    conversionApplied.current = false;
     setStep('upload');
     setImageUrl(null);
     setImageBase64(null);
@@ -164,23 +215,56 @@ const OcrInboundPage = () => {
       );
       return;
     }
+
+    const noFactor = items.filter(
+      (item) => item.purchaseUnit && item.conversionFactor === undefined,
+    );
+    if (noFactor.length > 0) {
+      toast.warning(
+        `단위 변환 계수가 입력되지 않은 항목이 ${noFactor.length}개 있습니다. 변환 계수를 입력해 주세요.`,
+      );
+      return;
+    }
+
     if (!storeId) return;
 
-    const inboundItems = items.map((item) => ({
-      ingredientId: (item.matchedInventoryId ?? item.newIngredientId)!,
-      amount: item.quantity,
-      unitPrice: item.unitPrice ?? null,
-      supplyPrice: item.supplyPrice ?? null,
-      expiryDate: item.expiryDate ?? null,
-      memo: item.memo ?? null,
-    }));
+    const inboundItems = items.map((item) => {
+      const effectiveUnitPrice =
+        item.purchaseUnit &&
+        item.conversionFactor !== undefined &&
+        item.conversionFactor > 0 &&
+        item.purchaseUnitPrice !== undefined
+          ? Math.round((item.purchaseUnitPrice / item.conversionFactor) * 10) / 10
+          : item.unitPrice;
+      return {
+        ingredientId: (item.matchedInventoryId ?? item.newIngredientId)!,
+        amount: item.quantity,
+        unitPrice: effectiveUnitPrice ?? null,
+        supplyPrice: item.supplyPrice ?? null,
+        expiryDate: item.expiryDate ?? null,
+        memo: item.memo ?? null,
+      };
+    });
+
+    // 새로 입력/수정된 변환 계수 수집
+    const conversionsToSave: UnitConversionSaveDto[] = items
+      .filter((item) => item.purchaseUnit && item.conversionFactor !== undefined)
+      .map((item) => ({
+        ingredientId: (item.matchedInventoryId ?? item.newIngredientId)!,
+        purchaseUnit: item.purchaseUnit!,
+        baseUnit: item.unit,
+        factor: item.conversionFactor!,
+      }));
 
     setIsConfirming(true);
     try {
+      if (conversionsToSave.length > 0) {
+        await saveUnitConversions(storeId, conversionsToSave);
+        qc.invalidateQueries({ queryKey: ['unitConversions', storeId] });
+      }
+
       await confirmInbound(storeId, inboundItems, metadata ?? undefined);
 
-      // 입고 완료 후 PATCH /stores/:storeId { safetyStockPct } 한 번으로
-      // 백엔드가 전체 식자재 안전재고를 현재 재고 기준으로 일괄 재계산
       if (safetyStockPct > 0) {
         try {
           await updateStoreSettings(storeId, { safetyStockPct });
@@ -194,7 +278,7 @@ const OcrInboundPage = () => {
       qc.invalidateQueries({ queryKey: ['ingredients', storeId] });
       qc.invalidateQueries({ queryKey: ['storeSettings', storeId] });
       toast.success('재고 등록이 완료되었습니다.');
-      navigate(routePaths.storeSettings);
+      navigate(routePaths.inventory);
     } catch {
       toast.error('입고 확정에 실패했습니다. 잠시 후 다시 시도해 주세요.');
     } finally {
@@ -251,7 +335,7 @@ const OcrInboundPage = () => {
             imageUrl={imageUrl}
             items={items}
             metadata={metadata}
-            onItemsChange={setItems}
+            onItemsChange={handleItemsChange}
             onConfirm={handleConfirm}
             onReset={handleReset}
             isConfirming={isConfirming}

--- a/src/shared/components/IngredientRegisterModal.tsx
+++ b/src/shared/components/IngredientRegisterModal.tsx
@@ -1,5 +1,14 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
+import { Trash2 } from 'lucide-react';
+import { toast } from 'sonner';
+
+import {
+  useDeleteUnitConversion,
+  useUnitConversions,
+  useUpdateUnitConversion,
+} from '@/features/ocr-inbound/hooks/useUnitConversions';
+import type { UnitConversionDto } from '@/features/ocr-inbound/types/ocrInbound.api.types';
 import {
   useCreateIngredient,
   useUpdateIngredient,
@@ -40,10 +49,30 @@ const IngredientRegisterModal = ({
 }: IngredientRegisterModalProps) => {
   const { mutate: createIngredient, isPending: isCreating } = useCreateIngredient();
   const { mutate: updateIngredient, isPending: isUpdating } = useUpdateIngredient();
+  const { data: conversionData } = useUnitConversions();
+  const { mutate: updateConversion, isPending: isUpdatingConv } = useUpdateUnitConversion();
+  const { mutate: deleteConversion, isPending: isDeletingConv } = useDeleteUnitConversion();
+
   const [form, setForm] = useState({ name: initialName, unit: initialUnit });
+  const [localFactors, setLocalFactors] = useState<Record<string, number>>({});
 
   const isEditMode = !!editingId;
   const isPending = isCreating || isUpdating;
+
+  const conversions: UnitConversionDto[] = editingId
+    ? (conversionData?.list.filter((c) => c.ingredientId === editingId) ?? [])
+    : [];
+
+  useEffect(() => {
+    if (!open) return;
+    const initial: Record<string, number> = {};
+    conversions.forEach((c) => {
+      initial[c.id] = c.factor;
+    });
+    // open될 때 서버 데이터로 로컬 편집 상태 초기화 — 외부 상태와 동기화 목적으로 허용
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setLocalFactors(initial);
+  }, [open, conversions.length]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -65,6 +94,30 @@ const IngredientRegisterModal = ({
         },
       );
     }
+  };
+
+  const handleSaveConversion = (conv: UnitConversionDto) => {
+    const factor = localFactors[conv.id];
+    if (!factor || factor <= 0) {
+      toast.error('변환 계수는 0보다 커야 합니다.');
+      return;
+    }
+    updateConversion(
+      {
+        ingredientId: conv.ingredientId,
+        purchaseUnit: conv.purchaseUnit,
+        baseUnit: conv.baseUnit,
+        factor,
+      },
+      { onSuccess: () => toast.success('변환 계수가 저장되었습니다.') },
+    );
+  };
+
+  const handleDeleteConversion = (conv: UnitConversionDto) => {
+    deleteConversion(conv.id, {
+      onSuccess: () => toast.success(`${conv.purchaseUnit} 변환 계수가 삭제되었습니다.`),
+      onError: () => toast.error('삭제에 실패했습니다. 잠시 후 다시 시도해 주세요.'),
+    });
   };
 
   return (
@@ -117,6 +170,82 @@ const IngredientRegisterModal = ({
               </Select>
             </div>
           </div>
+
+          {isEditMode && (
+            <div className="border-t pt-3 flex flex-col gap-2">
+              <p className="text-xs font-medium text-muted-foreground">입고 단위 변환</p>
+              {conversions.length === 0 ? (
+                <p className="text-xs text-muted-foreground py-2 text-center">
+                  저장된 변환 계수가 없습니다.
+                  <br />
+                  <span className="text-[10px]">
+                    OCR 입고 처리 시 박스·병 등 명세서 단위의 변환 계수를 입력하면 여기에
+                    저장됩니다.
+                  </span>
+                </p>
+              ) : (
+                <div className="space-y-1.5">
+                  <div className="grid grid-cols-[1fr_90px_30px_48px_28px] gap-1.5 px-1 text-[10px] font-medium text-muted-foreground">
+                    <span>명세서 단위</span>
+                    <span>변환 계수</span>
+                    <span>단위</span>
+                    <span />
+                    <span />
+                  </div>
+                  {conversions.map((conv) => {
+                    const isDirty =
+                      localFactors[conv.id] !== undefined && localFactors[conv.id] !== conv.factor;
+                    return (
+                      <div
+                        key={conv.id}
+                        className="grid grid-cols-[1fr_90px_30px_48px_28px] gap-1.5 items-center px-1"
+                      >
+                        <span className="text-sm font-medium">1 {conv.purchaseUnit}</span>
+                        <Input
+                          type="number"
+                          value={localFactors[conv.id] ?? conv.factor}
+                          onChange={(e) =>
+                            setLocalFactors((prev) => ({
+                              ...prev,
+                              [conv.id]: Number(e.target.value),
+                            }))
+                          }
+                          className="h-7 text-xs"
+                          min={0.001}
+                          step="any"
+                        />
+                        <span className="text-xs text-muted-foreground">{conv.baseUnit}</span>
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant={isDirty ? 'default' : 'outline'}
+                          className={
+                            isDirty
+                              ? 'bg-baro-blue hover:bg-baro-blue/90 text-white h-7 text-xs px-2'
+                              : 'h-7 text-xs px-2'
+                          }
+                          onClick={() => handleSaveConversion(conv)}
+                          disabled={isUpdatingConv}
+                        >
+                          저장
+                        </Button>
+                        <Button
+                          type="button"
+                          size="icon"
+                          variant="ghost"
+                          className="h-7 w-7 text-muted-foreground hover:text-baro-red hover:bg-red-50"
+                          onClick={() => handleDeleteConversion(conv)}
+                          disabled={isDeletingConv}
+                        >
+                          <Trash2 className="w-3 h-3" />
+                        </Button>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          )}
 
           <div className="flex gap-2 pt-1">
             <Button type="button" variant="outline" className="flex-1" onClick={onClose}>


### PR DESCRIPTION
## 📌 요약

- OCR 거래명세서의 박스·병 등 명세서 단위 항목을 g/ml/개로 변환하는 factor 입력·저장·자동 채움 기능 구현
- 식자재 수정 모달에서 저장된 변환 계수 확인·수정·삭제 지원

<br/>

## 🏷️ 관련 이슈

- Closes #139

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- OCR 응답 구조 변경 반영: `amount: null` = 명세서 단위 항목 (factor 입력 필요), `amount: number` = 이미 변환된 항목
- 검수 화면에서 factor 입력 시 수량·단가 실시간 계산 (단가는 `purchaseUnitPrice / factor` 파생, 상태 저장 없음)
- 저장된 factor가 있는 식자재는 검수 화면 진입 시 자동 채움
- `is_warning` 항목에 빨간 행 하이라이트 + TriangleAlert 툴팁으로 경고 이유 표시
- 입고 확정 후 이동 경로: `/settings` → `/inventory`
- 식자재 수정 모달(수정 모드)에 "입고 단위 변환" 섹션 추가 — 저장된 factor 수정·삭제 가능

<br/>

### 📂 세부 변경사항

- `ocrInbound.types.ts` / `ocrInbound.api.types.ts`: purchaseUnit, amount nullable, is_warning 등 필드 추가
- `unitConversions.api.ts` (신규): GET·PUT·DELETE `/unit-conversions` API
- `useUnitConversions.ts` (신규): factor Map 캐싱, useUpdateUnitConversion·useDeleteUnitConversion 훅
- `OcrReviewStep.tsx`: factor 입력 서브행, 경고 표시, "확인 필요 N개 / 변환 필요 N개" 배지
- `OcrInboundPage.tsx`: 저장된 factor 자동 적용, 확정 시 factor 저장 후 /inventory 이동
- `IngredientRegisterModal.tsx`: 수정 모드에서 입고 단위 변환 섹션 통합

<br/>

## 📸 Screenshots

| Before | After |
| ------ | ----- |
| 명세서 단위 항목 처리 불가 | factor 입력 서브행 + 수량·단가 실시간 계산 |
| 경고 항목 구분 없음 | 빨간 행 + TriangleAlert 툴팁 |
| factor 확인 방법 없음 | 식자재 수정 모달 내 변환 계수 섹션 |

<br/>

## 🧪 테스트 방법

1. OCR 업로드 → 검수 화면에서 명세서 단위(박스 등) 항목 확인
2. factor 입력 → 수량·단가 자동 계산 확인
3. `is_warning: true` 항목에 빨간 배경 + 툴팁 표시 확인
4. 동일 식자재로 재입고 시 factor 자동 채움 확인
5. 입고 확정 후 `/inventory`로 이동 확인
6. 식자재 관리 → 수정 모달 → 입고 단위 변환 섹션 수정·삭제 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [x] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [ ] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- 단가 파생 계산(`purchaseUnitPrice / factor`)은 상태에 저장하지 않고 렌더 시 계산 — 중간 입력값이 상태에 오염되는 버그 방지
- `TooltipTrigger`가 base-ui 기반이라 `asChild` 미지원 → 아이콘 직접 삽입으로 처리