### PR TITLE
💄 (#144) style: UI 전반 개선 — baro-yellow 토큰 통일·다이얼로그 아이콘·데이터 초기화 기능

### DIFF
--- a/src/features/account-settings/components/sections/AccountSection.tsx
+++ b/src/features/account-settings/components/sections/AccountSection.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from 'react';
 
-import { Check, LogOut, Pencil, Trash2, UserCircle, X } from 'lucide-react';
+import { Check, LogOut, Pencil, TriangleAlert, Trash2, UserCircle, X } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
 import { withdrawUser } from '@/features/account-settings/api/accountSettings.api';
@@ -172,7 +172,10 @@ const AccountSection = () => {
       <Dialog open={isWithdrawDialogOpen} onOpenChange={setIsWithdrawDialogOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>정말 탈퇴하시겠어요?</DialogTitle>
+            <DialogTitle className="flex items-center gap-2">
+              <TriangleAlert className="size-4 text-baro-red" />
+              정말 탈퇴하시겠어요?
+            </DialogTitle>
             <DialogDescription>
               탈퇴하면 가게 정보, 재고, 메뉴, 레시피 등 모든 데이터가 영구적으로 삭제됩니다. 이
               작업은 되돌릴 수 없습니다.
@@ -186,7 +189,12 @@ const AccountSection = () => {
             >
               취소
             </Button>
-            <Button variant="destructive" onClick={handleWithdraw} disabled={isWithdrawing}>
+            <Button
+              variant="destructive"
+              onClick={handleWithdraw}
+              disabled={isWithdrawing}
+              className="bg-baro-red/10 text-baro-red-dark hover:bg-baro-red/20 border-baro-red-dark/50"
+            >
               탈퇴하기
             </Button>
           </DialogFooter>

--- a/src/features/account-settings/components/sections/AppInfoSection.tsx
+++ b/src/features/account-settings/components/sections/AppInfoSection.tsx
@@ -1,13 +1,46 @@
 import { ChevronRight, Info } from 'lucide-react';
+import { Link } from 'react-router-dom';
 
+import { routePaths } from '@/app/routes/routePaths';
 import { APP_VERSION } from '@/features/account-settings/data/account-settings.mock';
 import { Separator } from '@/shadcn/ui/separator';
 import SettingRow from '@/shared/components/SettingRow';
 import SettingsSection from '@/shared/components/SettingsSection';
 
-const LinkRow = ({ label }: { label: string }) => (
-  <SettingRow label={label} action={<ChevronRight className="h-4 w-4 text-muted-foreground" />} />
-);
+const LinkRow = ({
+  label,
+  href,
+  external,
+}: {
+  label: string;
+  href?: string;
+  external?: boolean;
+}) => {
+  const content = (
+    <>
+      <p className="text-sm font-medium">{label}</p>
+      <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" />
+    </>
+  );
+
+  const className =
+    'flex items-center justify-between gap-4 rounded-lg -mx-2 px-2 transition-colors hover:bg-muted/50';
+
+  if (!href) return <div className="flex items-center justify-between gap-4">{content}</div>;
+
+  if (external)
+    return (
+      <a href={href} target="_blank" rel="noopener noreferrer" className={className}>
+        {content}
+      </a>
+    );
+
+  return (
+    <Link to={href} className={className}>
+      {content}
+    </Link>
+  );
+};
 
 const AppInfoSection = () => {
   return (
@@ -17,13 +50,13 @@ const AppInfoSection = () => {
         action={<span className="text-sm text-muted-foreground">{APP_VERSION}</span>}
       />
       <Separator />
-      <LinkRow label="이용약관" />
+      <LinkRow label="이용약관" href={routePaths.terms} />
       <Separator />
-      <LinkRow label="개인정보처리방침" />
+      <LinkRow label="개인정보처리방침" href={routePaths.privacy} />
       <Separator />
       <LinkRow label="오픈소스 라이선스" />
       <Separator />
-      <LinkRow label="문의하기" />
+      <LinkRow label="문의하기" href="https://naver.me/xM5slAyu" external />
     </SettingsSection>
   );
 };

--- a/src/features/closing/components/AfterClosingModal.tsx
+++ b/src/features/closing/components/AfterClosingModal.tsx
@@ -6,7 +6,7 @@ import {
   ChevronRight,
   ClipboardList,
   LogOut,
-  Moon,
+  CalendarCheck,
   ShoppingCart,
   Siren,
 } from 'lucide-react';
@@ -15,7 +15,7 @@ import { useNavigate } from 'react-router-dom';
 import { useGenerateOrderGuide } from '@/features/order-guide/hooks/useGenerateOrderGuide';
 import type { OrderGuideItem, UrgencyLevel } from '@/features/order-guide/types/orderGuide.types';
 import { Button } from '@/shadcn/ui/button';
-import { Dialog, DialogContent } from '@/shadcn/ui/dialog';
+import { Dialog, DialogContent, DialogFooter } from '@/shadcn/ui/dialog';
 
 interface AfterClosingModalProps {
   open: boolean;
@@ -204,12 +204,16 @@ const AfterClosingModal = ({
                 className="w-full flex items-center gap-3 p-4 rounded-xl border border-border hover:bg-muted/50 transition-colors text-left"
               >
                 <div className="shrink-0 w-10 h-10 rounded-xl bg-muted flex items-center justify-center">
-                  <Moon className="w-5 h-5 text-muted-foreground" />
+                  <CalendarCheck className="w-5 h-5 text-muted-foreground" />
                 </div>
                 <div className="flex-1 min-w-0">
-                  <p className="text-sm font-semibold text-foreground">오픈 때 볼게요</p>
+                  <p className="text-sm font-semibold text-foreground">
+                    {isRetroactive ? '나중에 볼게요' : '오픈 때 볼게요'}
+                  </p>
                   <p className="text-xs text-muted-foreground mt-0.5">
-                    내일 오픈 전 발주 가이드 메뉴에서 확인
+                    {isRetroactive
+                      ? '발주 가이드 메뉴에서 나중에 확인'
+                      : '내일 오픈 전 발주 가이드 메뉴에서 확인'}
                   </p>
                 </div>
                 <ChevronRight className="w-4 h-4 text-muted-foreground shrink-0" />
@@ -222,11 +226,11 @@ const AfterClosingModal = ({
         {step === 'summary' && (
           <>
             <div className="flex items-center gap-3 px-6 pt-6 pb-4 border-b">
-              <div className="w-9 h-9 rounded-xl bg-baro-blue/10 flex items-center justify-center shrink-0">
-                <ClipboardList className="w-4 h-4 text-baro-blue" />
-              </div>
               <div>
-                <h2 className="text-base font-bold">발주 가이드 요약</h2>
+                <h2 className="flex items-center gap-2 text-base font-bold">
+                  <ClipboardList className="size-4 text-muted-foreground" />
+                  발주 가이드 요약
+                </h2>
                 <p className="text-xs text-muted-foreground">
                   {urgentItems.length > 0
                     ? `긴급·주의 ${urgentItems.length}건 포함`
@@ -269,36 +273,40 @@ const AfterClosingModal = ({
               )}
             </div>
 
-            <div className="flex gap-2 px-6 py-4 border-t">
+            <div className="flex flex-col gap-2 px-6 py-4 border-t">
               <Button
                 variant="outline"
-                className="flex-1"
+                className="w-full h-10"
                 onClick={() =>
                   navigate('/closing/order-guide-detail', { state: { items: guideItems } })
                 }
               >
                 <ClipboardList className="w-4 h-4 mr-1.5" />
-                전체 보기
+                자세히 보기
               </Button>
-              <Button
-                className="flex-1 bg-baro-blue hover:bg-baro-blue/90 text-white"
-                onClick={handleExit}
-              >
-                <LogOut className="w-4 h-4 mr-1.5" />
-                종료
-              </Button>
+              <div className="flex gap-2">
+                <Button variant="outline" className="flex-1 h-10" onClick={() => setStep('choose')}>
+                  이전 페이지로
+                </Button>
+                <Button
+                  className="flex-1 bg-baro-blue hover:bg-baro-blue/90 text-white h-10"
+                  onClick={handleExit}
+                >
+                  프로그램 종료
+                </Button>
+              </div>
             </div>
           </>
         )}
 
         {/* ── 오픈 때 보기: 종료 확인 ── */}
         {step === 'confirm-exit' && (
-          <div className="px-6 py-8 text-center space-y-4">
+          <div className="p-5 text-center space-y-4">
             <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-slate-100 dark:bg-slate-800">
-              <Moon className="w-8 h-8 text-slate-400" />
+              <CalendarCheck className="w-8 h-8 text-slate-400" />
             </div>
             <div>
-              <h2 className="text-lg font-bold">
+              <h2 className="text-lg font-bold pb-3">
                 {isRetroactive ? '대시보드로 돌아갈까요?' : '프로그램을 종료할까요?'}
               </h2>
               <p className="text-sm text-muted-foreground mt-1.5 leading-relaxed">
@@ -306,18 +314,18 @@ const AfterClosingModal = ({
                 발주 가이드 메뉴에서 확인할 수 있어요.
               </p>
             </div>
-            <div className="flex gap-2 pt-1">
-              <Button variant="outline" className="flex-1" onClick={() => setStep('choose')}>
+            <DialogFooter className="flex gap-2">
+              <Button variant="outline" className="flex-1 h-10" onClick={() => setStep('choose')}>
                 취소
               </Button>
               <Button
-                className="flex-1 bg-baro-blue hover:bg-baro-blue/90 text-white flex items-center gap-1.5"
+                className="flex-1 h-10 bg-baro-blue hover:bg-baro-blue/90 text-white flex items-center gap-1.5"
                 onClick={handleExit}
               >
                 <LogOut className="w-4 h-4" />
                 {isRetroactive ? '돌아가기' : '종료'}
               </Button>
-            </div>
+            </DialogFooter>
           </div>
         )}
       </DialogContent>

--- a/src/features/closing/components/ClosingCancelModal.tsx
+++ b/src/features/closing/components/ClosingCancelModal.tsx
@@ -103,7 +103,7 @@ const ClosingCancelModal = ({ open, onClose, storeId }: ClosingCancelModalProps)
             </DialogDescription>
           </DialogHeader>
 
-          <div className="space-y-2 max-h-64 overflow-y-auto">
+          <div className="space-y-2 max-h-64 overflow-y-auto pr-2">
             {isLoading ? (
               <>
                 <Skeleton className="h-14 w-full rounded-lg" />
@@ -139,12 +139,17 @@ const ClosingCancelModal = ({ open, onClose, storeId }: ClosingCancelModalProps)
           </div>
 
           <div className="flex gap-2 pt-1">
-            <Button variant="outline" className="flex-1" onClick={handleClose} disabled={isPending}>
+            <Button
+              variant="outline"
+              className="flex-1 h-10"
+              onClick={handleClose}
+              disabled={isPending}
+            >
               닫기
             </Button>
             <Button
               variant="destructive"
-              className="flex-1 flex items-center gap-1.5"
+              className="flex-1 flex items-center gap-1.5 h-10 border-baro-red bg-baro-red/10 hover:bg-baro-red/20 text-baro-red"
               onClick={handleCancelRequest}
               disabled={!selectedId || isPending}
             >
@@ -170,22 +175,24 @@ const ClosingCancelModal = ({ open, onClose, storeId }: ClosingCancelModalProps)
             <AlertDialogDescription className="sr-only">마감 취소 경고</AlertDialogDescription>
             <div className="space-y-3 text-sm">
               {confirmingItem && (
-                <p className="text-foreground font-medium">
-                  선택한 마감은{' '}
+                <p className="text-foreground font-medium pb-2">
                   <span className="text-baro-red font-semibold">
                     현재 날짜로부터 {daysAgo}일 전
                   </span>{' '}
-                  ({formatDate(confirmingItem.date)})입니다.
+                  마감({formatDate(confirmingItem.date)})입니다.
                 </p>
               )}
-              <div className="rounded-lg border border-amber-200 bg-amber-50 dark:bg-amber-950/20 dark:border-amber-900 px-4 py-3 text-amber-800 dark:text-amber-300">
-                <p className="font-semibold mb-1">⚠️ 복구 불가능한 작업입니다</p>
+              <div className="rounded-lg border border-baro-yellow/30 bg-baro-yellow/10 dark:bg-baro-yellow/10 dark:border-baro-yellow/30 px-4 py-3 text-baro-yellow-text dark:text-baro-yellow-text">
+                <div className="flex flex-row gap-2 items-center mb-2">
+                  <AlertTriangle className="w-4 h-4 text-baro-yellow-dark" />
+                  <p className="font-semibold mb-1 ">복구 불가능한 작업입니다</p>
+                </div>
                 <p className="text-xs leading-relaxed">
                   마감을 취소하면 해당 날짜의 재고 차감이 원상 복구되지만, 이미 개점이 이루어진
-                  이후이므로 <strong>마감 재진행 및 재고 재차감이 불가능합니다.</strong>
+                  이후이므로 <strong>마감 재진행 및 재고 재차감이 불가능합니다.</strong> 그래도
+                  마감을 취소하시겠습니까?
                 </p>
               </div>
-              <p className="text-muted-foreground text-xs">그래도 마감을 취소하시겠습니까?</p>
             </div>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/src/features/customer-order/components/CustomerOrderStatusBadge.tsx
+++ b/src/features/customer-order/components/CustomerOrderStatusBadge.tsx
@@ -1,7 +1,7 @@
 import type { OrderStatus } from '@/features/customer-order/types/customerOrder.types';
 
 const STATUS_CONFIG: Record<OrderStatus, { label: string; className: string }> = {
-  pending: { label: '신규 주문', className: 'bg-amber-50 text-amber-500/90' },
+  pending: { label: '신규 주문', className: 'bg-baro-yellow/10 text-baro-yellow-text' },
   preparing: { label: '준비중', className: 'bg-sky-50 text-sky-500' },
   completed: { label: '완료', className: 'bg-slate-100 text-slate-400' },
   cancelled: { label: '취소', className: 'bg-zinc-100 text-zinc-400' },

--- a/src/features/customer-order/components/CustomerOrderStatusCard.tsx
+++ b/src/features/customer-order/components/CustomerOrderStatusCard.tsx
@@ -132,7 +132,7 @@ const OrderStatusCard = ({ storeId }: OrderStatusCardProps) => {
           <ShoppingBag className="size-4 text-muted-foreground" />
           오늘 주문 현황
           {pendingCount > 0 && (
-            <span className="flex size-5 items-center justify-center rounded-full bg-amber-400/80 text-xs font-bold text-white">
+            <span className="flex size-5 items-center justify-center rounded-full bg-baro-yellow text-xs font-bold text-white">
               {pendingCount}
             </span>
           )}

--- a/src/features/dashboard/components/MemoCard.tsx
+++ b/src/features/dashboard/components/MemoCard.tsx
@@ -41,11 +41,11 @@ const MemoCard = () => {
   }, []);
 
   return (
-    <div className="flex-1 flex flex-col bg-yellow-100 dark:bg-zinc-800 rounded-sm shadow-md relative overflow-hidden">
+    <div className="flex-1 flex flex-col bg-baro-yellow/20 dark:bg-zinc-800 rounded-sm shadow-md relative overflow-hidden">
       {/* 포스트잇 상단 헤더 */}
-      <div className="shrink-0 bg-yellow-200 dark:bg-zinc-700 px-4 py-2.5 flex items-center gap-2 border-b border-yellow-300/60 dark:border-zinc-600">
-        <PenLine className="w-3.5 h-3.5 text-yellow-700 dark:text-zinc-300" />
-        <span className="text-xs font-semibold text-yellow-800 dark:text-zinc-300 tracking-wide">
+      <div className="shrink-0 bg-baro-yellow/30 dark:bg-zinc-700 px-4 py-2.5 flex items-center gap-2 border-b border-baro-yellow/50 dark:border-zinc-600">
+        <PenLine className="w-3.5 h-3.5 text-baro-yellow-dark dark:text-zinc-300" />
+        <span className="text-xs font-semibold text-baro-yellow-text dark:text-zinc-300 tracking-wide">
           메모
         </span>
       </div>
@@ -55,8 +55,8 @@ const MemoCard = () => {
         <textarea
           className="
             flex-1 w-full resize-none bg-transparent
-            text-sm leading-7 text-yellow-950 dark:text-zinc-100
-            placeholder:text-yellow-700/40 dark:placeholder:text-zinc-500
+            text-sm leading-7 text-baro-yellow-text dark:text-zinc-100
+            placeholder:text-baro-yellow-text/40 dark:placeholder:text-zinc-500
             focus:outline-none
             bg-[repeating-linear-gradient(transparent,transparent_calc(1.75rem-1px),#ca8a0428_calc(1.75rem-1px),#ca8a0428_1.75rem)]
             dark:bg-[repeating-linear-gradient(transparent,transparent_calc(1.75rem-1px),rgba(113,113,122,0.2)_calc(1.75rem-1px),rgba(113,113,122,0.2)_1.75rem)]
@@ -68,8 +68,8 @@ const MemoCard = () => {
       </div>
 
       {/* 접힌 모서리 효과 */}
-      <div className="absolute bottom-0 right-0 w-8 h-8 bg-yellow-300/80 dark:bg-zinc-600 [clip-path:polygon(100%_0,100%_100%,0_100%)] shadow-inner" />
-      <div className="absolute bottom-0 right-0 w-0 h-0 border-l-32 border-b-32 border-l-transparent border-b-yellow-50/60 dark:border-b-zinc-900 pointer-events-none" />
+      <div className="absolute bottom-0 right-0 w-8 h-8 bg-baro-yellow/50 dark:bg-zinc-600 [clip-path:polygon(100%_0,100%_100%,0_100%)] shadow-inner" />
+      <div className="absolute bottom-0 right-0 w-0 h-0 border-l-32 border-b-32 border-l-transparent border-b-baro-yellow/10 dark:border-b-zinc-900 pointer-events-none" />
     </div>
   );
 };

--- a/src/features/dashboard/components/StoreStatusCard.tsx
+++ b/src/features/dashboard/components/StoreStatusCard.tsx
@@ -67,7 +67,9 @@ const StoreStatusCard = ({ stats, storeId }: StoreStatusCardProps) => {
               ? `발주 추천 ${stats.aiOrderRecommendations}개 있어요`
               : '발주 추천 없어요'
           }
-          commentColor={stats.aiOrderRecommendations > 0 ? 'text-amber-500' : 'text-baro-green'}
+          commentColor={
+            stats.aiOrderRecommendations > 0 ? 'text-baro-yellow-text' : 'text-baro-green'
+          }
         />
         <StatTile
           label="유통기한 임박"

--- a/src/features/initial-setup/components/InitialSetupForm.tsx
+++ b/src/features/initial-setup/components/InitialSetupForm.tsx
@@ -196,7 +196,7 @@ const InitialSetupForm = () => {
               </div>
               <CardDescription className="mt-0.5">{currentStepConfig.description}</CardDescription>
             </CardHeader>
-            <CardContent className="flex flex-1 min-h-0 flex-col p-4">
+            <CardContent className="flex flex-1 min-h-0 flex-col px-4 py-2">
               <div className="flex flex-1 min-h-0 flex-col">{renderStep()}</div>
             </CardContent>
           </Card>

--- a/src/features/initial-setup/components/MenuRegistrationModal.tsx
+++ b/src/features/initial-setup/components/MenuRegistrationModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 
-import { ImagePlus, Star, X } from 'lucide-react';
+import { ImagePlus, Star, UtensilsCrossed, X } from 'lucide-react';
 
 import type { MenuItem } from '@/features/initial-setup/types/initialSetup.types';
 import { Button } from '@/shadcn/ui/button';
@@ -104,12 +104,15 @@ const MenuRegistrationModal = ({
 
   return (
     <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
-      <DialogContent>
+      <DialogContent showCloseButton={false}>
         <DialogHeader>
-          <DialogTitle>{editingMenu ? '메뉴 수정' : '메뉴 등록'}</DialogTitle>
+          <DialogTitle className="flex items-center gap-2">
+            <UtensilsCrossed className="size-4 text-muted-foreground" />
+            {editingMenu ? '메뉴 수정' : '메뉴 등록'}
+          </DialogTitle>
         </DialogHeader>
 
-        <div>
+        <div className="flex flex-col gap-4">
           {/* 사진 업로드 */}
           <div className="space-y-1.5">
             <Label>메뉴 사진</Label>
@@ -199,12 +202,12 @@ const MenuRegistrationModal = ({
             <button
               type="button"
               onClick={() => setForm((prev) => ({ ...prev, isFeatured: !prev.isFeatured }))}
-              className="mb-0.5 flex h-10 items-center gap-1.5 rounded-lg border px-3 transition-colors hover:bg-yellow-50"
+              className="mb-0.5 flex h-10 items-center gap-1.5 rounded-lg border px-3 transition-colors hover:bg-baro-yellow/10"
             >
               <Star
                 className={
                   form.isFeatured
-                    ? 'size-4 fill-yellow-400 text-yellow-400'
+                    ? 'size-4 fill-baro-yellow text-baro-yellow'
                     : 'size-4 text-gray-300'
                 }
               />
@@ -213,16 +216,11 @@ const MenuRegistrationModal = ({
           </div>
         </div>
 
-        <DialogFooter className="mx-0 mb-0 border-t p-4">
-          <Button type="button" variant="outline" size="sm" onClick={onClose}>
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={onClose}>
             취소
           </Button>
-          <Button
-            type="button"
-            size="sm"
-            onClick={handleSave}
-            className="bg-baro-blue text-white hover:bg-baro-blue-dark"
-          >
+          <Button type="button" onClick={handleSave} className="bg-baro-blue hover:bg-baro-blue/80">
             {editingMenu ? '수정 완료' : '등록하기'}
           </Button>
         </DialogFooter>

--- a/src/features/initial-setup/components/steps/StepIngredientsAndRecipes.tsx
+++ b/src/features/initial-setup/components/steps/StepIngredientsAndRecipes.tsx
@@ -155,7 +155,7 @@ const RecipePanel = ({ menu, recipe, ingredients, onRecipeChange }: RecipePanelP
         <div className="flex items-center gap-2">
           <span className="text-sm font-semibold">{menu.name || '(이름 없음)'}</span>
           {menu.isFeatured && (
-            <span className="rounded-full bg-yellow-100 px-2 py-0.5 text-[10px] font-medium text-yellow-700">
+            <span className="rounded-full bg-baro-yellow/20 px-2 py-0.5 text-[10px] font-medium text-baro-yellow-text">
               대표
             </span>
           )}

--- a/src/features/initial-setup/components/steps/StepMenuRegistration.tsx
+++ b/src/features/initial-setup/components/steps/StepMenuRegistration.tsx
@@ -196,7 +196,7 @@ const StepMenuRegistration = ({ data, onChange }: StepMenuRegistrationProps) => 
                     )}
 
                     {menu.isFeatured && (
-                      <div className="absolute left-2 top-2 flex items-center gap-0.5 rounded-full bg-yellow-400 px-1.5 py-0.5">
+                      <div className="absolute left-2 top-2 flex items-center gap-0.5 rounded-full bg-baro-yellow px-1.5 py-0.5">
                         <Star className="size-2.5 fill-white text-white" />
                         <span className="text-[10px] font-bold text-white">대표</span>
                       </div>
@@ -243,7 +243,7 @@ const StepMenuRegistration = ({ data, onChange }: StepMenuRegistrationProps) => 
               variant="outline"
               size="sm"
               onClick={() => setOcrStep('upload')}
-              className="flex-1 gap-1.5 border-dashed"
+              className="flex-1 gap-1.5 border-dashed h-10"
             >
               <ScanLine className="size-4" />
               메뉴판으로 등록
@@ -253,7 +253,7 @@ const StepMenuRegistration = ({ data, onChange }: StepMenuRegistrationProps) => 
               variant="outline"
               size="sm"
               onClick={handleOpenNew}
-              className="flex-1 gap-1.5 border-dashed"
+              className="flex-1 gap-1.5 border-dashed h-10"
             >
               <Plus className="size-4" />
               직접 입력하기

--- a/src/features/initial-setup/components/steps/StepOperatingHours.tsx
+++ b/src/features/initial-setup/components/steps/StepOperatingHours.tsx
@@ -1,6 +1,7 @@
 import { DAY_OF_WEEK_CONFIG } from '@/features/initial-setup/constants/initialSetup.constants';
 import type { OperatingHour } from '@/features/initial-setup/types/initialSetup.types';
 import { cn } from '@/lib/utils';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/shadcn/ui/select';
 import { Switch } from '@/shadcn/ui/switch';
 
 interface StepOperatingHoursProps {
@@ -8,19 +9,47 @@ interface StepOperatingHoursProps {
   onChange: (data: OperatingHour[]) => void;
 }
 
-interface TimeInputProps {
+interface TimeSelectProps {
   value: string;
   onChange: (value: string) => void;
 }
 
-const TimeInput = ({ value, onChange }: TimeInputProps) => (
-  <input
-    type="time"
-    value={value}
-    onChange={(e) => onChange(e.target.value)}
-    className="h-5 min-w-0 flex-1 rounded border border-input px-1 text-xs outline-none transition-colors focus:border-baro-blue focus:ring-1 focus:ring-baro-blue/20"
-  />
-);
+const HOURS = Array.from({ length: 24 }, (_, i) => String(i).padStart(2, '0'));
+const MINUTES = ['00', '10', '20', '30', '40', '50'];
+
+const TimePicker = ({ value, onChange }: TimeSelectProps) => {
+  const [h, m] = value ? value.split(':') : ['', ''];
+
+  return (
+    <div className="flex flex-1 items-center gap-1">
+      <Select value={h || undefined} onValueChange={(v) => onChange(`${v}:${m || '00'}`)}>
+        <SelectTrigger size="sm" className="h-6 flex-1 text-xs">
+          <SelectValue placeholder="시" />
+        </SelectTrigger>
+        <SelectContent className="max-h-48">
+          {HOURS.map((hour) => (
+            <SelectItem key={hour} value={hour} className="text-xs">
+              {hour}시
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <span className="shrink-0 text-[10px] text-muted-foreground">:</span>
+      <Select value={m || undefined} onValueChange={(v) => onChange(`${h || '00'}:${v}`)}>
+        <SelectTrigger size="sm" className="h-6 flex-1 text-xs">
+          <SelectValue placeholder="분" />
+        </SelectTrigger>
+        <SelectContent>
+          {MINUTES.map((min) => (
+            <SelectItem key={min} value={min} className="text-xs">
+              {min}분
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+};
 
 const StepOperatingHours = ({ data, onChange }: StepOperatingHoursProps) => {
   const handleUpdate = (index: number, updated: Partial<OperatingHour>) => {
@@ -68,15 +97,15 @@ const StepOperatingHours = ({ data, onChange }: StepOperatingHoursProps) => {
               />
             </div>
 
-            <div className="flex h-5 items-center gap-1">
+            <div className="flex items-center gap-1">
               {hour.isOpen ? (
                 <>
-                  <TimeInput
+                  <TimePicker
                     value={hour.openTime ?? ''}
                     onChange={(v) => handleUpdate(index, { openTime: v })}
                   />
                   <span className="shrink-0 text-[10px] text-muted-foreground">~</span>
-                  <TimeInput
+                  <TimePicker
                     value={hour.closeTime ?? ''}
                     onChange={(v) => handleUpdate(index, { closeTime: v })}
                   />

--- a/src/features/inventory/components/InventoryStockEditDialog.tsx
+++ b/src/features/inventory/components/InventoryStockEditDialog.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from 'react';
 
-import { CalendarDays, X } from 'lucide-react';
+import { CalendarDays, Pencil, X } from 'lucide-react';
 
 import { useUpdateIngredient } from '@/features/store-settings/hooks/useIngredients';
 import { Button } from '@/shadcn/ui/button';
@@ -157,7 +157,10 @@ const InventoryStockEditDialog = ({ open, onClose, item }: InventoryStockEditDia
   <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
     <DialogContent className="sm:max-w-xs">
       <DialogHeader>
-        <DialogTitle>재고 수정</DialogTitle>
+        <DialogTitle className="flex items-center gap-2">
+          <Pencil className="size-4 text-muted-foreground" />
+          재고 수정
+        </DialogTitle>
       </DialogHeader>
       {item && <DialogForm key={item.id} item={item} onClose={onClose} />}
     </DialogContent>

--- a/src/features/inventory/components/InventoryTable.tsx
+++ b/src/features/inventory/components/InventoryTable.tsx
@@ -74,9 +74,9 @@ const STATUS_CONFIG: Record<
   },
   warning: {
     label: '주의',
-    badgeClass: 'bg-yellow-50 text-yellow-600/80 border border-yellow-200/60',
-    rowClass: 'border-l-4 border-l-yellow-300',
-    icon: <AlertTriangle className="w-3 h-3" />,
+    badgeClass: 'bg-baro-yellow/10 text-baro-yellow-text border border-baro-yellow/30',
+    rowClass: 'border-l-4 border-l-baro-yellow/50',
+    icon: <AlertTriangle className="w-3 h-3 text-baro-yellow-dark" />,
   },
   normal: {
     label: '정상',
@@ -112,7 +112,7 @@ const getDday = (expiryDate?: string) => {
   if (diff < 0) return { text: '만료됨', chipClass: 'bg-zinc-100 text-zinc-400' };
   if (diff === 0) return { text: 'D-Day', chipClass: 'bg-red-50 text-red-400 font-bold' };
   if (diff <= 3) return { text: `D-${diff}`, chipClass: 'bg-red-50 text-red-400 font-semibold' };
-  if (diff <= 7) return { text: `D-${diff}`, chipClass: 'bg-yellow-50 text-yellow-600/80' };
+  if (diff <= 7) return { text: `D-${diff}`, chipClass: 'bg-baro-yellow/10 text-baro-yellow-text' };
   return { text: `D-${diff}`, chipClass: 'bg-slate-100 text-slate-400' };
 };
 
@@ -149,8 +149,8 @@ const InventoryRow = ({ item, onToggleFavorite, onEdit }: InventoryRowProps) => 
           className={cn(
             'w-4 h-4 transition-colors',
             item.isFavorite
-              ? 'fill-yellow-400 text-yellow-400'
-              : 'text-muted-foreground/30 hover:text-yellow-400',
+              ? 'fill-baro-yellow text-baro-yellow'
+              : 'text-muted-foreground/30 hover:text-baro-yellow',
           )}
         />
       </button>
@@ -301,10 +301,10 @@ const InventoryTable = () => {
 
   return (
     <>
-      <Card className="flex flex-col flex-1 min-h-0 overflow-hidden">
+      <Card className="flex flex-col flex-1 min-h-0 overflow-hidden gap-0 pb-0">
         {/* 카드 헤더 */}
-        <CardHeader className="border-b pb-0">
-          <div className="flex items-center justify-between gap-3 mb-3 flex-wrap">
+        <CardHeader className="border-b pb-0 shrink-0">
+          <div className="flex items-center justify-between mb-3">
             <CardTitle className="text-sm flex items-center gap-2">
               <Package2 className="w-4 h-4 text-muted-foreground" />
               전체 재고
@@ -312,8 +312,46 @@ const InventoryTable = () => {
                 — 총 {items.length}개 품목
               </span>
             </CardTitle>
+          </div>
 
-            <div className="flex items-center gap-2 ml-auto">
+          {/* 상태 필터 탭 + 액션 버튼 */}
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex gap-1">
+              {FILTER_TABS.map((tab) => {
+                const count =
+                  tab.key === 'all' ? items.length : countByStatus(tab.key as InventoryStatus);
+                const isActive = activeTab === tab.key;
+                return (
+                  <button
+                    key={tab.key}
+                    onClick={() => setActiveTab(tab.key)}
+                    className={cn(
+                      'px-3 py-2 text-xs font-medium rounded-t-md border-b-2 transition-colors',
+                      isActive
+                        ? 'border-b-baro-blue text-baro-blue-dark bg-blue-50/50 dark:bg-blue-950/20'
+                        : 'border-b-transparent text-muted-foreground hover:text-foreground hover:bg-muted/50',
+                    )}
+                  >
+                    {tab.label}
+                    <span
+                      className={cn(
+                        'ml-1.5 inline-flex items-center justify-center w-4 h-4 rounded-full text-[10px] font-bold',
+                        isActive
+                          ? 'bg-baro-blue text-white'
+                          : tab.key === 'critical' && count > 0
+                            ? 'bg-red-50 text-red-400'
+                            : 'bg-muted text-muted-foreground',
+                      )}
+                    >
+                      {count}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+
+            {/* 액션 버튼 */}
+            <div className="flex items-center gap-2 shrink-0">
               <button
                 onClick={() => navigate(routePaths.ocrInbound)}
                 className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium bg-baro-blue text-white hover:bg-baro-blue/90 transition-colors"
@@ -333,31 +371,28 @@ const InventoryTable = () => {
                   </span>
                 )}
               </button>
-              {/* 즐겨찾기 필터 버튼 */}
               <button
                 onClick={() => setShowFavoritesOnly((prev) => !prev)}
                 className={cn(
                   'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium border transition-colors',
                   showFavoritesOnly
-                    ? 'bg-yellow-50 border-yellow-300 text-yellow-600'
+                    ? 'bg-baro-yellow/10 border-baro-yellow/50 text-baro-yellow-text'
                     : 'border-input text-muted-foreground hover:bg-muted/50',
                 )}
               >
                 <Star
                   className={cn(
                     'w-3.5 h-3.5',
-                    showFavoritesOnly && 'fill-yellow-400 text-yellow-400',
+                    showFavoritesOnly && 'fill-baro-yellow text-baro-yellow',
                   )}
                 />
                 즐겨찾기만
                 {favoriteCount > 0 && (
-                  <span className="ml-0.5 bg-yellow-400 text-white rounded-full w-4 h-4 inline-flex items-center justify-center text-[10px] font-bold">
+                  <span className="ml-0.5 bg-baro-yellow text-white rounded-full w-4 h-4 inline-flex items-center justify-center text-[10px] font-bold">
                     {favoriteCount}
                   </span>
                 )}
               </button>
-
-              {/* 정렬 버튼 */}
               <div className="flex items-center gap-0.5 border rounded-md px-1.5 py-0.5">
                 <ArrowUpDown className="w-3 h-3 text-muted-foreground mr-0.5 shrink-0" />
                 {(
@@ -373,9 +408,7 @@ const InventoryTable = () => {
                       onClick={() => handleSortClick(key)}
                       className={cn(
                         'px-2 py-1 rounded text-xs font-medium transition-colors',
-                        isActive
-                          ? 'bg-baro-blue text-white'
-                          : 'text-muted-foreground hover:bg-muted/60',
+                        isActive ? 'text-baro-blue' : 'text-muted-foreground hover:bg-muted/60',
                       )}
                     >
                       {label}
@@ -384,15 +417,13 @@ const InventoryTable = () => {
                   );
                 })}
               </div>
-
-              {/* 검색 */}
               <div className="relative w-52">
                 <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
                 <Input
                   placeholder="식자재 검색..."
                   value={search}
                   onChange={(e) => setSearch(e.target.value)}
-                  className="pl-8 h-8 text-xs"
+                  className="pl-8 h-8 text-xs placeholder:text-xs"
                 />
                 {search && (
                   <button
@@ -404,41 +435,6 @@ const InventoryTable = () => {
                 )}
               </div>
             </div>
-          </div>
-
-          {/* 상태 필터 탭 */}
-          <div className="flex gap-1">
-            {FILTER_TABS.map((tab) => {
-              const count =
-                tab.key === 'all' ? items.length : countByStatus(tab.key as InventoryStatus);
-              const isActive = activeTab === tab.key;
-              return (
-                <button
-                  key={tab.key}
-                  onClick={() => setActiveTab(tab.key)}
-                  className={cn(
-                    'px-3 py-2 text-xs font-medium rounded-t-md border-b-2 transition-colors',
-                    isActive
-                      ? 'border-b-baro-blue text-baro-blue-dark bg-blue-50/50 dark:bg-blue-950/20'
-                      : 'border-b-transparent text-muted-foreground hover:text-foreground hover:bg-muted/50',
-                  )}
-                >
-                  {tab.label}
-                  <span
-                    className={cn(
-                      'ml-1.5 inline-flex items-center justify-center w-4 h-4 rounded-full text-[10px] font-bold',
-                      isActive
-                        ? 'bg-baro-blue text-white'
-                        : tab.key === 'critical' && count > 0
-                          ? 'bg-red-50 text-red-400'
-                          : 'bg-muted text-muted-foreground',
-                    )}
-                  >
-                    {count}
-                  </span>
-                </button>
-              );
-            })}
           </div>
         </CardHeader>
 

--- a/src/features/ocr-inbound/components/IngredientLinkModal.tsx
+++ b/src/features/ocr-inbound/components/IngredientLinkModal.tsx
@@ -46,9 +46,7 @@ const IngredientLinkModal = ({
       <DialogContent className="max-w-sm">
         <DialogHeader className="gap-0">
           <DialogTitle className="text-lg! leading-none! flex items-center gap-2">
-            <div className="w-8 h-8 rounded-lg bg-baro-blue/10 flex items-center justify-center shrink-0">
-              <Link className="w-4 h-4 text-baro-blue" />
-            </div>
+            <Link className="size-4 text-muted-foreground" />
             기존 식자재 연결
           </DialogTitle>
           <p className="text-xs text-muted-foreground">

--- a/src/features/ocr-inbound/components/OcrReviewStep.tsx
+++ b/src/features/ocr-inbound/components/OcrReviewStep.tsx
@@ -278,7 +278,7 @@ const OcrReviewStep = ({
               </span>
             )}
             {needsFactorCount > 0 && (
-              <span className="text-xs bg-amber-50 text-amber-600 px-2 py-0.5 rounded-full border border-amber-200/60">
+              <span className="text-xs bg-baro-yellow/10 text-baro-yellow-text px-2 py-0.5 rounded-full border border-baro-yellow/30">
                 변환 필요 {needsFactorCount}개
               </span>
             )}
@@ -338,7 +338,7 @@ const OcrReviewStep = ({
                     !item.isWarning &&
                       item.purchaseUnit &&
                       !item.conversionFactor &&
-                      'bg-amber-50/20',
+                      'bg-baro-yellow/10',
                   )}
                 >
                   <div className="flex items-center justify-center">
@@ -501,8 +501,8 @@ const OcrReviewStep = ({
 
                 {/* 비표준 단위 변환 계수 입력 행 */}
                 {item.purchaseUnit && (
-                  <div className="flex items-center gap-2 px-4 py-2 bg-amber-50/60 text-xs">
-                    <AlertCircle className="w-3.5 h-3.5 text-amber-500 shrink-0" />
+                  <div className="flex items-center gap-2 px-4 py-2 bg-baro-yellow/10 text-xs">
+                    <AlertCircle className="w-3.5 h-3.5 text-baro-yellow-dark shrink-0" />
                     <span className="text-muted-foreground">명세서 원본:</span>
                     <span className="font-medium text-foreground">
                       {item.purchaseQuantity} {item.purchaseUnit}
@@ -520,7 +520,7 @@ const OcrReviewStep = ({
                     <span className="text-muted-foreground">{item.unit}</span>
                     {item.conversionFactor !== undefined && item.purchaseQuantity !== undefined && (
                       <>
-                        <span className="text-amber-700 font-medium">
+                        <span className="text-baro-yellow-text font-medium">
                           → 합계 {(item.purchaseQuantity * item.conversionFactor).toLocaleString()}{' '}
                           {item.unit}
                         </span>

--- a/src/features/store-registration/components/InviteCodeModal.tsx
+++ b/src/features/store-registration/components/InviteCodeModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { KeyRound } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
 import { routePaths } from '@/app/routes/routePaths';
@@ -37,7 +38,10 @@ const InviteCodeModal = ({ open, onOpenChange }: InviteCodeModalProps) => {
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-sm p-5">
         <DialogHeader>
-          <DialogTitle className="text-xl! mb-1!">초대코드 입력</DialogTitle>
+          <DialogTitle className="text-xl! mb-1! flex items-center gap-2">
+            <KeyRound className="size-4 text-muted-foreground" />
+            초대코드 입력
+          </DialogTitle>
           <DialogDescription className="text-xs text-muted-foreground">
             사장님께 받은 초대코드를 입력해 주세요. 코드가 맞으면 가게에 직원으로 등록됩니다.
           </DialogDescription>

--- a/src/features/store-settings/api/storeSettings.api.ts
+++ b/src/features/store-settings/api/storeSettings.api.ts
@@ -29,6 +29,10 @@ export async function updateStoreSettings(
   await axiosInstance.patch(`/stores/${storeId}`, data);
 }
 
+export async function resetStoreData(storeId: string): Promise<void> {
+  await axiosInstance.post(`/stores/${storeId}/reset`);
+}
+
 export async function updateOperatingHours(
   storeId: string,
   operatingHours: OperatingHour[],

--- a/src/features/store-settings/components/MenuOcrModal.tsx
+++ b/src/features/store-settings/components/MenuOcrModal.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { Loader2 } from 'lucide-react';
+import { Loader2, ScanLine } from 'lucide-react';
 
 import useAuthStore from '@/features/auth/store/authStore';
 import { uploadMenuOcrScan } from '@/features/store-settings/api/menus.api';
@@ -99,7 +99,10 @@ const MenuOcrModal = ({
     <Dialog open={open} onOpenChange={(v) => !v && handleClose()}>
       <DialogContent className="sm:max-w-3xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle>{titleMap[step]}</DialogTitle>
+          <DialogTitle className="flex items-center gap-2">
+            <ScanLine className="size-4 text-muted-foreground" />
+            {titleMap[step]}
+          </DialogTitle>
         </DialogHeader>
 
         {step === 'upload' && (

--- a/src/features/store-settings/components/MenuOcrReviewStep.tsx
+++ b/src/features/store-settings/components/MenuOcrReviewStep.tsx
@@ -182,15 +182,15 @@ const MenuOcrReviewStep = ({
               <button
                 type="button"
                 onClick={() => handleChange(item.id, 'isFeatured', !item.isFeatured)}
-                className="flex items-center justify-center w-8 h-8 rounded-md hover:bg-yellow-50 transition-colors"
+                className="flex items-center justify-center w-8 h-8 rounded-md hover:bg-baro-yellow/10 transition-colors"
                 title={item.isFeatured ? '대표 메뉴 해제' : '대표 메뉴 설정'}
               >
                 <Star
                   className={cn(
                     'w-4 h-4',
                     item.isFeatured
-                      ? 'fill-yellow-400 text-yellow-400'
-                      : 'text-gray-300 hover:text-yellow-300',
+                      ? 'fill-baro-yellow text-baro-yellow'
+                      : 'text-gray-300 hover:text-baro-yellow/50',
                   )}
                 />
               </button>

--- a/src/features/store-settings/components/MenuOcrUploadStep.tsx
+++ b/src/features/store-settings/components/MenuOcrUploadStep.tsx
@@ -32,7 +32,7 @@ const MenuOcrUploadStep = ({ onFileSelect, onBack }: MenuOcrUploadStepProps) => 
   };
 
   return (
-    <div className="flex flex-col gap-6">
+    <div className="flex flex-col gap-6 pr-2">
       <div className="flex flex-col gap-4">
         <div>
           <p className="text-sm font-semibold">메뉴판을 등록해주세요</p>

--- a/src/features/store-settings/components/sections/DataSection.tsx
+++ b/src/features/store-settings/components/sections/DataSection.tsx
@@ -1,43 +1,144 @@
-import { Database, Download, Trash2 } from 'lucide-react';
+import { useState } from 'react';
 
+import { AlertTriangle, Database, Loader2, Trash2 } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { useResetStoreData } from '@/features/store-settings/hooks/useStoreSettings';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/shadcn/ui/alert-dialog';
 import { Button } from '@/shadcn/ui/button';
-import { Separator } from '@/shadcn/ui/separator';
 import SettingRow from '@/shared/components/SettingRow';
 import SettingsSection from '@/shared/components/SettingsSection';
 
 const DataSection = () => {
+  const [open, setOpen] = useState(false);
+  const { mutate: resetStore, isPending } = useResetStoreData();
+
+  const handleConfirm = () => {
+    resetStore(undefined, {
+      onSuccess: () => {
+        toast.success('가게 데이터가 초기화되었습니다.');
+        setOpen(false);
+      },
+      onError: () => {
+        toast.error('데이터 초기화에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+        setOpen(false);
+      },
+    });
+  };
+
   return (
-    <SettingsSection
-      title="데이터 관리"
-      description="재고 데이터를 내보내거나 초기화합니다."
-      icon={<Database className="h-4 w-4" />}
-    >
-      <SettingRow
-        label="데이터 내보내기"
-        description="전체 재고 및 입출고 내역을 CSV 파일로 다운로드합니다."
-        action={
-          <Button variant="outline" size="sm" className="gap-1.5">
-            <Download className="h-3.5 w-3.5" />
-            CSV 내보내기
-          </Button>
-        }
-      />
-      <Separator />
-      <SettingRow
-        label="데이터 초기화"
-        description="모든 재고 데이터가 삭제됩니다. 이 작업은 되돌릴 수 없습니다."
-        action={
-          <Button
-            variant="outline"
-            size="sm"
-            className="gap-1.5 border-baro-red text-baro-red hover:bg-baro-red/10 hover:text-baro-red"
-          >
-            <Trash2 className="h-3.5 w-3.5" />
-            초기화
-          </Button>
-        }
-      />
-    </SettingsSection>
+    <>
+      <SettingsSection
+        title="데이터 관리"
+        description="재고 데이터를 초기화합니다."
+        icon={<Database className="h-4 w-4" />}
+      >
+        {/* MVP 이후 구현 예정
+        <SettingRow
+          label="데이터 내보내기"
+          description="전체 재고 및 입출고 내역을 CSV 파일로 다운로드합니다."
+          action={
+            <Button variant="outline" size="sm" className="gap-1.5">
+              <Download className="h-3.5 w-3.5" />
+              CSV 내보내기
+            </Button>
+          }
+        />
+        <Separator />
+        */}
+        <SettingRow
+          label="데이터 초기화"
+          description="모든 재고 데이터가 삭제됩니다. 이 작업은 되돌릴 수 없습니다."
+          action={
+            <Button
+              variant="outline"
+              size="sm"
+              className="gap-1.5 border-baro-red text-baro-red hover:bg-baro-red/10 hover:text-baro-red"
+              onClick={() => setOpen(true)}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+              초기화
+            </Button>
+          }
+        />
+      </SettingsSection>
+
+      <AlertDialog open={open} onOpenChange={setOpen}>
+        <AlertDialogContent className="sm:max-w-xl">
+          <AlertDialogHeader>
+            <AlertDialogTitle className="flex items-center gap-2 text-baro-red">
+              <AlertTriangle className="w-4 h-4" />
+              데이터 초기화 전 확인하세요
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              <div className="space-y-3 text-sm">
+                <div className="space-y-2">
+                  <div className="flex justify-end items-center gap-3 text-xs text-muted-foreground">
+                    <span className="flex items-center gap-1">
+                      <span className="inline-block w-1.5 h-1.5 rounded-full bg-baro-red" />
+                      삭제
+                    </span>
+                    <span className="flex items-center gap-1">
+                      <span className="inline-block w-1.5 h-1.5 rounded-full bg-muted-foreground/40" />
+                      유지
+                    </span>
+                  </div>
+                  <div className="flex flex-wrap gap-1.5">
+                    {[
+                      { label: '메뉴', del: true },
+                      { label: '메뉴 카테고리', del: true },
+                      { label: '식자재', del: true },
+                      { label: '레시피', del: true },
+                      { label: '주문', del: true },
+                      { label: '입고 기록', del: true },
+                      { label: '마감', del: true },
+                      { label: '발주 가이드', del: true },
+                      { label: '가게 기본 정보', del: false },
+                      { label: '멤버', del: false },
+                      { label: '운영 시간', del: false },
+                    ].map(({ label, del }) => (
+                      <span
+                        key={label}
+                        className={
+                          del
+                            ? 'rounded-md bg-red-50 px-2 py-0.5 text-xs text-baro-red border border-red-100'
+                            : 'rounded-md bg-muted px-2 py-0.5 text-xs text-muted-foreground border border-border'
+                        }
+                      >
+                        {label}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+                <p className="text-sm text-muted-foreground leading-relaxed">
+                  초기화 후에는 삭제된 데이터를 복구할 수 없습니다. 계속하기 전에 필요한 데이터를
+                  별도로 기록해 두세요.
+                </p>
+              </div>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isPending}>돌아가기</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleConfirm}
+              disabled={isPending}
+              className="bg-baro-red hover:bg-baro-red-dark text-white"
+            >
+              {isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : '초기화 확정'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 };
 

--- a/src/features/store-settings/components/sections/StoreInfoSection.tsx
+++ b/src/features/store-settings/components/sections/StoreInfoSection.tsx
@@ -120,7 +120,7 @@ const StoreInfoSection = () => {
               }
             >
               <SelectTrigger className="w-full">
-                <SelectValue />
+                <SelectValue>{labelOf(BUSINESS_TYPE_OPTIONS, form.businessType)}</SelectValue>
               </SelectTrigger>
               <SelectContent>
                 {BUSINESS_TYPE_OPTIONS.map((o) => (
@@ -138,7 +138,7 @@ const StoreInfoSection = () => {
               onValueChange={(val) => setForm((f) => f && { ...f, category: val ?? f.category })}
             >
               <SelectTrigger className="w-full">
-                <SelectValue />
+                <SelectValue>{labelOf(CATEGORY_OPTIONS, form.category)}</SelectValue>
               </SelectTrigger>
               <SelectContent>
                 {CATEGORY_OPTIONS.map((o) => (

--- a/src/features/store-settings/hooks/useStoreSettings.ts
+++ b/src/features/store-settings/hooks/useStoreSettings.ts
@@ -4,6 +4,7 @@ import useAuthStore from '@/features/auth/store/authStore';
 import type { OperatingHour } from '@/features/initial-setup/types/initialSetup.types';
 import {
   fetchStoreSettings,
+  resetStoreData,
   updateStoreSettings,
   updateOperatingHours,
 } from '@/features/store-settings/api/storeSettings.api';
@@ -32,6 +33,21 @@ export function useUpdateStoreSettings() {
       if (variables.safetyStockPct !== undefined) {
         queryClient.invalidateQueries({ queryKey: ['ingredients', storeId] });
       }
+    },
+  });
+}
+
+export function useResetStoreData() {
+  const storeId = useAuthStore((s) => s.storeId);
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => resetStoreData(storeId!),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['storeSettings', storeId] });
+      queryClient.invalidateQueries({ queryKey: ['ingredients', storeId] });
+      queryClient.invalidateQueries({ queryKey: ['menus', storeId] });
+      queryClient.invalidateQueries({ queryKey: ['recipes', storeId] });
     },
   });
 }

--- a/src/index.css
+++ b/src/index.css
@@ -82,6 +82,9 @@
   --baro-black-muted: #6a6a6a;
   --baro-ivory: #f2e9e1;
   --baro-ivory-dark: #d8d0c4;
+  --baro-yellow: #ffd94d;
+  --baro-yellow-dark: #ffca1a;
+  --baro-yellow-text: #a07830;
 }
 
 #root {
@@ -97,7 +100,6 @@
 body {
   margin: 0;
 }
-
 
 p {
   margin: 0;
@@ -134,6 +136,9 @@ code {
   --color-baro-black-muted: var(--baro-black-muted);
   --color-baro-ivory: var(--baro-ivory);
   --color-baro-ivory-dark: var(--baro-ivory-dark);
+  --color-baro-yellow: var(--baro-yellow);
+  --color-baro-yellow-dark: var(--baro-yellow-dark);
+  --color-baro-yellow-text: var(--baro-yellow-text);
 
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);

--- a/src/pages/ClosingPage.tsx
+++ b/src/pages/ClosingPage.tsx
@@ -149,8 +149,8 @@ const ClosingPage = () => {
 
         {/* 소급 마감 안내 배너 */}
         {isRetroactive && (
-          <div className="mx-6 mt-4 flex items-start gap-2.5 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
-            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
+          <div className="mx-6 mt-4 flex items-start gap-2.5 rounded-lg border border-baro-yellow/30 bg-baro-yellow/10 px-4 py-3 text-sm text-baro-yellow-text">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-baro-yellow-dark" />
             <p>
               전날 마감을 소급 처리합니다. 오늘 이미 발생한 매출과 재고 차감 순서가 실제와 다를 수
               있습니다.

--- a/src/pages/InventoryPage.tsx
+++ b/src/pages/InventoryPage.tsx
@@ -2,7 +2,7 @@ import InventoryTable from '@/features/inventory/components/InventoryTable';
 
 const InventoryPage = () => {
   return (
-    <div className="flex flex-col h-full min-h-0 overflow-hidden p-4">
+    <div className="flex flex-col h-full p-4">
       <InventoryTable />
     </div>
   );

--- a/src/pages/PrivacyPolicyPage.tsx
+++ b/src/pages/PrivacyPolicyPage.tsx
@@ -1,7 +1,5 @@
 import { ArrowLeft } from 'lucide-react';
-import { Link } from 'react-router-dom';
-
-import { routePaths } from '@/app/routes/routePaths';
+import { useNavigate } from 'react-router-dom';
 
 const SECTIONS = [
   {
@@ -89,16 +87,18 @@ const SECTIONS = [
 ];
 
 const PrivacyPolicyPage = () => {
+  const navigate = useNavigate();
   return (
     <div className="min-h-screen bg-white">
       <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-        <Link
-          to={routePaths.landing}
+        <button
+          type="button"
+          onClick={() => navigate(-1)}
           className="inline-flex items-center gap-2 text-sm text-gray-500 hover:text-gray-800 transition-colors mb-10"
         >
           <ArrowLeft className="w-4 h-4" />
           돌아가기
-        </Link>
+        </button>
 
         <h1 className="text-3xl font-bold text-baro-black mb-2">개인정보 처리방침</h1>
         <p className="text-sm text-gray-500 mb-10">

--- a/src/pages/SettingsIngredientsPage.tsx
+++ b/src/pages/SettingsIngredientsPage.tsx
@@ -10,6 +10,7 @@ import {
   Search,
   ShieldCheck,
   Trash2,
+  TriangleAlert,
 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
@@ -290,7 +291,10 @@ const SettingsIngredientsPage = () => {
       >
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>식자재를 삭제하시겠습니까?</AlertDialogTitle>
+            <AlertDialogTitle className="flex items-center gap-2">
+              <Trash2 className="size-4 text-baro-red" />
+              식자재를 삭제하시겠습니까?
+            </AlertDialogTitle>
             <AlertDialogDescription>
               <span className="font-medium text-foreground">{deleteTarget?.name}</span>을(를)
               삭제하면 되돌릴 수 없습니다.
@@ -313,7 +317,10 @@ const SettingsIngredientsPage = () => {
       <AlertDialog open={!!conflictDetail} onOpenChange={(open) => !open && handleCancelDelete()}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>관련 기록도 함께 삭제됩니다</AlertDialogTitle>
+            <AlertDialogTitle className="flex items-center gap-2">
+              <TriangleAlert className="size-4 text-baro-red" />
+              관련 기록도 함께 삭제됩니다
+            </AlertDialogTitle>
             <AlertDialogDescription>
               <span className="font-medium text-foreground">{deleteTarget?.name}</span>에 연결된
               입고 기록 {conflictDetail?.inboundCount ?? 0}건, 마감 기록{' '}
@@ -337,7 +344,10 @@ const SettingsIngredientsPage = () => {
       <Dialog open={safetyOpen} onOpenChange={setSafetyOpen}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
-            <DialogTitle>안전 재고 기준 설정</DialogTitle>
+            <DialogTitle className="flex items-center gap-2">
+              <ShieldCheck className="size-4 text-muted-foreground" />
+              안전 재고 기준 설정
+            </DialogTitle>
           </DialogHeader>
           <div className="space-y-4">
             <p className="text-sm text-muted-foreground">
@@ -347,11 +357,11 @@ const SettingsIngredientsPage = () => {
                 OCR 입고 후에는 자동으로 반영됩니다. 지금 즉시 적용하려면 '전체 적용'을 눌러주세요.
               </span>
             </p>
-            <div className="flex justify-center">
+            <div className="flex justify-center py-4">
               <SafetyStockDial value={safetyPct} onChange={setSafetyPct} step={5} />
             </div>
             <Button
-              className="w-full bg-baro-blue hover:bg-baro-blue/80 text-white"
+              className="w-full bg-baro-blue hover:bg-baro-blue/80 text-white h-10"
               onClick={handleApplySafety}
               disabled={isSavingPct}
             >

--- a/src/pages/SettingsMenusPage.tsx
+++ b/src/pages/SettingsMenusPage.tsx
@@ -12,6 +12,7 @@ import {
   ScanLine,
   Search,
   Trash2,
+  UtensilsCrossed,
   X,
 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
@@ -141,7 +142,10 @@ const MenuModal = ({
     <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
       <DialogContent showCloseButton={false}>
         <DialogHeader>
-          <DialogTitle>{editing ? '메뉴 수정' : '메뉴 등록'}</DialogTitle>
+          <DialogTitle className="flex items-center gap-2">
+            <UtensilsCrossed className="size-4 text-muted-foreground" />
+            {editing ? '메뉴 수정' : '메뉴 등록'}
+          </DialogTitle>
         </DialogHeader>
 
         <div className="flex gap-4 flex-col">
@@ -191,7 +195,7 @@ const MenuModal = ({
                 value={form.categoryId}
                 onValueChange={(val) => setForm((p) => ({ ...p, categoryId: val ?? '' }))}
               >
-                <SelectTrigger id="menu-category" className="h-10 w-full">
+                <SelectTrigger id="menu-category" className="h-10! w-full">
                   {form.categoryId ? (
                     <span className="text-sm">
                       {categories.find((c) => c.id === form.categoryId)?.name ?? '미분류'}

--- a/src/pages/SettingsRecipesPage.tsx
+++ b/src/pages/SettingsRecipesPage.tsx
@@ -356,14 +356,17 @@ const SettingsRecipesPage = () => {
       >
         <DialogContent className="flex max-h-[60vh] max-w-xl flex-col overflow-hidden">
           <DialogHeader>
-            <DialogTitle>레시피 수정</DialogTitle>
+            <DialogTitle className="flex items-center gap-2">
+              <Pencil className="size-4 text-muted-foreground" />
+              레시피 수정
+            </DialogTitle>
             <DialogDescription>
               <span className="font-medium text-foreground">{editingMenuName}</span>의 식자재
               사용량을 수정합니다
             </DialogDescription>
           </DialogHeader>
 
-          <div className="flex-1 overflow-y-auto pb-2">
+          <div className="flex-1 overflow-y-auto pb-2 pr-2">
             <div className="space-y-4 py-2">
               <div className="flex items-center gap-3">
                 <div className="h-px flex-1 bg-border" />
@@ -501,7 +504,10 @@ const SettingsRecipesPage = () => {
       >
         <DialogContent className="max-w-sm">
           <DialogHeader>
-            <DialogTitle>레시피 삭제</DialogTitle>
+            <DialogTitle className="flex items-center gap-2">
+              <Trash2 className="size-4 text-baro-red" />
+              레시피 삭제
+            </DialogTitle>
             <DialogDescription>
               <span className="font-medium text-foreground">{deletingMenuName}</span>의 레시피에
               등록된 식자재를 모두 삭제하시겠습니까?

--- a/src/pages/SystemStartPage.tsx
+++ b/src/pages/SystemStartPage.tsx
@@ -141,11 +141,11 @@ const SystemStartPage = () => {
         );
       case 'before-open-not-closed':
         return (
-          <div className="flex items-start gap-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
-            <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5 text-amber-500" />
+          <div className="flex items-start gap-3 rounded-lg border border-baro-yellow/30 bg-baro-yellow/10 px-4 py-3 text-sm text-baro-yellow-text">
+            <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5 text-baro-yellow-dark" />
             <div>
               <p className="font-semibold">전날 마감이 완료되지 않았습니다.</p>
-              <p className="mt-0.5 text-xs text-amber-700">
+              <p className="mt-0.5 text-xs text-baro-yellow-text">
                 {formatShortDate(businessDate)} 소급 마감 후 영업을 시작할 수 있습니다.
               </p>
             </div>
@@ -160,8 +160,8 @@ const SystemStartPage = () => {
         );
       case 'holiday':
         return (
-          <div className="flex items-center gap-3 rounded-lg border border-purple-200 bg-purple-50 px-4 py-3 text-sm text-purple-800">
-            <MoonStar className="h-4 w-4 shrink-0 text-purple-400" />
+          <div className="flex items-center gap-3 rounded-lg border border-slate-300 bg-slate-100 px-4 py-3 text-sm text-slate-600">
+            <MoonStar className="h-4 w-4 shrink-0 text-slate-400" />
             <span>오늘은 설정된 휴무일입니다.</span>
           </div>
         );
@@ -183,20 +183,20 @@ const SystemStartPage = () => {
         return (
           <button
             onClick={() => navigate('/dashboard')}
-            className="w-full bg-baro-blue hover:bg-baro-blue/90 text-white rounded-lg px-8 py-6 flex items-center justify-between transition-colors text-left group"
+            className="w-full bg-white dark:bg-card border border-border hover:border-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800/50 rounded-lg px-8 py-6 flex items-center justify-between transition-colors text-left group cursor-pointer"
           >
             <div className="flex items-center gap-4">
-              <div className="w-12 h-12 rounded-lg bg-white/15 flex items-center justify-center shrink-0">
-                <Store className="w-6 h-6" />
+              <div className="w-12 h-12 rounded-lg bg-slate-100 dark:bg-slate-800 flex items-center justify-center shrink-0">
+                <Store className="w-6 h-6 text-slate-500" />
               </div>
               <div>
-                <p className="font-bold text-xl">영업 중 · 대시보드로 이동</p>
-                <p className="text-sm text-white/70 mt-1">
+                <p className="font-bold text-xl text-foreground">영업 중 · 대시보드로 이동</p>
+                <p className="text-sm text-muted-foreground mt-1">
                   {formatShortDate(businessDate)} 영업이 진행 중입니다
                 </p>
               </div>
             </div>
-            <ChevronRight className="w-6 h-6 opacity-60 shrink-0 group-hover:translate-x-0.5 transition-transform" />
+            <ChevronRight className="w-6 h-6 text-slate-400 shrink-0" />
           </button>
         );
 
@@ -205,20 +205,22 @@ const SystemStartPage = () => {
           <button
             onClick={() => handleStartBusiness()}
             disabled={isStarting}
-            className="w-full bg-baro-blue hover:bg-baro-blue/90 disabled:opacity-60 text-white rounded-lg px-8 py-6 flex items-center justify-between transition-colors text-left group"
+            className="w-full bg-white dark:bg-card border border-border hover:border-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800/50 disabled:opacity-60 rounded-lg px-8 py-6 flex items-center justify-between transition-colors text-left group cursor-pointer"
           >
             <div className="flex items-center gap-4">
-              <div className="w-12 h-12 rounded-lg bg-white/15 flex items-center justify-center shrink-0">
-                <LogIn className="w-6 h-6" />
+              <div className="w-12 h-12 rounded-lg bg-slate-100 dark:bg-slate-800 flex items-center justify-center shrink-0">
+                <LogIn className="w-6 h-6 text-slate-500" />
               </div>
               <div>
-                <p className="font-bold text-xl">{isStarting ? '시작 중...' : '영업 시작하기'}</p>
-                <p className="text-sm text-white/70 mt-1">
+                <p className="font-bold text-xl text-foreground">
+                  {isStarting ? '시작 중...' : '영업 시작하기'}
+                </p>
+                <p className="text-sm text-muted-foreground mt-1">
                   오늘 영업을 시작하고 대시보드로 이동합니다
                 </p>
               </div>
             </div>
-            <ChevronRight className="w-6 h-6 opacity-60 shrink-0 group-hover:translate-x-0.5 transition-transform" />
+            <ChevronRight className="w-6 h-6 text-slate-400 shrink-0" />
           </button>
         );
 
@@ -239,20 +241,20 @@ const SystemStartPage = () => {
         return (
           <button
             onClick={() => navigate(`/closing?date=${businessDate}`)}
-            className="w-full bg-amber-500 hover:bg-amber-600 text-white rounded-lg px-8 py-6 flex items-center justify-between transition-colors text-left group"
+            className="w-full bg-white dark:bg-card border border-border hover:border-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800/50 rounded-lg px-8 py-6 flex items-center justify-between transition-colors text-left group cursor-pointer"
           >
             <div className="flex items-center gap-4">
-              <div className="w-12 h-12 rounded-lg bg-white/15 flex items-center justify-center shrink-0">
-                <AlertTriangle className="w-6 h-6" />
+              <div className="w-12 h-12 rounded-lg bg-slate-100 dark:bg-slate-800 flex items-center justify-center shrink-0">
+                <AlertTriangle className="w-6 h-6 text-slate-500" />
               </div>
               <div>
-                <p className="font-bold text-xl">전날 마감하러 가기</p>
-                <p className="text-sm text-white/80 mt-1">
+                <p className="font-bold text-xl text-foreground">전날 마감하러 가기</p>
+                <p className="text-sm text-muted-foreground mt-1">
                   {formatShortDate(businessDate)} 소급 마감을 진행합니다
                 </p>
               </div>
             </div>
-            <ChevronRight className="w-6 h-6 opacity-60 shrink-0 group-hover:translate-x-0.5 transition-transform" />
+            <ChevronRight className="w-6 h-6 text-slate-400 shrink-0" />
           </button>
         );
 
@@ -275,18 +277,20 @@ const SystemStartPage = () => {
           <button
             onClick={() => setShowHolidayModal(true)}
             disabled={isStarting}
-            className="w-full bg-purple-600 hover:bg-purple-700 disabled:opacity-60 text-white rounded-lg px-8 py-6 flex items-center justify-between transition-colors text-left group"
+            className="w-full bg-white dark:bg-card border border-border hover:border-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800/50 disabled:opacity-60 rounded-lg px-8 py-6 flex items-center justify-between transition-colors text-left group cursor-pointer"
           >
             <div className="flex items-center gap-4">
-              <div className="w-12 h-12 rounded-lg bg-white/15 flex items-center justify-center shrink-0">
-                <LogIn className="w-6 h-6" />
+              <div className="w-12 h-12 rounded-lg bg-slate-100 dark:bg-slate-800 flex items-center justify-center shrink-0">
+                <LogIn className="w-6 h-6 text-slate-500" />
               </div>
               <div>
-                <p className="font-bold text-xl">임시 영업 시작하기</p>
-                <p className="text-sm text-white/70 mt-1">휴무일에 임시로 영업을 시작합니다</p>
+                <p className="font-bold text-xl text-foreground">임시 영업 시작하기</p>
+                <p className="text-sm text-muted-foreground mt-1">
+                  휴무일에 임시로 영업을 시작합니다
+                </p>
               </div>
             </div>
-            <ChevronRight className="w-6 h-6 opacity-60 shrink-0 group-hover:translate-x-0.5 transition-transform" />
+            <ChevronRight className="w-6 h-6 text-slate-400 shrink-0" />
           </button>
         );
     }
@@ -313,7 +317,7 @@ const SystemStartPage = () => {
               </p>
             )}
             {!isLoading && businessDateClosed && (
-              <span className="inline-block mt-1 text-xs font-medium text-amber-700 bg-amber-100 border border-amber-200 px-2 py-0.5 rounded-full">
+              <span className="inline-block mt-1 text-xs font-medium text-baro-yellow-text bg-baro-yellow/20 border border-baro-yellow/30 px-2 py-0.5 rounded-full">
                 {formatShortDate(businessDate)} 마감 완료
               </span>
             )}
@@ -324,9 +328,9 @@ const SystemStartPage = () => {
               (currentCase === 'already-open' || currentCase === 'normal') && (
                 <Link
                   to={`/closing?date=${getYesterdayKST()}`}
-                  className="inline-flex items-center gap-1 mt-1 text-xs font-medium text-amber-700 bg-amber-100 border border-amber-300 px-2 py-0.5 rounded-full hover:bg-amber-200 transition-colors"
+                  className="inline-flex items-center gap-1 mt-1 text-xs font-medium text-baro-yellow-text bg-baro-yellow/20 border border-baro-yellow/50 px-2 py-0.5 rounded-full hover:bg-baro-yellow/30 transition-colors"
                 >
-                  <AlertTriangle className="h-3 w-3 shrink-0" />
+                  <AlertTriangle className="h-3 w-3 shrink-0 text-baro-yellow-dark" />
                   전날 마감 누락
                 </Link>
               )}
@@ -360,7 +364,7 @@ const SystemStartPage = () => {
             <div className="grid grid-cols-3 gap-4">
               <button
                 onClick={() => navigate('/inventory')}
-                className="bg-white dark:bg-card border border-border hover:border-baro-green/40 hover:bg-baro-green/5 rounded-lg p-5 flex flex-col gap-4 transition-colors text-left"
+                className="bg-white dark:bg-card border border-border hover:border-baro-green/40 hover:bg-baro-green/5 rounded-lg p-5 flex flex-col gap-4 transition-colors text-left cursor-pointer"
               >
                 <div className="w-10 h-10 rounded-lg bg-baro-green/10 flex items-center justify-center">
                   <Archive className="w-5 h-5 text-baro-green" />
@@ -373,10 +377,10 @@ const SystemStartPage = () => {
 
               <button
                 onClick={() => navigate('/order-guide')}
-                className="bg-white dark:bg-card border border-border hover:border-purple-300/50 hover:bg-purple-50/60 dark:hover:bg-purple-950/20 rounded-lg p-5 flex flex-col gap-4 transition-colors text-left"
+                className="bg-white dark:bg-card border border-border hover:border-baro-yellow/50 hover:bg-baro-yellow/10 dark:hover:bg-baro-yellow/10 rounded-lg p-5 flex flex-col gap-4 transition-colors text-left cursor-pointer"
               >
-                <div className="w-10 h-10 rounded-lg bg-purple-100/70 dark:bg-purple-950/30 flex items-center justify-center">
-                  <ClipboardList className="w-5 h-5 text-purple-400" />
+                <div className="w-10 h-10 rounded-lg bg-baro-yellow/20 dark:bg-baro-yellow/20 flex items-center justify-center">
+                  <ClipboardList className="w-5 h-5 text-baro-yellow-dark" />
                 </div>
                 <div>
                   <p className="font-semibold text-foreground">발주 가이드</p>
@@ -386,7 +390,7 @@ const SystemStartPage = () => {
 
               <button
                 onClick={() => toast.info('이전 마감 현황 기능은 준비 중이에요.')}
-                className="bg-white dark:bg-card border border-border hover:border-baro-blue/40 hover:bg-baro-blue/5 rounded-lg p-5 flex flex-col gap-4 transition-colors text-left"
+                className="bg-white dark:bg-card border border-border hover:border-baro-blue/40 hover:bg-baro-blue/5 rounded-lg p-5 flex flex-col gap-4 transition-colors text-left cursor-pointer"
               >
                 <div className="w-10 h-10 rounded-lg bg-baro-blue/10 flex items-center justify-center">
                   <History className="w-5 h-5 text-baro-blue" />
@@ -402,7 +406,7 @@ const SystemStartPage = () => {
             <div className="grid grid-cols-2 gap-4">
               <button
                 onClick={() => setShowCancelModal(true)}
-                className="bg-white dark:bg-card border border-border hover:border-baro-red/40 hover:bg-red-50 dark:hover:bg-red-950/20 rounded-lg p-5 flex flex-col gap-4 transition-colors text-left"
+                className="bg-white dark:bg-card border border-border hover:border-baro-red/40 hover:bg-red-50 dark:hover:bg-red-950/20 rounded-lg p-5 flex flex-col gap-4 transition-colors text-left cursor-pointer"
               >
                 <div className="w-10 h-10 rounded-lg bg-baro-red/10 flex items-center justify-center">
                   <Trash2 className="w-5 h-5 text-baro-red" />
@@ -415,7 +419,7 @@ const SystemStartPage = () => {
 
               <button
                 onClick={() => navigate('/store-settings')}
-                className="bg-white dark:bg-card border border-border hover:bg-muted/50 rounded-lg p-5 flex flex-col gap-4 transition-colors text-left"
+                className="bg-white dark:bg-card border border-border hover:bg-muted/50 rounded-lg p-5 flex flex-col gap-4 transition-colors text-left cursor-pointer"
               >
                 <div className="w-10 h-10 rounded-lg bg-muted flex items-center justify-center">
                   <Settings className="w-5 h-5 text-muted-foreground" />
@@ -443,7 +447,10 @@ const SystemStartPage = () => {
       <Dialog open={showHolidayModal} onOpenChange={setShowHolidayModal}>
         <DialogContent className="sm:max-w-sm">
           <DialogHeader>
-            <DialogTitle>임시 영업 시작</DialogTitle>
+            <DialogTitle className="flex items-center gap-2">
+              <Store className="size-4 text-muted-foreground" />
+              임시 영업 시작
+            </DialogTitle>
             <DialogDescription>
               오늘은 휴무일로 설정되어 있습니다. 그래도 영업을 시작하시겠습니까?
             </DialogDescription>
@@ -462,7 +469,7 @@ const SystemStartPage = () => {
                 handleStartBusiness(todayKST);
               }}
               disabled={isStarting}
-              className="bg-purple-600 hover:bg-purple-700 text-white"
+              className="bg-slate-100 hover:bg-slate-200 text-slate-700"
             >
               {isStarting ? '시작 중...' : '임시 영업 시작'}
             </Button>

--- a/src/pages/TermsOfServicePage.tsx
+++ b/src/pages/TermsOfServicePage.tsx
@@ -1,7 +1,5 @@
 import { ArrowLeft } from 'lucide-react';
-import { Link } from 'react-router-dom';
-
-import { routePaths } from '@/app/routes/routePaths';
+import { useNavigate } from 'react-router-dom';
 
 const SECTIONS = [
   {
@@ -79,16 +77,18 @@ const SECTIONS = [
 ];
 
 const TermsOfServicePage = () => {
+  const navigate = useNavigate();
   return (
     <div className="min-h-screen bg-white">
       <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-        <Link
-          to={routePaths.landing}
+        <button
+          type="button"
+          onClick={() => navigate(-1)}
           className="inline-flex items-center gap-2 text-sm text-gray-500 hover:text-gray-800 transition-colors mb-10"
         >
           <ArrowLeft className="w-4 h-4" />
           돌아가기
-        </Link>
+        </button>
 
         <h1 className="text-3xl font-bold text-baro-black mb-2">이용 약관</h1>
         <p className="text-sm text-gray-500 mb-10">

--- a/src/shadcn/ui/dialog.tsx
+++ b/src/shadcn/ui/dialog.tsx
@@ -26,7 +26,7 @@ function DialogOverlay({ className, ...props }: DialogPrimitive.Backdrop.Props) 
     <DialogPrimitive.Backdrop
       data-slot="dialog-overlay"
       className={cn(
-        'fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0',
+        'fixed inset-0 isolate z-50 bg-black/10 duration-200 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0',
         className,
       )}
       {...props}
@@ -48,7 +48,7 @@ function DialogContent({
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          'fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+          'fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-200 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
           className,
         )}
         {...props}

--- a/src/shadcn/ui/sonner.tsx
+++ b/src/shadcn/ui/sonner.tsx
@@ -30,6 +30,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
           '--normal-text': 'var(--popover-foreground)',
           '--normal-border': 'var(--border)',
           '--border-radius': 'var(--radius)',
+          fontFamily: "'Pretendard', system-ui, 'Segoe UI', Roboto, sans-serif",
         } as React.CSSProperties
       }
       toastOptions={{

--- a/src/shared/components/IngredientRegisterModal.tsx
+++ b/src/shared/components/IngredientRegisterModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { Trash2 } from 'lucide-react';
+import { Package, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 
 import {
@@ -125,6 +125,7 @@ const IngredientRegisterModal = ({
       <DialogContent className="max-w-sm">
         <DialogHeader>
           <DialogTitle className="text-lg! leading-none! flex items-center gap-2">
+            <Package className="size-4 text-muted-foreground" />
             {isEditMode ? '식자재 수정' : '식자재 등록'}
           </DialogTitle>
           <DialogDescription className="text-xs text-muted-foreground">
@@ -157,7 +158,7 @@ const IngredientRegisterModal = ({
                   v && setForm((prev) => ({ ...prev, unit: v as IngredientUnit }))
                 }
               >
-                <SelectTrigger className="h-9 w-full text-sm">
+                <SelectTrigger className="h-9! w-full text-sm">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -248,13 +249,13 @@ const IngredientRegisterModal = ({
           )}
 
           <div className="flex gap-2 pt-1">
-            <Button type="button" variant="outline" className="flex-1" onClick={onClose}>
+            <Button type="button" variant="outline" className="flex-1 h-10" onClick={onClose}>
               취소
             </Button>
             <Button
               type="submit"
               disabled={!form.name.trim() || isPending}
-              className="flex-1 bg-baro-blue hover:bg-baro-blue/90 text-white"
+              className="flex-1 bg-baro-blue hover:bg-baro-blue/90 text-white h-10"
             >
               {isPending
                 ? isEditMode

--- a/src/widgets/AppHeader.tsx
+++ b/src/widgets/AppHeader.tsx
@@ -41,9 +41,9 @@ const AppHeader = ({
       {missedClosing && (
         <Link
           to={`/closing?date=${getYesterdayKST()}`}
-          className="flex items-center gap-1.5 rounded-full border border-amber-300 bg-amber-50 px-3 py-1 text-xs font-medium text-amber-700 hover:bg-amber-100 transition-colors"
+          className="flex items-center gap-1.5 rounded-full border border-baro-yellow/50 bg-baro-yellow/10 px-3 py-1 text-xs font-medium text-baro-yellow-text hover:bg-baro-yellow/20 transition-colors"
         >
-          <AlertTriangle className="h-3 w-3 shrink-0" />
+          <AlertTriangle className="h-3 w-3 shrink-0 text-baro-yellow-dark" />
           전날 마감 누락
         </Link>
       )}


### PR DESCRIPTION
## 📌 요약

- 브랜드 색상 `baro-yellow` 디자인 토큰을 신설하고, 전체 amber 계열 임시 색상을 통일
- 모든 다이얼로그·모달 타이틀에 컨텍스트 아이콘 추가로 시각적 일관성 강화
- 가게 설정 > 데이터 초기화 기능 실제 API 연동

<br/>

## 🏷️ 관련 이슈

- Closes #144

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- `baro-yellow / baro-yellow-dark / baro-yellow-text` CSS 변수 및 Tailwind 토큰 추가 (`index.css`)
- 전체 amber 계열 색상 → baro-yellow 토큰으로 일괄 교체 (MemoCard, InventoryTable, OcrReviewStep, CustomerOrderStatus 등 12개 파일)
- `POST /stores/:id/reset` API 연동 및 DataSection 확인 다이얼로그 구현 (삭제·유지 항목 시각화)
- 앱 정보 섹션 이용약관·개인정보처리방침·문의하기 링크 실제 연결
- 이용약관·개인정보처리방침 페이지 '돌아가기' 랜딩 고정 → `navigate(-1)` 변경

### 📂 세부 변경사항

- **SystemStartPage**: 영업시작·소급마감·임시영업 액션 버튼을 색상 배경(blue/amber/purple)에서 white/border 카드 스타일로 통일
- **AfterClosingModal**: Moon → CalendarCheck 아이콘, 소급 마감 여부 텍스트 분기, 버튼 레이아웃 세로 정렬
- **StepOperatingHours**: `<input type="time">` → 시·분 드롭다운 `TimePicker` 컴포넌트로 교체
- **InventoryTable**: 필터 탭 + 액션 버튼(OCR·즐겨찾기·정렬·검색)을 동일 행 배치로 개선
- **다이얼로그 타이틀 아이콘**: 식자재 등록·재고 수정·기존 식자재 연결·초대코드·메뉴 OCR·레시피 수정·삭제·회원 탈퇴 등 전 다이얼로그 아이콘 추가
- **StoreInfoSection**: SelectValue에 레이블 명시 (사업 유형·카테고리 선택값 표시 버그 수정)
- **shadcn/dialog**: 애니메이션 duration-100 → duration-200
- **shadcn/sonner**: Pretendard 폰트 패밀리 명시 적용
- 버튼 높이 h-10 통일, 탈퇴 버튼 destructive → baro-red 커스텀 스타일

<br/>

## 📸 Screenshots

| Before | After |
| ------ | ----- |
| SystemStartPage: 파란/주황/보라 배경 버튼 | white/border 카드 스타일 통일 |
| amber 계열 임시 색상 혼용 | baro-yellow 토큰으로 통일 |
| 다이얼로그 타이틀 텍스트만 표시 | 컨텍스트 아이콘 + 텍스트 |

<br/>

## 🧪 테스트 방법

1. 재고 현황 페이지 → warning 상태 배지·즐겨찾기 색상 확인
2. 가게 설정 > 데이터 관리 > 초기화 버튼 → 확인 다이얼로그 노출 및 삭제·유지 항목 확인
3. 회원 설정 > 앱 정보 > 이용약관·개인정보처리방침 링크 클릭 → 페이지 이동 후 '돌아가기' 버튼으로 복귀 확인
4. 초기설정 > 운영시간 단계 → 시·분 드롭다운 TimePicker 정상 동작 확인
5. 마감 완료 > AfterClosingModal → 소급 마감과 일반 마감 각각 텍스트 분기 확인
6. 각 다이얼로그(식자재 등록, 재고 수정, 메뉴 등록 등) 타이틀 아이콘 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [ ] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- `shadcn/ui/dialog.tsx`, `shadcn/ui/sonner.tsx`는 원칙상 수정 금지이나, 프로젝트 전체 UX와 폰트 일관성을 위해 최소한으로 수정함
- `StoreInfoSection` SelectValue 레이블 표시 수정은 기존 사업 유형·카테고리 선택값이 Select 트리거에 반영되지 않던 버그 수정 포함