### PR TITLE
🐛 (#148) fix: 아이디/비밀번호 로그인 실패 시 카카오 로그인 페이지로 강제 이동되는 버그 수정

### DIFF
--- a/src/shared/api/axiosInstance.ts
+++ b/src/shared/api/axiosInstance.ts
@@ -15,11 +15,15 @@ axiosInstance.interceptors.request.use((config) => {
   return config;
 });
 
+const AUTH_REQUEST_URLS = ['/auth/login', '/auth/register'];
+
 axiosInstance.interceptors.response.use(
   (response) => response,
   (error) => {
-    const isRefreshRequest = error.config?.url?.includes('/auth/refresh');
-    if (error.response?.status === 401 && !isRefreshRequest) {
+    const requestUrl: string = error.config?.url ?? '';
+    const isRefreshRequest = requestUrl.includes('/auth/refresh');
+    const isAuthRequest = AUTH_REQUEST_URLS.some((url) => requestUrl.includes(url));
+    if (error.response?.status === 401 && !isRefreshRequest && !isAuthRequest) {
       useAuthStore.getState().clearAuth();
       window.location.href = '/login';
     }


### PR DESCRIPTION
## 📌 요약

- 아이디/비밀번호 로그인 실패 시 에러 토스트 없이 카카오 로그인 페이지(`/login`)로 강제 이동되는 버그 수정
- Axios 응답 인터셉터에서 인증 요청(`/auth/login`, `/auth/register`)의 401은 리다이렉트를 건너뛰도록 처리

<br/>

## 🏷️ 관련 이슈

- Closes #148

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- `axiosInstance.ts` 응답 인터셉터에 `isAuthRequest` 조건 추가: 인증 엔드포인트의 401은 리다이렉트 대신 에러를 그대로 전파

<br/>

### 📂 세부 변경사항

- `src/shared/api/axiosInstance.ts`: `AUTH_REQUEST_URLS` 상수 정의 후 interceptor 조건 분기 추가

<br/>

## 📸 Screenshots

| Before | After |
| ------ | ----- |
| 로그인 실패 시 토스트 없이 `/login`(카카오 로그인)으로 이동 | 로그인 실패 시 "아이디 또는 비밀번호가 올바르지 않습니다." 토스트 표시 후 폼 유지 |

<br/>

## 🧪 테스트 방법

1. `/credential-login` 접속
2. 잘못된 아이디/비밀번호 입력 후 로그인 버튼 클릭
3. 에러 토스트가 표시되고 페이지 이동 없이 폼에 머무는지 확인
4. 올바른 자격증명으로 로그인 시 정상 이동 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [ ] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- 기존에 `isRefreshRequest` 체크만 있던 로직에 `isAuthRequest` 조건을 추가한 것으로, 인증된 사용자의 세션 만료 리다이렉트 동작에는 영향 없음
- `/auth/login`, `/auth/register` 두 엔드포인트만 예외 처리하며, 이후 인증 관련 엔드포인트가 추가되면 `AUTH_REQUEST_URLS`에 추가
