### PR TITLE
🐛 (#153) fix: 가입·로그인 리다이렉트 및 계정 홈 편집 모드·가게 관리 구현

### DIFF
--- a/src/features/auth/components/CredentialLoginForm.tsx
+++ b/src/features/auth/components/CredentialLoginForm.tsx
@@ -10,7 +10,6 @@ import { z } from 'zod';
 import { routePaths } from '@/app/routes/routePaths';
 import { credentialLogin } from '@/features/auth/api/authApi';
 import useAuthStore from '@/features/auth/store/authStore';
-import { fetchMyStores } from '@/features/store-registration/api/storeRegistration.api';
 import { Button } from '@/shadcn/ui/button';
 import { Input } from '@/shadcn/ui/input';
 import { Label } from '@/shadcn/ui/label';
@@ -24,7 +23,7 @@ type FormValues = z.infer<typeof schema>;
 
 const CredentialLoginForm = () => {
   const navigate = useNavigate();
-  const { setTokens, setStoreId } = useAuthStore();
+  const { setTokens } = useAuthStore();
   const [showPassword, setShowPassword] = useState(false);
 
   const {
@@ -37,18 +36,6 @@ const CredentialLoginForm = () => {
     try {
       const { accessToken, refreshToken } = await credentialLogin(values);
       setTokens(accessToken, refreshToken);
-
-      const stores = await fetchMyStores().catch(() => []);
-
-      if (stores.length === 0) {
-        navigate(routePaths.storeSelection, { replace: true });
-        return;
-      }
-
-      const saved = useAuthStore.getState().storeId;
-      const match = stores.find((s) => s.storeId === saved);
-      const target = match ?? stores[0];
-      setStoreId(target.storeId);
       navigate(routePaths.myStores, { replace: true });
     } catch (err: unknown) {
       const status = (err as { response?: { status?: number } })?.response?.status;

--- a/src/features/auth/components/RegisterForm.tsx
+++ b/src/features/auth/components/RegisterForm.tsx
@@ -13,7 +13,6 @@ import useAuthStore from '@/features/auth/store/authStore';
 import { Button } from '@/shadcn/ui/button';
 import { Input } from '@/shadcn/ui/input';
 import { Label } from '@/shadcn/ui/label';
-import axiosInstance from '@/shared/api/axiosInstance';
 
 const schema = z.object({
   username: z
@@ -30,7 +29,7 @@ type FormValues = z.infer<typeof schema>;
 
 const RegisterForm = () => {
   const navigate = useNavigate();
-  const { setTokens, setStoreId } = useAuthStore();
+  const { setTokens } = useAuthStore();
   const [showPassword, setShowPassword] = useState(false);
 
   const {
@@ -41,23 +40,9 @@ const RegisterForm = () => {
 
   const onSubmit = async (values: FormValues) => {
     try {
-      const { accessToken, refreshToken, isNewUser } = await registerApi(values);
+      const { accessToken, refreshToken } = await registerApi(values);
       setTokens(accessToken, refreshToken);
-
-      if (isNewUser) {
-        navigate(routePaths.initialSetup, { replace: true });
-        return;
-      }
-
-      axiosInstance
-        .get('/users/me/store')
-        .then((res) => {
-          if (res.data.data?.storeId) {
-            setStoreId(res.data.data.storeId);
-          }
-        })
-        .catch(() => {})
-        .finally(() => navigate(routePaths.storeHome, { replace: true }));
+      navigate(routePaths.myStores, { replace: true });
     } catch (err: unknown) {
       const status = (err as { response?: { status?: number } })?.response?.status;
       if (status === 403) {

--- a/src/features/initial-setup/components/InitialSetupForm.tsx
+++ b/src/features/initial-setup/components/InitialSetupForm.tsx
@@ -165,7 +165,12 @@ const InitialSetupForm = () => {
           </div>
 
           {/* Step card */}
-          <Card className="flex flex-col shadow-sm max-h-[calc(100vh-14rem)] overflow-hidden">
+          <Card
+            className={cn(
+              'flex flex-col shadow-sm overflow-hidden',
+              currentStep >= 3 ? 'h-[calc(100vh-14rem)]' : 'max-h-[calc(100vh-14rem)]',
+            )}
+          >
             <CardHeader>
               <div className="flex items-center gap-2">
                 <span className="flex size-6 items-center justify-center rounded-full bg-baro-blue text-xs font-bold text-white">
@@ -176,7 +181,9 @@ const InitialSetupForm = () => {
               <CardDescription className="mt-0.5">{currentStepConfig.description}</CardDescription>
             </CardHeader>
             <CardContent className="flex flex-1 min-h-0 flex-col px-4 py-2">
-              <div className="flex flex-1 min-h-0 flex-col">{renderStep()}</div>
+              <div className="flex flex-1 min-h-0 flex-col overflow-y-auto overflow-x-hidden">
+                {renderStep()}
+              </div>
             </CardContent>
           </Card>
 

--- a/src/features/initial-setup/components/steps/StepIngredientsAndRecipes.tsx
+++ b/src/features/initial-setup/components/steps/StepIngredientsAndRecipes.tsx
@@ -330,7 +330,7 @@ const StepIngredientsAndRecipes = ({
   };
 
   return (
-    <div className="flex flex-1 min-h-0 gap-4">
+    <div className="flex flex-1 min-h-0 flex-col gap-4 md:flex-row">
       {/* ── 왼쪽 패널: 식자재 등록 ── */}
       <div className="flex flex-1 min-h-0 flex-col overflow-hidden rounded-xl border">
         {/* 패널 헤더 */}

--- a/src/features/initial-setup/components/steps/StepOperatingHours.tsx
+++ b/src/features/initial-setup/components/steps/StepOperatingHours.tsx
@@ -62,7 +62,7 @@ const StepOperatingHours = ({ data, onChange }: StepOperatingHoursProps) => {
   };
 
   return (
-    <div className="grid grid-cols-2 gap-1.5">
+    <div className="grid grid-cols-1 gap-1.5 md:grid-cols-2">
       {DAY_OF_WEEK_CONFIG.map((day, index) => {
         const hour = data[index];
         const isSat = day.value === 'saturday';

--- a/src/features/store-registration/api/storeRegistration.api.ts
+++ b/src/features/store-registration/api/storeRegistration.api.ts
@@ -18,3 +18,11 @@ export async function regenerateInviteCode(storeId: string): Promise<string> {
   const response = await axiosInstance.post(`/stores/${storeId}/invite-code`);
   return response.data.data.inviteCode;
 }
+
+export async function deleteStore(storeId: string): Promise<void> {
+  await axiosInstance.delete(`/stores/${storeId}`);
+}
+
+export async function leaveStore(storeId: string): Promise<void> {
+  await axiosInstance.delete(`/stores/${storeId}/members/me`);
+}

--- a/src/features/store-registration/components/MyStoresList.tsx
+++ b/src/features/store-registration/components/MyStoresList.tsx
@@ -4,10 +4,12 @@ import {
   Check,
   ChevronRight,
   Info,
+  Loader2,
   LogOut,
   Moon,
   Pencil,
   Plus,
+  Settings,
   Store,
   Sun,
   Trash2,
@@ -23,12 +25,26 @@ import { APP_VERSION } from '@/features/account-settings/data/account-settings.m
 import { useUpdateUserName, useUserInfo } from '@/features/account-settings/hooks/useUserInfo';
 import { logout } from '@/features/auth/api/authApi';
 import useAuthStore from '@/features/auth/store/authStore';
-import { useMyStores } from '@/features/store-registration/hooks/useMyStores';
+import {
+  useDeleteStore,
+  useLeaveStore,
+  useMyStores,
+} from '@/features/store-registration/hooks/useMyStores';
 import type { MyStore } from '@/features/store-registration/types/storeRegistration.types';
 import { fetchStoreSettings } from '@/features/store-settings/api/storeSettings.api';
 import ThemeToggle from '@/features/theme/components/ThemeToggle';
 import { useTheme } from '@/features/theme/hooks/useTheme';
 import { cn } from '@/lib/utils';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/shadcn/ui/alert-dialog';
 import { Button } from '@/shadcn/ui/button';
 import {
   Dialog,
@@ -74,7 +90,13 @@ const MyStoresList = () => {
   const [withdrawOpen, setWithdrawOpen] = useState(false);
   const [isEditingName, setIsEditingName] = useState(false);
   const [draftName, setDraftName] = useState('');
+  const [isEditMode, setIsEditMode] = useState(false);
+  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
+  const [leaveTargetId, setLeaveTargetId] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  const { mutate: deleteStoreMutate, isPending: isDeleting } = useDeleteStore();
+  const { mutate: leaveStoreMutate, isPending: isLeaving } = useLeaveStore();
 
   const handleSelectStore = async (storeId: string) => {
     setSelectingId(storeId);
@@ -129,6 +151,36 @@ const MyStoresList = () => {
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') handleSaveName();
     if (e.key === 'Escape') setIsEditingName(false);
+  };
+
+  const handleDeleteConfirm = () => {
+    if (!deleteTargetId) return;
+    deleteStoreMutate(deleteTargetId, {
+      onSuccess: () => {
+        toast.success('가게가 삭제되었습니다.');
+        useAuthStore.setState({ storeId: null });
+        setDeleteTargetId(null);
+        setIsEditMode(false);
+      },
+      onError: () => {
+        toast.error('가게 삭제에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+      },
+    });
+  };
+
+  const handleLeaveConfirm = () => {
+    if (!leaveTargetId) return;
+    leaveStoreMutate(leaveTargetId, {
+      onSuccess: () => {
+        toast.success('가게에서 나왔습니다.');
+        useAuthStore.setState({ storeId: null });
+        setLeaveTargetId(null);
+        setIsEditMode(false);
+      },
+      onError: () => {
+        toast.error('가게 나가기에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+      },
+    });
   };
 
   const isBlocked = selectingId !== null || isLoggingOut;
@@ -232,6 +284,20 @@ const MyStoresList = () => {
               <ThemeToggle dark={dark} toggleTheme={toggleTheme} />
             </div>
 
+            {/* 내 가게 설정 */}
+            {stores && stores.length > 0 && (
+              <button
+                onClick={() => setIsEditMode((v) => !v)}
+                className="flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-sm text-left transition-colors hover:bg-muted"
+              >
+                <div className="flex items-center gap-2.5">
+                  <Settings className="h-4 w-4 text-muted-foreground" />
+                  <span>{isEditMode ? '편집 완료' : '내 가게 설정'}</span>
+                </div>
+                {isEditMode && <span className="h-2 w-2 rounded-full bg-baro-blue animate-pulse" />}
+              </button>
+            )}
+
             {/* 서비스 정보 드롭다운 */}
             <DropdownMenu>
               <DropdownMenuTrigger>
@@ -299,7 +365,7 @@ const MyStoresList = () => {
           </div>
 
           {/* Stores grid — scrolls internally */}
-          <div className="flex-1 overflow-y-auto p-1 md:overflow-y-auto">
+          <div className="flex-1 overflow-y-auto p-1 pt-3 md:overflow-y-auto">
             {isStoresLoading ? (
               <div className="grid grid-cols-2 gap-3 md:grid-cols-2 md:gap-4 lg:grid-cols-3">
                 {Array.from({ length: 3 }).map((_, i) => (
@@ -314,11 +380,29 @@ const MyStoresList = () => {
                     <div
                       key={store.storeId}
                       className={cn(
-                        'group flex flex-col justify-between gap-5 rounded-2xl border bg-background p-5',
-                        'shadow-sm transition-all duration-200 hover:shadow-md hover:-translate-y-0.5 ',
+                        'group relative flex flex-col justify-between gap-5 rounded-2xl border bg-background p-5',
+                        'shadow-sm transition-all duration-200',
+                        !isEditMode && 'hover:shadow-md hover:-translate-y-0.5',
                         isSelecting && 'pointer-events-none opacity-60',
+                        isEditMode && 'animate-wiggle',
                       )}
                     >
+                      {isEditMode && store.role === 'owner' && (
+                        <button
+                          className="absolute -right-2 -top-2 z-10 flex h-5 w-5 items-center justify-center rounded-full bg-baro-blue text-white shadow"
+                          onClick={() => setDeleteTargetId(store.storeId)}
+                        >
+                          <X className="size-3" />
+                        </button>
+                      )}
+                      {isEditMode && store.role === 'staff' && (
+                        <button
+                          className="absolute -right-2 -top-2 z-10 flex h-5 w-5 items-center justify-center rounded-full bg-baro-blue text-white shadow text-sm font-bold leading-none"
+                          onClick={() => setLeaveTargetId(store.storeId)}
+                        >
+                          –
+                        </button>
+                      )}
                       <div className="space-y-3">
                         <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-muted">
                           <Store className="size-6 text-muted-foreground" />
@@ -339,7 +423,7 @@ const MyStoresList = () => {
                         size="sm"
                         className="w-full h-9 rounded-full bg-baro-blue text-white hover:bg-baro-blue/90"
                         onClick={() => handleSelectStore(store.storeId)}
-                        disabled={isBlocked}
+                        disabled={isBlocked || isEditMode}
                       >
                         {isSelecting ? '이동 중...' : '입장하기'}
                       </Button>
@@ -348,37 +432,97 @@ const MyStoresList = () => {
                 })}
 
                 {/* Add store card */}
-                <button
-                  onClick={() => navigate(routePaths.storeSelection)}
-                  disabled={isBlocked}
-                  className="flex flex-col items-center justify-center gap-2 rounded-2xl border-2 border-dashed bg-background text-muted-foreground transition-colors hover:border-baro-blue/40 hover:bg-baro-blue/5 hover:text-baro-blue min-h-44"
-                >
-                  <Plus className="size-6" />
-                  <span className="text-sm font-medium">새 가게 추가</span>
-                  <span className="text-xs">새 가게 등록 또는 초대코드로 합류</span>
-                </button>
+                {!isEditMode && (
+                  <button
+                    onClick={() => navigate(routePaths.storeSelection)}
+                    disabled={isBlocked}
+                    className="flex flex-col items-center justify-center gap-2 rounded-2xl border-2 border-dashed bg-background text-muted-foreground transition-colors hover:border-baro-blue/40 hover:bg-baro-blue/5 hover:text-baro-blue min-h-44"
+                  >
+                    <Plus className="size-6" />
+                    <span className="text-sm font-medium">새 가게 추가</span>
+                    <span className="text-xs">새 가게 등록 또는 초대코드로 합류</span>
+                  </button>
+                )}
               </div>
             ) : (
-              <div className="flex h-full flex-col items-center justify-center gap-3 rounded-2xl border-2 border-dashed bg-background text-center">
-                <Store className="size-10 text-muted-foreground/40" />
-                <div>
-                  <p className="font-semibold">참여 중인 가게가 없어요</p>
-                  <p className="mt-0.5 text-sm text-muted-foreground">
-                    가게를 만들거나 초대코드로 합류해 보세요.
+              <div className="flex h-full flex-col items-center justify-center gap-4 rounded-2xl border bg-background text-center">
+                <Store className="size-9 text-muted-foreground" strokeWidth={1.25} />
+                <div className="space-y-1">
+                  <p className="font-medium">참여 중인 가게가 없어요</p>
+                  <p className="text-sm text-muted-foreground">
+                    가게를 등록하거나 초대코드로 합류하세요.
                   </p>
                 </div>
                 <Button
-                  className="mt-2 gap-2 bg-baro-blue text-white hover:bg-baro-blue/90"
+                  size="sm"
+                  className="bg-baro-blue text-white hover:bg-baro-blue/90"
                   onClick={() => navigate(routePaths.storeSelection)}
                 >
-                  <Plus className="size-4" />
-                  시작하기
+                  가게 추가하기
                 </Button>
               </div>
             )}
           </div>
         </main>
       </div>
+
+      {/* Delete store dialog */}
+      <AlertDialog
+        open={deleteTargetId !== null}
+        onOpenChange={(open) => !open && setDeleteTargetId(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle className="flex items-center gap-2 text-baro-red">
+              <TriangleAlert className="size-4" />
+              가게를 삭제하시겠어요?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              가게를 삭제하면 재고·메뉴·레시피 등 모든 데이터가 영구적으로 삭제됩니다. 이 작업은
+              되돌릴 수 없습니다.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeleting}>취소</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDeleteConfirm}
+              disabled={isDeleting}
+              className="bg-baro-red hover:bg-baro-red-dark text-white"
+            >
+              {isDeleting ? <Loader2 className="size-4 animate-spin" /> : '삭제'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Leave store dialog */}
+      <AlertDialog
+        open={leaveTargetId !== null}
+        onOpenChange={(open) => !open && setLeaveTargetId(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle className="flex items-center gap-2">
+              <TriangleAlert className="size-4 text-baro-red" />
+              가게에서 나가시겠어요?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              가게를 나가면 더 이상 해당 가게에 접근할 수 없습니다. 다시 합류하려면 초대코드가
+              필요합니다.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isLeaving}>취소</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleLeaveConfirm}
+              disabled={isLeaving}
+              className="bg-baro-red hover:bg-baro-red-dark text-white"
+            >
+              {isLeaving ? <Loader2 className="size-4 animate-spin" /> : '나가기'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       {/* Withdraw dialog */}
       <Dialog open={withdrawOpen} onOpenChange={setWithdrawOpen}>

--- a/src/features/store-registration/hooks/useMyStores.ts
+++ b/src/features/store-registration/hooks/useMyStores.ts
@@ -1,10 +1,34 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import { fetchMyStores } from '@/features/store-registration/api/storeRegistration.api';
+import {
+  deleteStore,
+  fetchMyStores,
+  leaveStore,
+} from '@/features/store-registration/api/storeRegistration.api';
 
 export function useMyStores() {
   return useQuery({
     queryKey: ['myStores'],
     queryFn: fetchMyStores,
+  });
+}
+
+export function useDeleteStore() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: deleteStore,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['myStores'] });
+    },
+  });
+}
+
+export function useLeaveStore() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: leaveStore,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['myStores'] });
+    },
   });
 }

--- a/src/features/store-settings/components/sections/DataSection.tsx
+++ b/src/features/store-settings/components/sections/DataSection.tsx
@@ -1,9 +1,16 @@
 import { useState } from 'react';
 
 import { AlertTriangle, Database, Loader2, Trash2 } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 
-import { useResetStoreData } from '@/features/store-settings/hooks/useStoreSettings';
+import { routePaths } from '@/app/routes/routePaths';
+import useAuthStore from '@/features/auth/store/authStore';
+import { useDeleteStore, useLeaveStore } from '@/features/store-registration/hooks/useMyStores';
+import {
+  useResetStoreData,
+  useStoreSettings,
+} from '@/features/store-settings/hooks/useStoreSettings';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -19,8 +26,16 @@ import SettingRow from '@/shared/components/SettingRow';
 import SettingsSection from '@/shared/components/SettingsSection';
 
 const DataSection = () => {
+  const navigate = useNavigate();
+  const storeId = useAuthStore((s) => s.storeId);
+  const { data: settings } = useStoreSettings();
+  const isOwner = settings?.myRole === 'owner';
   const [open, setOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [leaveOpen, setLeaveOpen] = useState(false);
   const { mutate: resetStore, isPending } = useResetStoreData();
+  const { mutate: deleteStoreMutate, isPending: isDeleting } = useDeleteStore();
+  const { mutate: leaveStoreMutate, isPending: isLeaving } = useLeaveStore();
 
   const handleConfirm = () => {
     resetStore(undefined, {
@@ -35,11 +50,41 @@ const DataSection = () => {
     });
   };
 
+  const handleDeleteConfirm = () => {
+    if (!storeId) return;
+    deleteStoreMutate(storeId, {
+      onSuccess: () => {
+        toast.success('가게가 삭제되었습니다.');
+        useAuthStore.setState({ storeId: null });
+        navigate(routePaths.myStores, { replace: true });
+      },
+      onError: () => {
+        toast.error('가게 삭제에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+        setDeleteOpen(false);
+      },
+    });
+  };
+
+  const handleLeaveConfirm = () => {
+    if (!storeId) return;
+    leaveStoreMutate(storeId, {
+      onSuccess: () => {
+        toast.success('가게에서 나왔습니다.');
+        useAuthStore.setState({ storeId: null });
+        navigate(routePaths.myStores, { replace: true });
+      },
+      onError: () => {
+        toast.error('가게 나가기에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+        setLeaveOpen(false);
+      },
+    });
+  };
+
   return (
     <>
       <SettingsSection
         title="데이터 관리"
-        description="재고 데이터를 초기화합니다."
+        description="재고 데이터 초기화 또는 가게 삭제를 진행합니다."
         icon={<Database className="h-4 w-4" />}
       >
         {/* MVP 이후 구현 예정
@@ -70,6 +115,39 @@ const DataSection = () => {
             </Button>
           }
         />
+        {isOwner ? (
+          <SettingRow
+            label="가게 삭제"
+            description="가게와 관련된 모든 데이터가 영구 삭제됩니다. 이 작업은 되돌릴 수 없습니다."
+            action={
+              <Button
+                variant="outline"
+                size="sm"
+                className="gap-1.5 border-baro-red text-baro-red hover:bg-baro-red/10 hover:text-baro-red"
+                onClick={() => setDeleteOpen(true)}
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+                가게 삭제
+              </Button>
+            }
+          />
+        ) : (
+          <SettingRow
+            label="가게 떠나기"
+            description="가게에서 나가면 더 이상 접근할 수 없습니다. 재합류하려면 초대코드가 필요합니다."
+            action={
+              <Button
+                variant="outline"
+                size="sm"
+                className="gap-1.5 border-baro-red text-baro-red hover:bg-baro-red/10 hover:text-baro-red"
+                onClick={() => setLeaveOpen(true)}
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+                가게 떠나기
+              </Button>
+            }
+          />
+        )}
       </SettingsSection>
 
       <AlertDialog open={open} onOpenChange={setOpen}>
@@ -134,6 +212,58 @@ const DataSection = () => {
               className="bg-baro-red hover:bg-baro-red-dark text-white"
             >
               {isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : '초기화 확정'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* 가게 나가기 확인 다이얼로그 */}
+      <AlertDialog open={leaveOpen} onOpenChange={setLeaveOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle className="flex items-center gap-2 text-baro-red">
+              <AlertTriangle className="w-4 h-4" />
+              가게에서 나가시겠어요?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              가게를 떠나면 더 이상 해당 가게에 접근할 수 없습니다. 다시 합류하려면 초대코드가
+              필요합니다.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isLeaving}>취소</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleLeaveConfirm}
+              disabled={isLeaving}
+              className="bg-baro-red hover:bg-baro-red-dark text-white"
+            >
+              {isLeaving ? <Loader2 className="w-4 h-4 animate-spin" /> : '나가기'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* 가게 삭제 확인 다이얼로그 */}
+      <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle className="flex items-center gap-2 text-baro-red">
+              <AlertTriangle className="w-4 h-4" />
+              가게를 삭제하시겠어요?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              가게를 삭제하면 재고·메뉴·레시피·주문 내역 등 모든 데이터가 영구적으로 삭제됩니다. 이
+              작업은 되돌릴 수 없습니다.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeleting}>취소</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDeleteConfirm}
+              disabled={isDeleting}
+              className="bg-baro-red hover:bg-baro-red-dark text-white"
+            >
+              {isDeleting ? <Loader2 className="w-4 h-4 animate-spin" /> : '가게 삭제'}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/index.css
+++ b/src/index.css
@@ -226,6 +226,16 @@ code {
   }
 }
 
+/* iOS 스타일 카드 흔들기 애니메이션 */
+@keyframes wiggle {
+  0%, 100% { transform: rotate(-0.6deg); }
+  50% { transform: rotate(0.6deg); }
+}
+
+.animate-wiggle {
+  animation: wiggle 0.4s ease-in-out infinite;
+}
+
 /* 페이지 전환 애니메이션 */
 @keyframes page-fade-in {
   from {

--- a/src/pages/AuthCallbackPage.tsx
+++ b/src/pages/AuthCallbackPage.tsx
@@ -4,7 +4,6 @@ import { useNavigate } from 'react-router-dom';
 
 import { routePaths } from '@/app/routes/routePaths';
 import useAuthStore from '@/features/auth/store/authStore';
-import { fetchMyStores } from '@/features/store-registration/api/storeRegistration.api';
 
 /* TODO: 백엔드와 협의 후 URL 쿼리로 토큰 전달 방식 개선 필요
    - 현재: accessToken/refreshToken이 URL에 노출 → 브라우저 히스토리, 서버 로그에 잔류
@@ -12,7 +11,6 @@ import { fetchMyStores } from '@/features/store-registration/api/storeRegistrati
 const AuthCallbackPage = () => {
   const navigate = useNavigate();
   const setTokens = useAuthStore((s) => s.setTokens);
-  const setStoreId = useAuthStore((s) => s.setStoreId);
   const processed = useRef(false);
 
   useEffect(() => {
@@ -30,21 +28,8 @@ const AuthCallbackPage = () => {
     }
 
     setTokens(accessToken, refreshToken);
-
-    fetchMyStores()
-      .then((stores) => {
-        if (stores.length === 0) {
-          navigate(routePaths.storeSelection, { replace: true });
-        } else {
-          const saved = useAuthStore.getState().storeId;
-          const match = stores.find((s) => s.storeId === saved);
-          const target = match ?? stores[0];
-          setStoreId(target.storeId);
-          navigate(routePaths.myStores, { replace: true });
-        }
-      })
-      .catch(() => navigate(routePaths.storeSelection, { replace: true }));
-  }, [navigate, setTokens, setStoreId]);
+    navigate(routePaths.myStores, { replace: true });
+  }, [navigate, setTokens]);
 
   return (
     <div className="flex min-h-screen items-center justify-center">


### PR DESCRIPTION
## 📌 요약

- 가입·로그인 후 스토어 수 분기 없이 항상 계정 홈(`/my-stores`)으로 이동하도록 수정
- 계정 홈에 iOS 스타일 편집 모드 추가 (wiggle 애니메이션, 가게 삭제·나가기)
- 가게 설정 `DataSection`에서 role 기반 가게 삭제/나가기 분기 처리
- 초기 세팅 단계별 카드 높이 및 모바일 반응형 레이아웃 개선

<br/>

## 🏷️ 관련 이슈

- Closes #153
- Related to #156

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- `RegisterForm`, `CredentialLoginForm`, `AuthCallbackPage` — 스토어 수 사전 조회 및 분기 제거, 항상 `/my-stores` 이동
- `MyStoresList` — 편집 모드 진입 시 카드 wiggle 애니메이션, owner 카드 X(삭제), staff 카드 −(나가기) 버튼, 빈 목록 empty state UI 개선
- `DataSection` — `myRole === 'owner'` 여부에 따라 "가게 삭제" / "가게 떠나기" SettingRow 분기

<br/>

### 📂 세부 변경사항

- `src/index.css` — wiggle 키프레임 추가 (`±0.6deg`, `0.4s`)
- `storeRegistration.api.ts` — `deleteStore`, `leaveStore` API 함수 추가
- `useMyStores.ts` — `useDeleteStore`, `useLeaveStore` mutation 훅 추가
- `InitialSetupForm.tsx` — 3·4단계 `h-` 고정, `overflow-y-auto overflow-x-hidden` 스크롤 처리
- `StepIngredientsAndRecipes.tsx` — 모바일 세로 스택 (`flex-col md:flex-row`)
- `StepOperatingHours.tsx` — 모바일 1열 그리드 (`grid-cols-1 md:grid-cols-2`)

<br/>

## 📸 Screenshots

| Before | After |
| ------ | ----- |
| 로그인 후 `/store-selection`으로 이동 | 로그인 후 `/my-stores`(계정 홈)으로 이동 |
| 편집 모드 없음 | <img width="1918" height="978" alt="image" src="https://github.com/user-attachments/assets/3da4a59f-2ec6-470f-a96f-fb7b7e858889" /> |

<br/>

## 🧪 테스트 방법

1. 신규 가입 후 `/my-stores`로 이동하는지 확인
2. 가게 미등록 계정으로 로그인 후 `/my-stores`(빈 empty state)로 이동하는지 확인
3. 계정 홈 → "내 가게 설정" 버튼 클릭 → 카드 wiggle 확인
4. owner 가게: X 버튼 → 삭제 AlertDialog → 확정 후 카드 사라짐 확인
5. staff 가게: − 버튼 → 나가기 AlertDialog → 확정 후 카드 사라짐 확인
6. 가게 설정 → 데이터 관리 섹션에서 role별 "가게 삭제"/"가게 떠나기" 버튼 확인
7. 초기 세팅 3·4단계에서 카드 높이가 뷰포트에 맞게 고정되고 내부 스크롤 동작하는지 확인
8. 모바일에서 영업시간 요일 1열, 식자재/레시피 세로 스택 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [ ] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- `MyStoresList`는 empty state(#153)와 편집 모드(#156) 변경이 같은 파일에 있어 커밋을 분리했지만 PR은 하나로 묶음
- 기존 `store-selection` 분기 로직은 완전 제거 — `MyStoresList` empty state가 빈 목록 케이스를 자체 처리