### PR TITLE
🎨 (#154) style: 로그인 상태 랜딩 CTA UX 개선 및 계정 홈 서비스 소개 링크 추가

### DIFF
--- a/src/features/account-settings/data/account-settings.mock.ts
+++ b/src/features/account-settings/data/account-settings.mock.ts
@@ -20,4 +20,4 @@ export const MOCK_NOTIFICATION_SETTINGS: NotificationSettings = {
   },
 };
 
-export const APP_VERSION = '0.1.0 (Beta)';
+export const APP_VERSION = '1.0.0';

--- a/src/features/landing/components/CTASection.tsx
+++ b/src/features/landing/components/CTASection.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 
 import { routePaths } from '@/app/routes/routePaths';
+import useAuthStore from '@/features/auth/store/authStore';
 import { cn } from '@/lib/utils';
 import { Button } from '@/shadcn/ui/button';
 import { useScrollReveal } from '@/shared/hooks/useScrollReveal';
@@ -8,6 +9,7 @@ import { useScrollReveal } from '@/shared/hooks/useScrollReveal';
 const CTASection = () => {
   const navigate = useNavigate();
   const { ref, isVisible } = useScrollReveal();
+  const isLoggedIn = useAuthStore((s) => !!s.accessToken);
 
   return (
     <section ref={ref} className="py-20 overflow-hidden mb-20">
@@ -19,7 +21,7 @@ const CTASection = () => {
           )}
         >
           <p className="text-baro-blue text-xs font-bold uppercase tracking-[0.2em] mb-6">
-            무료로 시작하기
+            {isLoggedIn ? '이미 로그인되어 있어요' : '무료로 시작하기'}
           </p>
           <h2 className="text-2xl lg:text-4xl font-black text-baro-black dark:text-white leading-tight mb-4">
             지금 바로,
@@ -32,10 +34,10 @@ const CTASection = () => {
             매일 반복되는 비효율에서 벗어나세요.
           </p>
           <Button
-            onClick={() => navigate(routePaths.login)}
+            onClick={() => navigate(isLoggedIn ? routePaths.myStores : routePaths.login)}
             className="mt-8 bg-baro-blue hover:bg-baro-blue/90 text-white font-bold p-4 py-5 rounded-full text-sm"
           >
-            BARO 무료로 시작하기
+            {isLoggedIn ? '계정 홈으로 가기' : 'BARO 무료로 시작하기'}
           </Button>
         </div>
       </div>

--- a/src/features/landing/components/HeroSection.tsx
+++ b/src/features/landing/components/HeroSection.tsx
@@ -2,6 +2,7 @@ import { CheckCircle2, ClipboardCheck } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
 import { routePaths } from '@/app/routes/routePaths';
+import useAuthStore from '@/features/auth/store/authStore';
 import { cn } from '@/lib/utils';
 import { Button } from '@/shadcn/ui/button';
 import baroLogo from '@/shared/assets/images/baro-logo.png';
@@ -10,9 +11,10 @@ import { useScrollReveal } from '@/shared/hooks/useScrollReveal';
 const HeroSection = () => {
   const navigate = useNavigate();
   const { ref, isVisible } = useScrollReveal();
+  const isLoggedIn = useAuthStore((s) => !!s.accessToken);
 
   const handleStartClick = () => {
-    navigate(routePaths.login);
+    navigate(isLoggedIn ? routePaths.myStores : routePaths.login);
   };
 
   const handleFeaturesClick = () => {
@@ -66,7 +68,7 @@ const HeroSection = () => {
                 onClick={handleStartClick}
                 className="h-auto rounded-full bg-baro-blue px-8 py-3 hover:bg-baro-blue/90 w-full sm:w-auto text-white"
               >
-                BARO 시작하기
+                {isLoggedIn ? '계정 홈으로 가기' : 'BARO 시작하기'}
               </Button>
 
               <Button

--- a/src/features/landing/components/Navbar.tsx
+++ b/src/features/landing/components/Navbar.tsx
@@ -4,6 +4,7 @@ import { Menu, X } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
 import { routePaths } from '@/app/routes/routePaths';
+import useAuthStore from '@/features/auth/store/authStore';
 import ThemeToggle from '@/features/theme/components/ThemeToggle';
 import { useTheme } from '@/features/theme/hooks/useTheme';
 import { Button } from '@/shadcn/ui/button';
@@ -12,14 +13,15 @@ const Navbar = () => {
   const navigate = useNavigate();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const { dark, toggleTheme } = useTheme();
+  const isLoggedIn = useAuthStore((s) => !!s.accessToken);
 
   const handleLogoClick = () => {
     navigate(routePaths.landing);
     setIsMenuOpen(false);
   };
 
-  const handleLoginClick = () => {
-    navigate(routePaths.login);
+  const handleCtaClick = () => {
+    navigate(isLoggedIn ? routePaths.myStores : routePaths.login);
     setIsMenuOpen(false);
   };
 
@@ -68,9 +70,9 @@ const Navbar = () => {
             <div className="flex items-center gap-3 ml-4">
               <Button
                 className="bg-baro-blue hover:bg-baro-blue-dark text-xs rounded-full text-white"
-                onClick={handleLoginClick}
+                onClick={handleCtaClick}
               >
-                시작하기
+                {isLoggedIn ? '계정 홈으로' : '시작하기'}
               </Button>
               <ThemeToggle dark={dark} toggleTheme={toggleTheme} />
             </div>
@@ -112,9 +114,9 @@ const Navbar = () => {
             </a>
             <Button
               className="bg-baro-blue hover:bg-baro-blue/90 w-full h-11 text-white"
-              onClick={handleLoginClick}
+              onClick={handleCtaClick}
             >
-              시작하기
+              {isLoggedIn ? '계정 홈으로 가기' : '시작하기'}
             </Button>
           </div>
         </div>

--- a/src/features/store-registration/components/MyStoresList.tsx
+++ b/src/features/store-registration/components/MyStoresList.tsx
@@ -3,6 +3,7 @@ import { useRef, useState } from 'react';
 import {
   Check,
   ChevronRight,
+  Globe,
   Info,
   Loader2,
   LogOut,
@@ -312,6 +313,13 @@ const MyStoresList = () => {
               <DropdownMenuContent side="right" align="start" className="w-48">
                 <DropdownMenuItem disabled className="text-xs text-muted-foreground">
                   버전 {APP_VERSION}
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem>
+                  <Link to={routePaths.landing} className="flex items-center gap-2">
+                    <Globe className="h-3.5 w-3.5" />
+                    서비스 소개
+                  </Link>
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem>


### PR DESCRIPTION
## 📌 요약

- 로그인 상태에서 랜딩 페이지 방문 시 CTA 버튼이 `/login` 대신 `/my-stores`(계정 홈)으로 이동하도록 수정
- 계정 홈 좌측 패널 서비스 정보 드롭다운에 서비스 소개 페이지 링크 항목 추가
- 앱 표시 버전 `0.1.0 (Beta)` → `1.0.0` 업데이트

<br/>

## 🏷️ 관련 이슈

- Closes #154

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- `Navbar` — 로그인 상태에서 "시작하기" → "계정 홈으로", `/my-stores` 이동
- `HeroSection` — "BARO 시작하기" → "계정 홈으로 가기", `/my-stores` 이동
- `CTASection` — 버튼 및 상단 레이블 로그인 여부에 따라 분기 처리
- `MyStoresList` — 서비스 정보 드롭다운에 Globe 아이콘 + "서비스 소개" 항목 추가

<br/>

### 📂 세부 변경사항

- `useAuthStore((s) => !!s.accessToken)`으로 로그인 여부 확인, 조건부 렌더링 적용
- `account-settings.mock.ts` — `APP_VERSION` `'1.0.0'`으로 변경

<br/>

## 📸 Screenshots

| 상태 | Navbar 버튼 | Hero CTA | CTA Section |
| ---- | ---------- | -------- | ----------- |
| 비로그인 | 시작하기 → `/login` | BARO 시작하기 → `/login` | BARO 무료로 시작하기 → `/login` |
| 로그인 | 계정 홈으로 → `/my-stores` | 계정 홈으로 가기 → `/my-stores` | 계정 홈으로 가기 → `/my-stores` |

<br/>

## 🧪 테스트 방법

1. 비로그인 상태에서 `/` 방문 → Navbar "시작하기", Hero "BARO 시작하기" 클릭 시 `/login` 이동 확인
2. 로그인 상태에서 `/` 방문 → 버튼 텍스트 변경 확인, 클릭 시 `/my-stores` 이동 확인
3. 계정 홈 → 좌측 패널 "서비스 정보" 드롭다운 열기 → "서비스 소개" 항목 클릭 시 `/` 이동 확인
4. 계정 홈 / 회원 설정 앱 버전 표시 `1.0.0` 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [ ] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- 랜딩 3개 컴포넌트 모두 `useAuthStore`를 직접 구독 — 별도 Context 불필요