### PR TITLE
🐛 (#163) fix: 세션 만료 후 재로그인 시 원래 페이지로 복귀

### DIFF
--- a/src/features/auth/components/CredentialLoginForm.tsx
+++ b/src/features/auth/components/CredentialLoginForm.tsx
@@ -36,7 +36,13 @@ const CredentialLoginForm = () => {
     try {
       const { accessToken, refreshToken } = await credentialLogin(values);
       setTokens(accessToken, refreshToken);
-      navigate(routePaths.myStores, { replace: true });
+      const redirectPath = sessionStorage.getItem('baro-redirect-after-login');
+      if (redirectPath) {
+        sessionStorage.removeItem('baro-redirect-after-login');
+        navigate(redirectPath, { replace: true });
+      } else {
+        navigate(routePaths.myStores, { replace: true });
+      }
     } catch (err: unknown) {
       const status = (err as { response?: { status?: number } })?.response?.status;
       if (status === 401) {

--- a/src/pages/AuthCallbackPage.tsx
+++ b/src/pages/AuthCallbackPage.tsx
@@ -28,7 +28,13 @@ const AuthCallbackPage = () => {
     }
 
     setTokens(accessToken, refreshToken);
-    navigate(routePaths.myStores, { replace: true });
+    const redirectPath = sessionStorage.getItem('baro-redirect-after-login');
+    if (redirectPath) {
+      sessionStorage.removeItem('baro-redirect-after-login');
+      navigate(redirectPath, { replace: true });
+    } else {
+      navigate(routePaths.myStores, { replace: true });
+    }
   }, [navigate, setTokens]);
 
   return (

--- a/src/shared/api/axiosInstance.ts
+++ b/src/shared/api/axiosInstance.ts
@@ -24,6 +24,12 @@ axiosInstance.interceptors.response.use(
     const isRefreshRequest = requestUrl.includes('/auth/refresh');
     const isAuthRequest = AUTH_REQUEST_URLS.some((url) => requestUrl.includes(url));
     if (error.response?.status === 401 && !isRefreshRequest && !isAuthRequest) {
+      const currentPath = window.location.pathname + window.location.search;
+      const AUTH_PAGE_PREFIXES = ['/login', '/auth/', '/register'];
+      const isAuthPage = AUTH_PAGE_PREFIXES.some((p) => currentPath.startsWith(p));
+      if (!isAuthPage && currentPath !== '/') {
+        sessionStorage.setItem('baro-redirect-after-login', currentPath);
+      }
       useAuthStore.getState().clearAuth();
       window.location.href = '/login';
     }


### PR DESCRIPTION
## 📌 요약

- 서비스 이용 중 JWT 세션이 만료되어 강제 로그아웃될 때, 재로그인 후 **끊겼던 페이지로 자동 복귀**하도록 수정
- 직접 로그인 페이지에 접근하는 의도적 로그인은 기존과 동일하게 계정 홈(myStores)으로 이동

<br/>

## 🏷️ 관련 이슈

- Closes #163

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- 401 감지 → 로그인 리다이렉트 전에 현재 경로를 `sessionStorage`에 저장
- 로그인 완료 후 저장된 경로가 있으면 복귀, 없으면 기존처럼 myStores로 이동

<br/>

### 📂 세부 변경사항

- `src/shared/api/axiosInstance.ts`: 401 핸들러에서 현재 경로 저장 (`baro-redirect-after-login` 키). 인증 페이지(`/login`, `/auth/`, `/register`)나 랜딩(`/`)은 저장 제외
- `src/pages/AuthCallbackPage.tsx`: 카카오 OAuth 콜백 후 저장 경로 확인 → 복귀 또는 myStores
- `src/features/auth/components/CredentialLoginForm.tsx`: 크레덴셜 로그인 성공 후 동일 처리

<br/>

## 📸 Screenshots

| Before | After |
| ------ | ----- |
| 세션 만료 → 재로그인 → 항상 계정 홈 이동 | 세션 만료 → 재로그인 → 끊겼던 페이지로 복귀 |

<br/>

## 🧪 테스트 방법

1. 발주 가이드(`/order-guide`) 등 내부 페이지에서 작업 중 토큰을 임의 삭제 (localStorage `baro-auth` 삭제)
2. 이후 API 요청 발생 시 자동으로 로그인 페이지로 이동되는지 확인
3. 재로그인 완료 후 `/order-guide`로 복귀하는지 확인
4. 반대로, 로그인 페이지를 직접 방문 후 로그인 시 계정 홈(`/my-stores`)으로 이동하는지 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [ ] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- `sessionStorage` 사용으로 탭 닫기 시 자동 초기화 → 브라우저 재시작 후 의도적 로그인에는 영향 없음
- 저장 제외 경로: `/login`, `/auth/`, `/register`, `/` (랜딩)