### PR TITLE
✨ (#164) feat: 이전 마감 현황 조회 기능

### DIFF
--- a/src/features/closing/api/closing.api.ts
+++ b/src/features/closing/api/closing.api.ts
@@ -2,6 +2,7 @@ import type {
   BusinessOpenRequest,
   BusinessOpenResponse,
   BusinessOpenStatus,
+  ClosingDetail,
   ClosingHistory,
   ClosingHistoryItem,
   ClosingPreview,
@@ -26,6 +27,11 @@ export const fetchClosingHistory = (storeId: string): Promise<ClosingHistory> =>
   axiosInstance
     .get<{ success: boolean; data: ClosingHistoryItem[] }>(`/stores/${storeId}/closing`)
     .then((res) => ({ closings: res.data.data }));
+
+export const fetchClosingDetail = (storeId: string, closingId: string): Promise<ClosingDetail> =>
+  axiosInstance
+    .get<{ success: boolean; data: ClosingDetail }>(`/stores/${storeId}/closing/${closingId}`)
+    .then((res) => res.data.data);
 
 export const cancelClosing = (storeId: string, id: string): Promise<void> =>
   axiosInstance.delete(`/stores/${storeId}/closing/${id}`).then(() => undefined);

--- a/src/features/closing/components/ClosingHistorySheet.tsx
+++ b/src/features/closing/components/ClosingHistorySheet.tsx
@@ -1,0 +1,252 @@
+import { useState } from 'react';
+
+import { ArrowLeft, CalendarDays, History, Package, ShoppingBag } from 'lucide-react';
+
+import { useClosingDetail } from '@/features/closing/hooks/useClosingDetail';
+import { useClosingHistory } from '@/features/closing/hooks/useClosingHistory';
+import type { ClosingHistoryItem } from '@/features/closing/types/closing.types';
+import { Separator } from '@/shadcn/ui/separator';
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/shadcn/ui/sheet';
+import { Skeleton } from '@/shadcn/ui/skeleton';
+
+interface ClosingHistorySheetProps {
+  open: boolean;
+  onClose: () => void;
+  storeId: string | null;
+}
+
+const formatDate = (dateStr: string) => {
+  const date = new Date(dateStr + 'T00:00:00');
+  return date.toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    weekday: 'short',
+  });
+};
+
+const formatCurrency = (amount: number) => `${amount.toLocaleString('ko-KR')}원`;
+
+const getDaysAgo = (dateStr: string): number => {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const target = new Date(dateStr + 'T00:00:00');
+  target.setHours(0, 0, 0, 0);
+  return Math.round((today.getTime() - target.getTime()) / (1000 * 60 * 60 * 24));
+};
+
+interface DetailViewProps {
+  storeId: string | null;
+  item: ClosingHistoryItem;
+  onBack: () => void;
+}
+
+const DetailView = ({ storeId, item, onBack }: DetailViewProps) => {
+  const { data: detail, isLoading } = useClosingDetail(storeId, item.id);
+  const daysAgo = getDaysAgo(item.date);
+
+  return (
+    <div className="flex flex-col h-full">
+      <SheetHeader className="px-6 pt-6 pb-4 shrink-0">
+        <button
+          onClick={onBack}
+          className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mb-2 w-fit"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          목록으로
+        </button>
+        <SheetTitle className="text-left">{formatDate(item.date)}</SheetTitle>
+        <SheetDescription className="text-left">
+          {daysAgo === 0 ? '오늘' : `${daysAgo}일 전`} 마감 ·{' '}
+          <span className="font-semibold text-foreground">{formatCurrency(item.totalRevenue)}</span>
+        </SheetDescription>
+      </SheetHeader>
+
+      <Separator />
+
+      <div className="flex-1 overflow-y-auto px-6 py-4 space-y-6">
+        {isLoading ? (
+          <div className="space-y-3">
+            <Skeleton className="h-5 w-32" />
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+          </div>
+        ) : !detail ? (
+          <p className="text-sm text-muted-foreground text-center py-8">
+            마감 상세 정보를 불러오지 못했습니다.
+          </p>
+        ) : (
+          <>
+            {/* 판매 메뉴 */}
+            <section>
+              <h3 className="flex items-center gap-2 text-sm font-semibold mb-3">
+                <ShoppingBag className="w-4 h-4 text-baro-blue" />
+                판매 메뉴
+              </h3>
+              {detail.soldMenus.length === 0 ? (
+                <p className="text-sm text-muted-foreground pl-6">판매 내역이 없습니다.</p>
+              ) : (
+                <div className="rounded-lg border overflow-hidden">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="bg-muted/50 text-muted-foreground">
+                        <th className="text-left px-3 py-2 font-medium">메뉴</th>
+                        <th className="text-right px-3 py-2 font-medium">수량</th>
+                        <th className="text-right px-3 py-2 font-medium">단가</th>
+                        <th className="text-right px-3 py-2 font-medium">소계</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {detail.soldMenus.map((menu) => (
+                        <tr key={menu.menuId} className="border-t">
+                          <td className="px-3 py-2.5 font-medium">{menu.menuName}</td>
+                          <td className="px-3 py-2.5 text-right text-muted-foreground">
+                            {menu.quantity}잔
+                          </td>
+                          <td className="px-3 py-2.5 text-right text-muted-foreground">
+                            {formatCurrency(menu.unitPrice)}
+                          </td>
+                          <td className="px-3 py-2.5 text-right font-medium">
+                            {formatCurrency(menu.subtotal)}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                    <tfoot>
+                      <tr className="border-t bg-muted/30">
+                        <td
+                          colSpan={3}
+                          className="px-3 py-2.5 text-right text-sm font-semibold text-muted-foreground"
+                        >
+                          총 매출
+                        </td>
+                        <td className="px-3 py-2.5 text-right font-bold text-baro-blue">
+                          {formatCurrency(detail.totalRevenue)}
+                        </td>
+                      </tr>
+                    </tfoot>
+                  </table>
+                </div>
+              )}
+            </section>
+
+            {/* 재고 차감 내역 */}
+            <section>
+              <h3 className="flex items-center gap-2 text-sm font-semibold mb-3">
+                <Package className="w-4 h-4 text-baro-green" />
+                재고 차감 내역
+              </h3>
+              {detail.inventoryDeductions.length === 0 ? (
+                <p className="text-sm text-muted-foreground pl-6">차감된 재고가 없습니다.</p>
+              ) : (
+                <div className="rounded-lg border overflow-hidden">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="bg-muted/50 text-muted-foreground">
+                        <th className="text-left px-3 py-2 font-medium">식자재</th>
+                        <th className="text-right px-3 py-2 font-medium">사용량</th>
+                        <th className="text-right px-3 py-2 font-medium">차감 후 재고</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {detail.inventoryDeductions.map((deduction) => (
+                        <tr key={deduction.ingredientId} className="border-t">
+                          <td className="px-3 py-2.5 font-medium">{deduction.ingredientName}</td>
+                          <td className="px-3 py-2.5 text-right text-muted-foreground">
+                            {deduction.usedAmount.toLocaleString('ko-KR')}
+                            {deduction.unit}
+                          </td>
+                          <td className="px-3 py-2.5 text-right">
+                            {deduction.remainingStock.toLocaleString('ko-KR')}
+                            {deduction.unit}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </section>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+const ClosingHistorySheet = ({ open, onClose, storeId }: ClosingHistorySheetProps) => {
+  const [selectedItem, setSelectedItem] = useState<ClosingHistoryItem | null>(null);
+  const { data: history, isLoading } = useClosingHistory(storeId);
+
+  const handleClose = () => {
+    setSelectedItem(null);
+    onClose();
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={handleClose}>
+      <SheetContent className="w-full sm:max-w-lg p-0 flex flex-col">
+        {selectedItem ? (
+          <DetailView storeId={storeId} item={selectedItem} onBack={() => setSelectedItem(null)} />
+        ) : (
+          <>
+            <SheetHeader className="px-6 pt-6 pb-4 shrink-0">
+              <SheetTitle className="flex items-center gap-2">
+                <History className="w-4 h-4" />
+                이전 마감 현황
+              </SheetTitle>
+              <SheetDescription>날짜를 선택하면 상세 내역을 확인할 수 있습니다.</SheetDescription>
+            </SheetHeader>
+
+            <Separator />
+
+            <div className="flex-1 overflow-y-auto px-6 py-4 space-y-2">
+              {isLoading ? (
+                <>
+                  <Skeleton className="h-16 w-full rounded-lg" />
+                  <Skeleton className="h-16 w-full rounded-lg" />
+                  <Skeleton className="h-16 w-full rounded-lg" />
+                </>
+              ) : !history?.closings.length ? (
+                <div className="flex flex-col items-center justify-center py-16 text-center gap-2">
+                  <History className="w-8 h-8 text-muted-foreground/50" />
+                  <p className="text-sm text-muted-foreground">아직 마감 이력이 없습니다.</p>
+                </div>
+              ) : (
+                history.closings.map((item) => {
+                  const daysAgo = getDaysAgo(item.date);
+                  return (
+                    <button
+                      key={item.id}
+                      onClick={() => setSelectedItem(item)}
+                      className="w-full flex items-center justify-between p-4 rounded-lg border hover:bg-muted/50 text-left transition-colors group"
+                    >
+                      <div className="flex items-center gap-3">
+                        <CalendarDays className="w-4 h-4 text-muted-foreground shrink-0" />
+                        <div>
+                          <p className="text-sm font-medium">{formatDate(item.date)}</p>
+                          <p className="text-xs text-muted-foreground mt-0.5">
+                            {daysAgo === 0 ? '오늘' : `${daysAgo}일 전`}
+                          </p>
+                        </div>
+                      </div>
+                      <div className="text-right">
+                        <p className="text-sm font-semibold">{formatCurrency(item.totalRevenue)}</p>
+                        <p className="text-xs text-muted-foreground mt-0.5 group-hover:text-foreground transition-colors">
+                          상세보기 →
+                        </p>
+                      </div>
+                    </button>
+                  );
+                })
+              )}
+            </div>
+          </>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+};
+
+export default ClosingHistorySheet;

--- a/src/features/closing/hooks/useClosingDetail.ts
+++ b/src/features/closing/hooks/useClosingDetail.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchClosingDetail } from '@/features/closing/api/closing.api';
+
+export const useClosingDetail = (storeId: string | null, closingId: string | null) =>
+  useQuery({
+    queryKey: ['closing-detail', storeId, closingId],
+    queryFn: () => fetchClosingDetail(storeId!, closingId!),
+    enabled: !!storeId && !!closingId,
+  });

--- a/src/features/closing/types/closing.types.ts
+++ b/src/features/closing/types/closing.types.ts
@@ -79,3 +79,28 @@ export interface ClosingHistoryItem {
 export interface ClosingHistory {
   closings: ClosingHistoryItem[];
 }
+
+export interface ClosingDetailSoldMenu {
+  menuId: string;
+  menuName: string;
+  quantity: number;
+  unitPrice: number;
+  subtotal: number;
+}
+
+export interface ClosingDetailInventoryDeduction {
+  ingredientId: string;
+  ingredientName: string;
+  unit: 'g' | 'ml' | '개';
+  usedAmount: number;
+  remainingStock: number;
+}
+
+export interface ClosingDetail {
+  id: string;
+  date: string;
+  totalRevenue: number;
+  createdAt: string;
+  soldMenus: ClosingDetailSoldMenu[];
+  inventoryDeductions: ClosingDetailInventoryDeduction[];
+}

--- a/src/pages/StoreHomePage.tsx
+++ b/src/pages/StoreHomePage.tsx
@@ -20,6 +20,7 @@ import { routePaths } from '@/app/routes/routePaths';
 import useAuthStore from '@/features/auth/store/authStore';
 import { openBusiness } from '@/features/closing/api/closing.api';
 import ClosingCancelModal from '@/features/closing/components/ClosingCancelModal';
+import ClosingHistorySheet from '@/features/closing/components/ClosingHistorySheet';
 import { useClosingHistory } from '@/features/closing/hooks/useClosingHistory';
 import useClosingStore from '@/features/closing/store/closingStore';
 import { useDashboardStats } from '@/features/dashboard/hooks/useDashboardStats';
@@ -99,6 +100,7 @@ const StoreHomePage = () => {
 
   const [isStarting, setIsStarting] = useState(false);
   const [showCancelModal, setShowCancelModal] = useState(false);
+  const [showHistorySheet, setShowHistorySheet] = useState(false);
   const [showHolidayModal, setShowHolidayModal] = useState(false);
 
   const getCase = (): BusinessCase => {
@@ -425,7 +427,7 @@ const StoreHomePage = () => {
               <div className="grid grid-cols-2 gap-3 md:flex-1 md:grid-cols-3 md:gap-4 md:min-h-0">
                 <button
                   onClick={() => navigate('/inventory')}
-                  className="flex h-32 flex-col justify-between rounded-xl border bg-background p-4 text-left shadow-sm transition-all hover:shadow-md hover:-translate-y-0.5 hover:border-baro-green/40 hover:bg-baro-green/5 md:h-full md:p-5"
+                  className="cursor-pointer flex h-32 flex-col justify-between rounded-xl border bg-background p-4 text-left shadow-sm transition-all hover:shadow-md hover:-translate-y-0.5 hover:border-baro-green/40 hover:bg-baro-green/5 md:h-full md:p-5"
                 >
                   <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-baro-green/10">
                     <Archive className="h-5 w-5 text-baro-green" />
@@ -438,7 +440,7 @@ const StoreHomePage = () => {
 
                 <button
                   onClick={() => navigate('/order-guide')}
-                  className="flex h-32 flex-col justify-between rounded-xl border bg-background p-4 text-left shadow-sm transition-all hover:shadow-md hover:-translate-y-0.5 hover:border-baro-yellow/50 hover:bg-baro-yellow/10 md:h-full md:p-5"
+                  className="cursor-pointer flex h-32 flex-col justify-between rounded-xl border bg-background p-4 text-left shadow-sm transition-all hover:shadow-md hover:-translate-y-0.5 hover:border-baro-yellow/50 hover:bg-baro-yellow/10 md:h-full md:p-5"
                 >
                   <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-baro-yellow/20">
                     <ClipboardList className="h-5 w-5 text-baro-yellow-dark" />
@@ -450,8 +452,8 @@ const StoreHomePage = () => {
                 </button>
 
                 <button
-                  onClick={() => toast.info('이전 마감 현황 기능은 준비 중이에요.')}
-                  className="col-span-2 flex h-32 flex-col justify-between rounded-xl border bg-background p-4 text-left shadow-sm transition-all hover:shadow-md hover:-translate-y-0.5 hover:border-baro-blue/40 hover:bg-baro-blue/5 md:col-span-1 md:h-full md:p-5"
+                  onClick={() => setShowHistorySheet(true)}
+                  className="cursor-pointer col-span-2 flex h-32 flex-col justify-between rounded-xl border bg-background p-4 text-left shadow-sm transition-all hover:shadow-md hover:-translate-y-0.5 hover:border-baro-blue/40 hover:bg-baro-blue/5 md:col-span-1 md:h-full md:p-5"
                 >
                   <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-baro-blue/10">
                     <History className="h-5 w-5 text-baro-blue" />
@@ -467,7 +469,7 @@ const StoreHomePage = () => {
               <div className="grid grid-cols-2 gap-3 md:flex-1 md:gap-4 md:min-h-0">
                 <button
                   onClick={() => setShowCancelModal(true)}
-                  className="flex h-32 flex-col justify-between rounded-xl border bg-background p-4 text-left shadow-sm transition-all hover:shadow-md hover:-translate-y-0.5 hover:border-baro-red/40 hover:bg-red-50 dark:hover:bg-red-950/20 md:h-full md:p-5"
+                  className="cursor-pointer flex h-32 flex-col justify-between rounded-xl border bg-background p-4 text-left shadow-sm transition-all hover:shadow-md hover:-translate-y-0.5 hover:border-baro-red/40 hover:bg-red-50 dark:hover:bg-red-950/20 md:h-full md:p-5"
                 >
                   <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-baro-red/10">
                     <Trash2 className="h-5 w-5 text-baro-red" />
@@ -482,7 +484,7 @@ const StoreHomePage = () => {
 
                 <button
                   onClick={() => navigate('/store-settings')}
-                  className="flex h-32 flex-col justify-between rounded-xl border bg-background p-4 text-left shadow-sm transition-all hover:shadow-md hover:-translate-y-0.5 hover:bg-muted/50 md:h-full md:p-5"
+                  className="cursor-pointer flex h-32 flex-col justify-between rounded-xl border bg-background p-4 text-left shadow-sm transition-all hover:shadow-md hover:-translate-y-0.5 hover:bg-muted/50 md:h-full md:p-5"
                 >
                   <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-muted">
                     <Settings className="h-5 w-5 text-muted-foreground" />
@@ -497,6 +499,13 @@ const StoreHomePage = () => {
           )}
         </main>
       </div>
+
+      {/* 이전 마감 현황 시트 */}
+      <ClosingHistorySheet
+        open={showHistorySheet}
+        onClose={() => setShowHistorySheet(false)}
+        storeId={storeId}
+      />
 
       {/* 마감 취소 모달 */}
       {storeId && (


### PR DESCRIPTION
## 📌 요약

- 가게 홈의 **마감 현황** 버튼을 클릭하면 이전 마감 이력을 조회할 수 있는 기능 추가
- 마감 목록에서 날짜 선택 시 판매 메뉴 및 재고 차감 상세 내역 확인 가능

<br/>

## 🏷️ 관련 이슈

- Closes #164

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- 가게 홈 "마감 현황" 버튼: 준비 중 토스트 → `ClosingHistorySheet` 오픈으로 교체
- Sheet 내 목록 뷰 → 상세 뷰 2단계 네비게이션 구현

<br/>

### 📂 세부 변경사항

- `closing.types.ts`: `ClosingDetail`, `ClosingDetailSoldMenu`, `ClosingDetailInventoryDeduction` 타입 추가
- `closing.api.ts`: `fetchClosingDetail()` — `GET /stores/:storeId/closing/:closingId` 연동
- `hooks/useClosingDetail.ts`: React Query 훅 신규 생성
- `components/ClosingHistorySheet.tsx`: Sheet 컴포넌트 신규 생성
  - 목록 뷰: 날짜·매출 카드 리스트, Skeleton 로딩
  - 상세 뷰: 판매 메뉴 테이블 + 재고 차감 내역 테이블, "목록으로" 뒤로가기
- `pages/StoreHomePage.tsx`: 기존 준비 중 버튼에 Sheet 연결

<br/>

## 📸 Screenshots

| 목록 뷰 | 상세 뷰 |
| ------ | ----- |
| 날짜별 마감 이력 + 총매출 | 판매 메뉴 테이블, 재고 차감 테이블 |

<br/>

## 🧪 테스트 방법

1. 가게 홈 접속
2. **마감 현황** 카드 클릭 → 우측에서 Sheet 슬라이드 인 확인
3. 마감 이력 목록에서 날짜 항목 클릭 → 상세 뷰로 전환 확인
4. 상세 뷰에서 판매 메뉴 / 재고 차감 테이블 확인
5. "목록으로" 버튼 클릭 → 목록으로 복귀 확인
6. Sheet 닫기 후 재오픈 시 목록 뷰로 초기화 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [x] Backend
- [x] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- 마감 이력 없을 시 빈 상태 안내 UI 처리
- Sheet 닫힐 때 선택된 항목(`selectedItem`) 초기화하여 재오픈 시 항상 목록 뷰에서 시작
- `useClosingDetail`은 `closingId`가 있을 때만 fetch (`enabled: !!storeId && !!closingId`)