### PR TITLE
🐛 (#174) fix: 메뉴·OCR 모달 콘텐츠 오버플로우 및 스크롤 버그 수정

### DIFF
--- a/src/features/initial-setup/components/MenuRegistrationModal.tsx
+++ b/src/features/initial-setup/components/MenuRegistrationModal.tsx
@@ -104,7 +104,7 @@ const MenuRegistrationModal = ({
 
   return (
     <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
-      <DialogContent showCloseButton={false}>
+      <DialogContent showCloseButton={false} className="max-h-[calc(100svh-4rem)] overflow-hidden">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <UtensilsCrossed className="size-4 text-muted-foreground" />
@@ -112,7 +112,7 @@ const MenuRegistrationModal = ({
           </DialogTitle>
         </DialogHeader>
 
-        <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-4 overflow-y-auto min-h-0">
           {/* 사진 업로드 */}
           <div className="space-y-1.5">
             <Label>메뉴 사진</Label>

--- a/src/features/store-settings/components/MenuOcrModal.tsx
+++ b/src/features/store-settings/components/MenuOcrModal.tsx
@@ -97,7 +97,7 @@ const MenuOcrModal = ({
 
   return (
     <Dialog open={open} onOpenChange={(v) => !v && handleClose()}>
-      <DialogContent className="sm:max-w-3xl max-h-[90vh] flex flex-col">
+      <DialogContent className="sm:max-w-3xl max-h-[90svh] flex flex-col overflow-hidden">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <ScanLine className="size-4 text-muted-foreground" />
@@ -117,7 +117,7 @@ const MenuOcrModal = ({
         )}
 
         {step === 'analyzing' && (
-          <div className="flex flex-col items-center justify-center gap-4 py-16">
+          <div className="flex flex-col items-center justify-center gap-4 py-16 min-h-80">
             <Loader2 className="w-10 h-10 animate-spin text-baro-blue" />
             <div className="text-center">
               <p className="text-sm font-semibold">메뉴를 인식하는 중입니다</p>
@@ -127,7 +127,7 @@ const MenuOcrModal = ({
         )}
 
         {step === 'review' && (
-          <div className="flex-1 min-h-0">
+          <div className="flex-1 min-h-0 flex flex-col">
             <MenuOcrReviewStep
               items={reviewItems}
               existingNames={existingNames}

--- a/src/features/store-settings/components/MenuOcrReviewStep.tsx
+++ b/src/features/store-settings/components/MenuOcrReviewStep.tsx
@@ -83,7 +83,7 @@ const MenuOcrReviewStep = ({
   const duplicateCount = items.filter((item) => item.name.trim() && isDuplicate(item.name)).length;
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col flex-1 min-h-0">
       {/* 스크롤 영역: 헤더 + 항목 목록 + 추가 버튼 */}
       <div className="flex-1 min-h-0 overflow-y-auto flex flex-col gap-4 pb-2 pr-1">
         <div className="flex items-center justify-between">

--- a/src/features/store-settings/components/MenuOcrUploadStep.tsx
+++ b/src/features/store-settings/components/MenuOcrUploadStep.tsx
@@ -32,7 +32,7 @@ const MenuOcrUploadStep = ({ onFileSelect, onBack }: MenuOcrUploadStepProps) => 
   };
 
   return (
-    <div className="flex flex-col gap-6 pr-2">
+    <div className="flex flex-col gap-6 flex-1 min-h-0 overflow-y-auto">
       <div className="flex flex-col gap-4">
         <div className="text-center">
           <p className="text-sm font-semibold">메뉴판을 등록해주세요</p>
@@ -88,7 +88,7 @@ const MenuOcrUploadStep = ({ onFileSelect, onBack }: MenuOcrUploadStepProps) => 
         <div className="flex flex-col gap-3 md:flex-row">
           <Button
             variant="outline"
-            className="w-full"
+            className="w-full md:flex-1"
             onClick={() => fileInputRef.current?.click()}
           >
             <FileImage className="w-4 h-4" />
@@ -96,7 +96,7 @@ const MenuOcrUploadStep = ({ onFileSelect, onBack }: MenuOcrUploadStepProps) => 
           </Button>
           <Button
             variant="outline"
-            className="w-full"
+            className="w-full md:flex-1"
             onClick={() => cameraInputRef.current?.click()}
           >
             <Camera className="w-4 h-4" />

--- a/src/pages/SettingsMenusPage.tsx
+++ b/src/pages/SettingsMenusPage.tsx
@@ -140,7 +140,7 @@ const MenuModal = ({
 
   return (
     <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
-      <DialogContent showCloseButton={false}>
+      <DialogContent showCloseButton={false} className="max-h-[calc(100svh-4rem)] overflow-hidden">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <UtensilsCrossed className="size-4 text-muted-foreground" />
@@ -148,7 +148,7 @@ const MenuModal = ({
           </DialogTitle>
         </DialogHeader>
 
-        <div className="flex gap-4 flex-col">
+        <div className="flex flex-col gap-4 overflow-y-auto min-h-0">
           {/* 사진 업로드 */}
           <div className="space-y-1.5">
             <Label>메뉴 사진</Label>


### PR DESCRIPTION
## 📌 요약

- 메뉴 등록/수정 모달, OCR 메뉴판 등록 모달에서 콘텐츠가 뷰포트 밖으로 삐져나오는 문제 수정
- OCR 모달 스텝 전환 시 높이 수축, 내부 스크롤 미동작, 버튼 잘림 문제 수정

<br/>

## 🏷️ 관련 이슈

- Closes #174

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- `MenuOcrModal`: `overflow-hidden` 추가로 모달 밖 콘텐츠 삐져나옴 해결, analyzing 단계 `min-h-80`으로 높이 수축 방지
- `MenuOcrReviewStep`: 루트 `h-full` → `flex-1 min-h-0` 변경으로 flex 체인 내 스크롤 정상화
- `MenuOcrUploadStep`: `flex-1 min-h-0 overflow-y-auto` 추가, 버튼 `w-full md:flex-1`으로 반응형 레이아웃 수정
- `MenuModal` / `MenuRegistrationModal`: `max-h-[calc(100svh-4rem)] overflow-hidden`, 폼 래퍼 `overflow-y-auto min-h-0`

<br/>

### 📂 세부 변경사항

- `MenuOcrModal.tsx`: `max-h-[90svh] flex flex-col overflow-hidden`, review 래퍼 `flex flex-col` 추가, analyzing `min-h-80`
- `MenuOcrReviewStep.tsx`: `flex flex-col h-full` → `flex flex-col flex-1 min-h-0`
- `MenuOcrUploadStep.tsx`: 루트 `flex-1 min-h-0 overflow-y-auto`, 버튼 `w-full md:flex-1`
- `SettingsMenusPage.tsx`: `DialogContent` max-h + overflow-hidden, 폼 래퍼 overflow-y-auto min-h-0
- `MenuRegistrationModal.tsx`: 동일 적용

<br/>

## 📸 Screenshots

| Before | After |
| ------ | ----- |
| 모달 콘텐츠 뷰포트 밖 삐져나옴 | 모달 내부 스크롤 동작 |
| OCR 스텝 전환 시 높이 수축 | 스텝 간 일관된 높이 유지 |
| 버튼 잘림 (모바일/데스크탑) | 모바일 세로 배열 / 데스크탑 가로 균등 배열 |

<br/>

## 🧪 테스트 방법

1. `/store-settings/menus` → **메뉴 추가** 버튼 클릭 → 이미지 업로드 후 필드 전체 확인 (모달 내 스크롤, Footer 버튼 노출)
2. **메뉴판으로 등록** 버튼 클릭 → 이미지 업로드 → 인식 중(높이 유지 확인) → 인식 결과 목록 스크롤 → 등록하기 버튼 노출 확인
3. 모바일 뷰포트(375px)에서 동일 플로우 확인 — 버튼 세로 배열, 하단 여백 적절

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [ ] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- `h-full`은 flex 컨테이너 내에서 부모에 확정 높이(h-)가 없으면 동작하지 않음. `flex-1 min-h-0`으로 대체
- `overflow-hidden` 없이 `max-h`만 지정하면 CSS 클리핑이 안 돼 콘텐츠가 그대로 밖으로 나옴
- `min-h-0`: grid/flex 자식 기본값 `min-height: auto`가 overflow 스크롤을 막으므로 필수