### PR TITLE
✨ (#173) feat: 에러 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,19 +4,22 @@ import { BrowserRouter } from 'react-router-dom';
 import AppInitializer from '@/app/AppInitializer';
 import Router from '@/app/routes/Router';
 import { Toaster } from '@/shadcn/ui/sonner';
+import ErrorBoundary from '@/shared/components/ErrorBoundary';
 
 const queryClient = new QueryClient();
 
 function App() {
   return (
-    <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <AppInitializer>
-          <Router />
-          <Toaster position="top-center" />
-        </AppInitializer>
-      </BrowserRouter>
-    </QueryClientProvider>
+    <ErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter>
+          <AppInitializer>
+            <Router />
+            <Toaster position="top-center" />
+          </AppInitializer>
+        </BrowserRouter>
+      </QueryClientProvider>
+    </ErrorBoundary>
   );
 }
 

--- a/src/app/routes/ProtectedRoute.tsx
+++ b/src/app/routes/ProtectedRoute.tsx
@@ -1,0 +1,17 @@
+import { Navigate, Outlet } from 'react-router-dom';
+
+import { routePaths } from './routePaths';
+
+import useAuthStore from '@/features/auth/store/authStore';
+
+const ProtectedRoute = () => {
+  const accessToken = useAuthStore((s) => s.accessToken);
+
+  if (!accessToken) {
+    return <Navigate to={routePaths.login} replace />;
+  }
+
+  return <Outlet />;
+};
+
+export default ProtectedRoute;

--- a/src/app/routes/Router.tsx
+++ b/src/app/routes/Router.tsx
@@ -1,6 +1,7 @@
 import { Routes, Route, useLocation } from 'react-router-dom';
 
 import AppLayout from '@/app/layouts/AppLayout';
+import ProtectedRoute from '@/app/routes/ProtectedRoute';
 import { routePaths } from '@/app/routes/routePaths';
 import SettingsPage from '@/pages/AccountSettingsPage';
 import AuthCallbackPage from '@/pages/AuthCallbackPage';
@@ -62,34 +63,6 @@ export default function Router() {
         element={<StandalonePageWrapper element={<RegisterPage />} />}
       />
       <Route
-        path={routePaths.storeSelection}
-        element={<StandalonePageWrapper element={<StoreSelectionPage />} />}
-      />
-      <Route
-        path={routePaths.myStores}
-        element={<StandalonePageWrapper element={<MyStoresPage />} />}
-      />
-      <Route
-        path={routePaths.initialSetup}
-        element={<StandalonePageWrapper element={<InitialSetupPage />} />}
-      />
-      <Route
-        path={routePaths.storeHome}
-        element={<StandalonePageWrapper element={<StoreHomePage />} />}
-      />
-      <Route
-        path={routePaths.dayClosed}
-        element={<StandalonePageWrapper element={<DayClosedPage />} />}
-      />
-      <Route
-        path={routePaths.closingOrderGuideDetail}
-        element={<StandalonePageWrapper element={<ClosingOrderGuidePage />} />}
-      />
-      <Route
-        path={routePaths.ocrInbound}
-        element={<StandalonePageWrapper element={<OcrInboundPage />} />}
-      />
-      <Route
         path={routePaths.customerOrder}
         element={<StandalonePageWrapper element={<CustomerOrderPage />} />}
       />
@@ -110,21 +83,53 @@ export default function Router() {
         element={<StandalonePageWrapper element={<NotFoundPage />} />}
       />
 
-      {/* 사이드바 + 상단바 공통 레이아웃 */}
-      <Route element={<AppLayout />}>
-        <Route path={routePaths.dashboard} element={<DashboardPage />} />
-        <Route path={routePaths.inventory} element={<InventoryPage />} />
-        <Route path={routePaths.orderGuide} element={<OrderGuidePage />} />
-        <Route path={routePaths.closing} element={<ClosingPage />} />
-        {/* 가게 설정 */}
-        <Route path={routePaths.storeSettings} element={<StoreSettingsPage />} />
-        <Route path={routePaths.storeSettingsMenus} element={<SettingsMenusPage />} />
-        <Route path={routePaths.storeSettingsMenuBoard} element={<SettingsMenuBoardPage />} />
-        <Route path={routePaths.storeSettingsTable} element={<SettingsTablePage />} />
-        <Route path={routePaths.storeSettingsRecipes} element={<SettingsRecipesPage />} />
-        <Route path={routePaths.storeSettingsIngredients} element={<SettingsIngredientsPage />} />
-        {/* 회원 설정 */}
-        <Route path={routePaths.settings} element={<SettingsPage />} />
+      {/* 로그인 필요 */}
+      <Route element={<ProtectedRoute />}>
+        <Route
+          path={routePaths.storeSelection}
+          element={<StandalonePageWrapper element={<StoreSelectionPage />} />}
+        />
+        <Route
+          path={routePaths.myStores}
+          element={<StandalonePageWrapper element={<MyStoresPage />} />}
+        />
+        <Route
+          path={routePaths.initialSetup}
+          element={<StandalonePageWrapper element={<InitialSetupPage />} />}
+        />
+        <Route
+          path={routePaths.storeHome}
+          element={<StandalonePageWrapper element={<StoreHomePage />} />}
+        />
+        <Route
+          path={routePaths.dayClosed}
+          element={<StandalonePageWrapper element={<DayClosedPage />} />}
+        />
+        <Route
+          path={routePaths.closingOrderGuideDetail}
+          element={<StandalonePageWrapper element={<ClosingOrderGuidePage />} />}
+        />
+        <Route
+          path={routePaths.ocrInbound}
+          element={<StandalonePageWrapper element={<OcrInboundPage />} />}
+        />
+
+        {/* 사이드바 + 상단바 공통 레이아웃 */}
+        <Route element={<AppLayout />}>
+          <Route path={routePaths.dashboard} element={<DashboardPage />} />
+          <Route path={routePaths.inventory} element={<InventoryPage />} />
+          <Route path={routePaths.orderGuide} element={<OrderGuidePage />} />
+          <Route path={routePaths.closing} element={<ClosingPage />} />
+          {/* 가게 설정 */}
+          <Route path={routePaths.storeSettings} element={<StoreSettingsPage />} />
+          <Route path={routePaths.storeSettingsMenus} element={<SettingsMenusPage />} />
+          <Route path={routePaths.storeSettingsMenuBoard} element={<SettingsMenuBoardPage />} />
+          <Route path={routePaths.storeSettingsTable} element={<SettingsTablePage />} />
+          <Route path={routePaths.storeSettingsRecipes} element={<SettingsRecipesPage />} />
+          <Route path={routePaths.storeSettingsIngredients} element={<SettingsIngredientsPage />} />
+          {/* 회원 설정 */}
+          <Route path={routePaths.settings} element={<SettingsPage />} />
+        </Route>
       </Route>
     </Routes>
   );

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -1,7 +1,26 @@
+import { useNavigate } from 'react-router-dom';
+
+import { routePaths } from '@/app/routes/routePaths';
+import { Button } from '@/shadcn/ui/button';
+
 const NotFoundPage = () => {
+  const navigate = useNavigate();
+
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen">
-      <h1 className="text-4xl font-bold">404 - 페이지를 찾을 수 없습니다</h1>
+    <div className="flex min-h-screen flex-col items-center justify-center gap-6 bg-background px-6">
+      <div className="text-center">
+        <p className="select-none text-8xl font-black text-baro-blue/20">404</p>
+        <h1 className="mt-2 text-xl font-bold text-foreground">페이지를 찾을 수 없어요</h1>
+        <p className="pt-2 text-sm text-muted-foreground">
+          요청하신 페이지가 존재하지 않거나 이동되었어요.
+        </p>
+      </div>
+      <Button
+        onClick={() => navigate(routePaths.storeHome)}
+        className="rounded-full bg-baro-blue px-6 py-5 text-white hover:bg-baro-blue/80"
+      >
+        홈으로 돌아가기
+      </Button>
     </div>
   );
 };

--- a/src/shared/components/ErrorBoundary.tsx
+++ b/src/shared/components/ErrorBoundary.tsx
@@ -1,0 +1,71 @@
+import { Component } from 'react';
+
+import { AlertTriangle } from 'lucide-react';
+
+import { Button } from '@/shadcn/ui/button';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  errorMessage: string | null;
+}
+
+class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, errorMessage: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, errorMessage: error.message || null };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex min-h-screen flex-col items-center justify-center gap-8 bg-background px-6">
+          <div className="relative flex items-center justify-center">
+            <div className="absolute size-28 rounded-full bg-baro-red/8 blur-2xl" />
+            <AlertTriangle className="relative size-16 text-baro-red" strokeWidth={1.5} />
+          </div>
+          <div className="text-center">
+            <h1 className="text-2xl font-bold text-foreground">오류가 발생했습니다</h1>
+            <p className="pt-3 text-sm leading-relaxed text-muted-foreground">
+              서비스를 이용하는 중 문제가 발생했어요.
+              <br />
+              잠시 후 다시 시도해 주세요.
+            </p>
+          </div>
+          {this.state.errorMessage && (
+            <p className="w-auto rounded-lg bg-muted px-4 py-3 font-mono text-xs leading-relaxed text-muted-foreground">
+              {this.state.errorMessage}
+            </p>
+          )}
+          <div className="mt-2 flex flex-col items-center gap-3">
+            <Button
+              size="lg"
+              onClick={() => window.location.reload()}
+              className="bg-baro-red px-8 text-white hover:bg-baro-red/80 rounded-full"
+            >
+              새로고침
+            </Button>
+            <button
+              type="button"
+              onClick={() => (window.location.href = '/')}
+              className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
+            >
+              홈으로 돌아가기
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION
## 📌 요약

- ErrorBoundary 컴포넌트 추가 및 App.tsx 최상단 적용
- ProtectedRoute 추가 — 미인증 접근 시 /login 리다이렉트
- NotFoundPage baro 브랜딩으로 리디자인

<br/>

## 🏷️ 관련 이슈

- Closes #173

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- `ErrorBoundary` 클래스 컴포넌트 신규 생성 — 런타임 에러 캡처 후 baro-red 테마 fallback UI 표시 (에러 메시지 + 새로고침 + 홈으로 돌아가기)
- `ProtectedRoute` 신규 생성 — accessToken 없을 시 /login 리다이렉트, 인증 필요 라우트 전체 감쌈
- `NotFoundPage` 리디자인 — 기존 plain text → baro 브랜딩 적용, 홈 버튼 /store-home으로 변경

<br/>

### 📂 세부 변경사항

- `src/shared/components/ErrorBoundary.tsx` 신규 생성
- `src/app/routes/ProtectedRoute.tsx` 신규 생성
- `src/App.tsx` — ErrorBoundary로 앱 전체 래핑
- `src/app/routes/Router.tsx` — 보호 라우트를 ProtectedRoute로 그룹핑
- `src/pages/NotFoundPage.tsx` — UI 리디자인

<br/>

## 📸 Screenshots

| Before | After |
| ------ | ----- |
| plain text 404 | baro 브랜딩 404 페이지 |
| ErrorBoundary 없음 | baro-red 테마 에러 fallback UI |

<br/>

## 🧪 테스트 방법

1. 존재하지 않는 URL 접속 (/xyz) → 404 페이지 노출 확인
2. 비로그인 상태에서 /dashboard 직접 접근 → /login 리다이렉트 확인
3. 404 페이지 '홈으로 돌아가기' 클릭 → 로그인 상태면 /store-home, 비로그인이면 /login 확인
4. 런타임 에러 발생 시 (컴포넌트에 throw 추가) → ErrorBoundary fallback UI + 에러 메시지 노출 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [ ] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- ProtectedRoute는 AppInitializer 완료 후 렌더되므로 토큰 초기화 타이밍 문제 없음
- ErrorBoundary는 클래스 컴포넌트 필수 (React hooks 사용 불가)
- ErrorBoundary fallback의 '홈으로 돌아가기'는 window.location.href 사용 (에러 발생 시 Router 신뢰 불가)