### PR TITLE
🐛✨ (#177~#182) fix·feat: UI 버그 수정 및 대표자 변경 기능 구현

### DIFF
--- a/src/features/initial-setup/components/steps/StepIngredientsAndRecipes.tsx
+++ b/src/features/initial-setup/components/steps/StepIngredientsAndRecipes.tsx
@@ -330,9 +330,9 @@ const StepIngredientsAndRecipes = ({
   };
 
   return (
-    <div className="flex flex-1 min-h-0 flex-col gap-4 md:flex-row">
+    <div className="flex flex-col gap-4 md:flex-1 md:min-h-0 md:flex-row">
       {/* ── 왼쪽 패널: 식자재 등록 ── */}
-      <div className="flex flex-1 min-h-0 flex-col overflow-hidden rounded-xl border">
+      <div className="flex flex-col overflow-hidden rounded-xl border md:flex-1 md:min-h-0">
         {/* 패널 헤더 */}
         <div className="shrink-0 border-b px-4 py-3">
           <h3 className="text-sm font-semibold">식자재 등록</h3>
@@ -395,9 +395,9 @@ const StepIngredientsAndRecipes = ({
         </div>
 
         {/* 식자재 태그 목록 — 스크롤 영역 */}
-        <div className="flex-1 min-h-0 overflow-y-auto p-3">
+        <div className="overflow-y-auto p-3 md:flex-1 md:min-h-0">
           {ingredients.length === 0 ? (
-            <div className="flex h-full items-center justify-center rounded-xl border-2 border-dashed border-gray-200 text-center">
+            <div className="flex min-h-25 items-center justify-center rounded-xl border-2 border-dashed border-gray-200 text-center md:h-full md:min-h-0">
               <p className="text-xs text-muted-foreground">
                 식자재를 입력하면 여기에 태그로 표시됩니다
               </p>
@@ -417,7 +417,7 @@ const StepIngredientsAndRecipes = ({
       </div>
 
       {/* ── 오른쪽 패널: 레시피 등록 ── */}
-      <div className="flex flex-1 min-h-0 flex-col overflow-hidden rounded-xl border">
+      <div className="flex flex-col overflow-hidden rounded-xl border md:flex-1 md:min-h-0">
         {/* 패널 헤더 */}
         <div className="shrink-0 border-b px-4 py-3">
           <h3 className="text-sm font-semibold">메뉴별 레시피</h3>
@@ -427,9 +427,9 @@ const StepIngredientsAndRecipes = ({
         </div>
 
         {/* 레시피 패널 목록 — 스크롤 영역 */}
-        <div className="flex-1 min-h-0 overflow-y-auto p-3">
+        <div className="overflow-y-auto p-3 md:flex-1 md:min-h-0">
           {menuItems.length === 0 ? (
-            <div className="flex h-full items-center justify-center rounded-xl border-2 border-dashed border-gray-200 text-center">
+            <div className="flex min-h-25 items-center justify-center rounded-xl border-2 border-dashed border-gray-200 text-center md:h-full md:min-h-0">
               <div>
                 <p className="text-sm text-muted-foreground">등록된 메뉴가 없습니다</p>
                 <p className="mt-0.5 text-xs text-muted-foreground">

--- a/src/features/store-registration/components/MyStoresList.tsx
+++ b/src/features/store-registration/components/MyStoresList.tsx
@@ -1,7 +1,8 @@
-import { useRef, useState } from 'react';
+import { useRef, useState, useEffect } from 'react';
 
 import {
   Check,
+  ChevronDown,
   ChevronRight,
   Globe,
   Info,
@@ -77,8 +78,20 @@ function getInitials(name?: string | null) {
   return name?.trim().slice(0, 2) ?? '?';
 }
 
+const useIsMobile = () => {
+  const [isMobile, setIsMobile] = useState(() => window.innerWidth < 768);
+  useEffect(() => {
+    const mq = window.matchMedia('(max-width: 767px)');
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+  return isMobile;
+};
+
 const MyStoresList = () => {
   const navigate = useNavigate();
+  const isMobile = useIsMobile();
   const { data: userInfo, isLoading: isUserLoading } = useUserInfo();
   const { data: stores, isLoading: isStoresLoading } = useMyStores();
   const { mutate: updateName, isPending: isUpdatingName } = useUpdateUserName();
@@ -307,10 +320,18 @@ const MyStoresList = () => {
                     <Info className="h-4 w-4 text-muted-foreground" />
                     <span>서비스 정보</span>
                   </div>
-                  <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                  {isMobile ? (
+                    <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                  ) : (
+                    <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                  )}
                 </button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent side="right" align="start" className="w-48">
+              <DropdownMenuContent
+                side={isMobile ? 'bottom' : 'right'}
+                align="start"
+                className="w-48"
+              >
                 <DropdownMenuItem disabled className="text-xs text-muted-foreground">
                   버전 {APP_VERSION}
                 </DropdownMenuItem>
@@ -373,7 +394,7 @@ const MyStoresList = () => {
           </div>
 
           {/* Stores grid — scrolls internally */}
-          <div className="flex-1 overflow-y-auto p-1 pt-3 md:overflow-y-auto">
+          <div className="flex-1 overflow-y-auto px-2 pt-3 pb-2 md:overflow-y-auto">
             {isStoresLoading ? (
               <div className="grid grid-cols-2 gap-3 md:grid-cols-2 md:gap-4 lg:grid-cols-3">
                 {Array.from({ length: 3 }).map((_, i) => (

--- a/src/features/store-settings/api/storeSettings.api.ts
+++ b/src/features/store-settings/api/storeSettings.api.ts
@@ -29,7 +29,7 @@ export async function fetchStoreSettings(storeId: string): Promise<StoreSettings
 
 export async function updateStoreSettings(
   storeId: string,
-  data: Partial<Omit<StoreSettings, 'operatingHours'>>,
+  data: Partial<Omit<StoreSettings, 'operatingHours'>> & { ownerId?: string },
 ): Promise<void> {
   await axiosInstance.patch(`/stores/${storeId}`, data);
 }

--- a/src/features/store-settings/components/sections/StoreInfoSection.tsx
+++ b/src/features/store-settings/components/sections/StoreInfoSection.tsx
@@ -5,6 +5,7 @@ import { Store } from 'lucide-react';
 import {
   useStoreSettings,
   useUpdateStoreSettings,
+  useStoreMembers,
 } from '@/features/store-settings/hooks/useStoreSettings';
 import type { StoreSettings } from '@/features/store-settings/types/store-settings.types';
 import { Button } from '@/shadcn/ui/button';
@@ -44,21 +45,31 @@ const labelOf = (options: { value: string; label: string }[], val: string) =>
 const StoreInfoSection = () => {
   const { data, isLoading } = useStoreSettings();
   const { mutate: updateStore, isPending } = useUpdateStoreSettings();
+  const { data: members = [] } = useStoreMembers();
   const [isEditing, setIsEditing] = useState(false);
   const [form, setForm] = useState<StoreSettings | null>(null);
+  const [pendingOwnerId, setPendingOwnerId] = useState<string | null>(null);
 
   const handleEdit = () => {
     if (data) setForm(data);
+    setPendingOwnerId(null);
     setIsEditing(true);
   };
 
   const handleSave = () => {
     if (!form) return;
-    updateStore(form, { onSuccess: () => setIsEditing(false) });
+    const updateData = pendingOwnerId ? { ...form, ownerId: pendingOwnerId } : form;
+    updateStore(updateData, {
+      onSuccess: () => {
+        setPendingOwnerId(null);
+        setIsEditing(false);
+      },
+    });
   };
 
   const handleCancel = () => {
     if (data) setForm(data);
+    setPendingOwnerId(null);
     setIsEditing(false);
   };
 
@@ -106,10 +117,44 @@ const StoreInfoSection = () => {
           </div>
           <div className="space-y-1.5">
             <Label className="text-xs text-muted-foreground">대표자명</Label>
-            <Input value={form.owner.name} disabled />
-            <p className="text-[11px] text-muted-foreground">
-              직원 추가 기능 오픈 후 변경 가능합니다.
-            </p>
+            {members.length <= 1 ? (
+              <>
+                <Input value={form.owner.name} disabled />
+                <p className="text-[11px] text-muted-foreground">
+                  팀 멤버가 없어 대표자를 변경할 수 없습니다.
+                </p>
+              </>
+            ) : (
+              <>
+                <Select
+                  value={pendingOwnerId ?? data?.owner.id ?? ''}
+                  onValueChange={(val) => setPendingOwnerId(val === data?.owner.id ? null : val)}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue>
+                      {pendingOwnerId
+                        ? members.find((m) => m.userId === pendingOwnerId)?.name
+                        : data?.owner.name}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    {members.map((member) => (
+                      <SelectItem key={member.userId} value={member.userId}>
+                        {member.name}
+                        {member.role === 'owner' && (
+                          <span className="ml-1.5 text-xs text-muted-foreground">(현재 대표)</span>
+                        )}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {pendingOwnerId && (
+                  <p className="text-[11px] text-amber-600">
+                    저장 시 해당 멤버에게 대표자 권한이 이전됩니다.
+                  </p>
+                )}
+              </>
+            )}
           </div>
           <div className="space-y-1.5">
             <Label className="text-xs text-muted-foreground">사업 유형</Label>

--- a/src/features/store-settings/hooks/useStoreSettings.ts
+++ b/src/features/store-settings/hooks/useStoreSettings.ts
@@ -27,7 +27,7 @@ export function useUpdateStoreSettings() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (data: Partial<Omit<StoreSettings, 'operatingHours'>>) =>
+    mutationFn: (data: Partial<Omit<StoreSettings, 'operatingHours'>> & { ownerId?: string }) =>
       updateStoreSettings(storeId!, data),
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: ['storeSettings', storeId] });

--- a/src/pages/SettingsMenuBoardPage.tsx
+++ b/src/pages/SettingsMenuBoardPage.tsx
@@ -192,7 +192,7 @@ const SettingsMenuBoardPage = () => {
               {/* 레이아웃 */}
               <div className="px-4 py-3">
                 <p className="mb-3 text-xs font-medium text-muted-foreground">레이아웃</p>
-                <div className="inline-flex gap-0.5 rounded-lg bg-gray-100 p-1">
+                <div className="inline-flex gap-0.5 rounded-lg bg-muted p-1">
                   {(
                     [
                       { key: 'list', label: '리스트', icon: AlignJustify },
@@ -206,8 +206,8 @@ const SettingsMenuBoardPage = () => {
                       className={cn(
                         'flex items-center gap-2 rounded-md px-5 py-2 text-sm transition-all',
                         form.layout === key
-                          ? 'bg-white font-medium text-gray-900 shadow-sm'
-                          : 'text-gray-400 hover:text-gray-600',
+                          ? 'bg-background font-medium text-foreground shadow-sm'
+                          : 'text-muted-foreground hover:text-foreground',
                       )}
                     >
                       <Icon className="size-4" />
@@ -295,9 +295,9 @@ const SettingsMenuBoardPage = () => {
                   <button
                     type="button"
                     onClick={() => bannerInputRef.current?.click()}
-                    className="flex h-20 w-full flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-200 bg-gray-50/60 transition-colors hover:border-baro-blue/40 hover:bg-baro-blue/5"
+                    className="flex h-20 w-full flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed border-border bg-muted/40 transition-colors hover:border-baro-blue/40 hover:bg-baro-blue/5 dark:bg-transparent"
                   >
-                    <ImagePlus className="size-5 text-gray-300" />
+                    <ImagePlus className="size-5 text-muted-foreground/40" />
                     <span className="text-xs text-muted-foreground">배너 이미지 추가</span>
                   </button>
                 )}

--- a/src/pages/SettingsMenusPage.tsx
+++ b/src/pages/SettingsMenusPage.tsx
@@ -140,15 +140,15 @@ const MenuModal = ({
 
   return (
     <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
-      <DialogContent showCloseButton={false} className="max-h-[calc(100svh-4rem)] overflow-hidden">
-        <DialogHeader>
+      <DialogContent showCloseButton={false} className="max-h-[calc(100svh-4rem)] flex flex-col">
+        <DialogHeader className="shrink-0">
           <DialogTitle className="flex items-center gap-2">
             <UtensilsCrossed className="size-4 text-muted-foreground" />
             {editing ? '메뉴 수정' : '메뉴 등록'}
           </DialogTitle>
         </DialogHeader>
 
-        <div className="flex flex-col gap-4 overflow-y-auto min-h-0">
+        <div className="flex flex-1 flex-col gap-4 overflow-y-auto min-h-0">
           {/* 사진 업로드 */}
           <div className="space-y-1.5">
             <Label>메뉴 사진</Label>
@@ -268,15 +268,15 @@ const MenuModal = ({
           </div>
         </div>
 
-        <DialogFooter>
-          <Button type="button" variant="outline" onClick={onClose}>
+        <DialogFooter className="shrink-0">
+          <Button type="button" variant="outline" onClick={onClose} className="shrink-0">
             취소
           </Button>
           <Button
             type="button"
             onClick={handleSave}
             disabled={isSaving || isUploading}
-            className="bg-baro-blue hover:bg-baro-blue/80"
+            className="shrink-0 bg-baro-blue hover:bg-baro-blue/80"
           >
             {editing ? '수정 완료' : '등록하기'}
           </Button>


### PR DESCRIPTION
## 📌 요약

- 메뉴 등록/수정 모달 내부 스크롤 및 버튼 고정 버그 수정
- 초기 세팅 식자재·레시피 단계 모바일 콘텐츠 잘림 수정
- 가게 설정 대표자 변경 기능 구현
- 계정 홈 서비스 정보 드롭다운 방향 반응형 처리 및 가게 편집 버튼 오버플로우 수정
- 메뉴판 설정 레이아웃·배너 버튼 다크모드 미적용 수정

<br/>

## 🏷️ 관련 이슈

- Closes #177
- Closes #178
- Closes #180
- Closes #181
- Closes #182

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- 가게 설정 > 가게 정보에서 팀 멤버 중 대표자 변경 가능 (백엔드 `PATCH /stores/:storeId` ownerId 지원 활용)

<br/>

### 📂 세부 변경사항

- **SettingsMenusPage.tsx**: DialogContent를 flex-col로 전환, 콘텐츠 영역 flex-1 overflow-y-auto, 헤더/푸터 shrink-0, 버튼 shrink-0
- **StepIngredientsAndRecipes.tsx**: 모바일에서 패널 flex-1 제거(md:에만 적용), 외부 컨테이너 스크롤로 위임
- **StoreInfoSection.tsx + storeSettings.api.ts + useStoreSettings.ts**: 대표자 Select UI, ownerId 타입 추가
- **MyStoresList.tsx**: useIsMobile 훅으로 DropdownMenu side·아이콘 반응형 전환, 그리드 래퍼 px-2로 버튼 돌출 수용
- **SettingsMenuBoardPage.tsx**: 하드코딩 gray → bg-muted/bg-background/text-foreground/border-border 등 시맨틱 토큰으로 교체

<br/>

## 🧪 테스트 방법

1. 메뉴 관리 > 메뉴 추가: 모달 내부 스크롤 동작, 하단 버튼 고정 및 좁은 화면에서 버튼 찌그러짐 없음 확인
2. 초기 세팅 4단계: 모바일(< 768px)에서 식자재 입력 행·태그 목록까지 전체 표시 확인
3. 가게 설정 > 가게 정보 > 수정: 팀 멤버 2명 이상 시 대표자 Select 표시, 변경 후 저장 확인
4. 계정 홈: 모바일에서 서비스 정보 드롭다운이 아래로 열리는지, 가게 편집 시 X/- 버튼이 화면을 밀지 않는지 확인
5. 메뉴판 설정: 다크모드에서 레이아웃 버튼·배너 업로드 버튼 정상 표시 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [ ] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- 대표자 변경은 새 대표자가 이미 storeMembers에 속해 있어야 함 (백엔드 검증)
- 팀 멤버가 본인 1명뿐이면 대표자 Select 대신 변경 불가 안내 문구 표시