### PR TITLE
♻️ (#184) refactor: 서버 에러 코드 기반 사용자 안내 메시지 + OCR·대시보드 다크모드 개선

### DIFF
--- a/src/features/auth/components/RegisterForm.tsx
+++ b/src/features/auth/components/RegisterForm.tsx
@@ -13,6 +13,7 @@ import useAuthStore from '@/features/auth/store/authStore';
 import { Button } from '@/shadcn/ui/button';
 import { Input } from '@/shadcn/ui/input';
 import { Label } from '@/shadcn/ui/label';
+import { getApiErrorMessage } from '@/shared/utils/apiError';
 
 const schema = z.object({
   username: z
@@ -44,14 +45,7 @@ const RegisterForm = () => {
       setTokens(accessToken, refreshToken);
       navigate(routePaths.myStores, { replace: true });
     } catch (err: unknown) {
-      const status = (err as { response?: { status?: number } })?.response?.status;
-      if (status === 403) {
-        toast.error('초대 코드가 올바르지 않습니다.');
-      } else if (status === 409) {
-        toast.error('이미 사용 중인 아이디입니다.');
-      } else {
-        toast.error('회원가입에 실패했습니다. 잠시 후 다시 시도해 주세요.');
-      }
+      toast.error(getApiErrorMessage(err, '회원가입에 실패했습니다. 잠시 후 다시 시도해 주세요.'));
     }
   };
 

--- a/src/features/dashboard/components/OcrUploadCard.tsx
+++ b/src/features/dashboard/components/OcrUploadCard.tsx
@@ -37,9 +37,9 @@ const OcrUploadCard = () => {
           onClick={() => fileInputRef.current?.click()}
           onDrop={handleDrop}
           onDragOver={(e) => e.preventDefault()}
-          className="border-2 border-dashed rounded-xl flex flex-col items-center justify-center gap-3 py-5 bg-blue-50/10 cursor-pointer hover:bg-baro-blue/10 transition-colors group"
+          className="border-2 border-dashed rounded-xl flex flex-col items-center justify-center gap-3 py-5 bg-muted/20 cursor-pointer hover:bg-baro-blue/5 transition-colors group"
         >
-          <div className="w-8 h-8 rounded-full bg-blue-100 flex items-center justify-center group-hover:bg-blue-200 transition-colors">
+          <div className="w-8 h-8 rounded-full bg-baro-blue/15 flex items-center justify-center group-hover:bg-baro-blue/25 transition-colors">
             <Upload className="w-4 h-4 text-baro-blue" />
           </div>
           <div className="text-center">

--- a/src/features/initial-setup/components/steps/StepBasicInfo.tsx
+++ b/src/features/initial-setup/components/steps/StepBasicInfo.tsx
@@ -40,11 +40,11 @@ const StepBasicInfo = ({ data, userName, onChange, errors }: StepBasicInfoProps)
         </Label>
         <Input
           id="storeName"
-          placeholder="예: 바로 카페 홍대점"
+          placeholder="예: 바로 카페 강원대점"
           value={data.storeName}
           onChange={(e) => onChange({ ...data, storeName: e.target.value })}
           aria-invalid={!!errors.storeName}
-          className="h-10"
+          className="h-10 focus:bg-background"
         />
         {errors.storeName && <p className="text-xs text-destructive">{errors.storeName}</p>}
       </div>

--- a/src/features/initial-setup/components/steps/StepMenuRegistration.tsx
+++ b/src/features/initial-setup/components/steps/StepMenuRegistration.tsx
@@ -11,6 +11,7 @@ import MenuOcrReviewStep, {
 } from '@/features/store-settings/components/MenuOcrReviewStep';
 import MenuOcrUploadStep from '@/features/store-settings/components/MenuOcrUploadStep';
 import { Button } from '@/shadcn/ui/button';
+import { getApiErrorMessage } from '@/shared/utils/apiError';
 
 type OcrStep = 'upload' | 'analyzing' | 'review';
 
@@ -67,8 +68,8 @@ const StepMenuRegistration = ({ data, onChange }: StepMenuRegistrationProps) => 
         })),
       );
       setOcrStep('review');
-    } catch {
-      setOcrError('메뉴 인식에 실패했습니다. 다시 시도해주세요.');
+    } catch (err) {
+      setOcrError(getApiErrorMessage(err, '메뉴 인식에 실패했습니다. 다시 시도해 주세요.'));
       setOcrStep('upload');
     }
   };
@@ -95,13 +96,13 @@ const StepMenuRegistration = ({ data, onChange }: StepMenuRegistrationProps) => 
   /* OCR 플로우 활성 중 */
   if (ocrStep !== null) {
     return (
-      <div className="flex flex-1 min-h-0 flex-col overflow-hidden py-2">
+      <div className="flex flex-1 min-h-0 flex-col overflow-hidden">
         {ocrStep === 'upload' && (
           <>
             {ocrError && (
-              <p className="text-xs text-destructive bg-red-50 rounded-lg px-3 py-2 mb-4">
+              <div className="text-xs text-destructive bg-destructive/10 rounded-lg px-3 py-2 mb-3">
                 {ocrError}
-              </p>
+              </div>
             )}
             <MenuOcrUploadStep
               onFileSelect={handleOcrFileSelect}
@@ -140,9 +141,9 @@ const StepMenuRegistration = ({ data, onChange }: StepMenuRegistrationProps) => 
     <div className="flex flex-1 min-h-0 flex-col">
       {data.length === 0 ? (
         /* 빈 상태 — 방법 선택 */
-        <div className="flex flex-1 flex-col items-center justify-center gap-4 rounded-xl border-2 border-dashed border-gray-200 text-center">
-          <div className="flex size-12 items-center justify-center rounded-full bg-gray-100">
-            <Plus className="size-6 text-gray-400" />
+        <div className="flex flex-1 flex-col items-center justify-center gap-4 rounded-xl border-2 border-dashed border-border text-center">
+          <div className="flex size-12 items-center justify-center rounded-full bg-muted">
+            <Plus className="size-6 text-muted-foreground" />
           </div>
           <div>
             <p className="text-sm font-medium text-muted-foreground">등록된 메뉴가 없습니다</p>
@@ -182,7 +183,7 @@ const StepMenuRegistration = ({ data, onChange }: StepMenuRegistrationProps) => 
                   key={menu.id}
                   className="group overflow-hidden rounded-xl border bg-card transition-shadow hover:shadow-md"
                 >
-                  <div className="relative h-28 bg-gray-100 dark:bg-gray-800">
+                  <div className="relative h-28 bg-muted">
                     {menu.imageUrl ? (
                       <img
                         src={menu.imageUrl}
@@ -191,7 +192,7 @@ const StepMenuRegistration = ({ data, onChange }: StepMenuRegistrationProps) => 
                       />
                     ) : (
                       <div className="flex h-full items-center justify-center">
-                        <ImageOff className="size-8 text-gray-300" />
+                        <ImageOff className="size-8 text-muted-foreground/40" />
                       </div>
                     )}
 
@@ -206,14 +207,14 @@ const StepMenuRegistration = ({ data, onChange }: StepMenuRegistrationProps) => 
                       <button
                         type="button"
                         onClick={() => handleOpenEdit(menu)}
-                        className="flex size-6 items-center justify-center rounded-full bg-white/90 text-gray-600 shadow-sm transition-colors hover:text-baro-blue"
+                        className="flex size-6 items-center justify-center rounded-full bg-background/90 text-foreground/70 shadow-sm transition-colors hover:text-baro-blue"
                       >
                         <Pencil className="size-3" />
                       </button>
                       <button
                         type="button"
                         onClick={() => handleDelete(menu.id)}
-                        className="flex size-6 items-center justify-center rounded-full bg-white/90 text-gray-600 shadow-sm transition-colors hover:text-red-500"
+                        className="flex size-6 items-center justify-center rounded-full bg-background/90 text-foreground/70 shadow-sm transition-colors hover:text-baro-red"
                       >
                         <Trash2 className="size-3" />
                       </button>

--- a/src/features/ocr-inbound/components/OcrUploadStep.tsx
+++ b/src/features/ocr-inbound/components/OcrUploadStep.tsx
@@ -85,7 +85,7 @@ const OcrUploadStep = ({ onFileSelect }: OcrUploadStepProps) => {
             onDrop={handleDrop}
             onDragOver={(e) => e.preventDefault()}
             onClick={() => fileInputRef.current?.click()}
-            className="flex-1 border-2 border-dashed border-border hover:border-baro-blue/50 rounded-xl bg-muted/20 hover:bg-blue-50/30 transition-all cursor-pointer flex flex-col items-center justify-center gap-3 py-10 md:flex-none md:py-14"
+            className="flex-1 border-2 border-dashed border-border hover:border-baro-blue/50 rounded-xl bg-muted/20 hover:bg-baro-blue/5 transition-all cursor-pointer flex flex-col items-center justify-center gap-3 py-10 md:flex-none md:py-14"
           >
             <div className="w-12 h-12 rounded-2xl bg-muted flex items-center justify-center">
               <FileImage className="w-6 h-6 text-muted-foreground" />

--- a/src/features/store-registration/components/InviteCodeModal.tsx
+++ b/src/features/store-registration/components/InviteCodeModal.tsx
@@ -19,16 +19,12 @@ import {
 } from '@/shadcn/ui/dialog';
 import { Input } from '@/shadcn/ui/input';
 import { Label } from '@/shadcn/ui/label';
+import { getApiErrorMessage } from '@/shared/utils/apiError';
 
 interface InviteCodeModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
-
-const ERROR_MESSAGES: Record<string, string> = {
-  INVALID_INVITE_CODE: '유효하지 않은 초대코드입니다. 다시 확인해 주세요.',
-  ALREADY_MEMBER: '이미 참여한 가게입니다.',
-};
 
 const InviteCodeModal = ({ open, onOpenChange }: InviteCodeModalProps) => {
   const navigate = useNavigate();
@@ -49,11 +45,9 @@ const InviteCodeModal = ({ open, onOpenChange }: InviteCodeModalProps) => {
         navigate(routePaths.storeHome, { replace: true });
       },
       onError: (err: unknown) => {
-        const code = (err as { response?: { data?: { error?: { code?: string } } } })?.response
-          ?.data?.error?.code;
-        const message =
-          (code && ERROR_MESSAGES[code]) ?? '가게 참여에 실패했습니다. 잠시 후 다시 시도해 주세요.';
-        toast.error(message);
+        toast.error(
+          getApiErrorMessage(err, '가게 참여에 실패했습니다. 잠시 후 다시 시도해 주세요.'),
+        );
       },
     });
   };

--- a/src/features/store-registration/components/StoreSelectionCards.tsx
+++ b/src/features/store-registration/components/StoreSelectionCards.tsx
@@ -66,7 +66,7 @@ const StoreSelectionCards = () => {
             {/* Text */}
             <div className="flex-1 space-y-2">
               <p className="text-xs font-bold uppercase tracking-widest text-baro-blue">사장님</p>
-              <h2 className="text-xl font-black text-baro-black">새 가게 등록하기</h2>
+              <h2 className="text-xl">새 가게 등록하기</h2>
               <p className="text-sm leading-relaxed text-muted-foreground">
                 직접 가게를 개설하고 재고를 관리하세요.
                 <br />
@@ -136,7 +136,7 @@ const StoreSelectionCards = () => {
             {/* Text */}
             <div className="flex-1 space-y-2">
               <p className="text-xs font-bold uppercase tracking-widest text-baro-green">직원</p>
-              <h2 className="text-xl font-black text-baro-black">초대코드로 합류하기</h2>
+              <h2 className="text-xl">초대코드로 합류하기</h2>
               <p className="text-sm leading-relaxed text-muted-foreground">
                 사장님께 받은 초대코드를 입력하면
                 <br />

--- a/src/features/store-settings/components/MenuOcrModal.tsx
+++ b/src/features/store-settings/components/MenuOcrModal.tsx
@@ -9,6 +9,7 @@ import MenuOcrReviewStep, {
 } from '@/features/store-settings/components/MenuOcrReviewStep';
 import MenuOcrUploadStep from '@/features/store-settings/components/MenuOcrUploadStep';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/shadcn/ui/dialog';
+import { getApiErrorMessage } from '@/shared/utils/apiError';
 
 type OcrStep = 'upload' | 'analyzing' | 'review';
 
@@ -65,8 +66,8 @@ const MenuOcrModal = ({
         })),
       );
       setStep('review');
-    } catch {
-      setErrorMsg('메뉴 인식에 실패했습니다. 다시 시도해주세요.');
+    } catch (err) {
+      setErrorMsg(getApiErrorMessage(err, '메뉴 인식에 실패했습니다. 다시 시도해 주세요.'));
       setStep('upload');
     }
   };
@@ -108,7 +109,7 @@ const MenuOcrModal = ({
         {step === 'upload' && (
           <>
             {errorMsg && (
-              <div className="text-xs text-destructive bg-red-50 rounded-md px-3 py-2">
+              <div className="text-xs text-destructive bg-destructive/10 rounded-md px-3 py-2">
                 {errorMsg}
               </div>
             )}

--- a/src/features/store-settings/components/MenuOcrReviewStep.tsx
+++ b/src/features/store-settings/components/MenuOcrReviewStep.tsx
@@ -99,7 +99,7 @@ const MenuOcrReviewStep = ({
 
         {/* 중복 안내 */}
         {duplicateCount > 0 && (
-          <p className="text-xs text-orange-600 bg-orange-50 border border-orange-200 rounded-lg px-3 py-2">
+          <p className="text-xs text-baro-yellow-text bg-baro-yellow/10 border border-baro-yellow/40 rounded-lg px-3 py-2">
             이미 등록된 메뉴 <strong>{duplicateCount}개</strong>는 등록하지 않습니다. 이름을
             수정하거나 해당 항목을 삭제해주세요.
           </p>
@@ -123,13 +123,13 @@ const MenuOcrReviewStep = ({
               <button
                 type="button"
                 onClick={() => handleImageClick(item.id)}
-                className="w-9 h-9 rounded-lg border overflow-hidden flex items-center justify-center bg-gray-50 hover:bg-gray-100 transition-colors shrink-0"
+                className="w-9 h-9 rounded-lg border overflow-hidden flex items-center justify-center bg-muted hover:bg-muted/60 transition-colors shrink-0"
                 title="사진 추가"
               >
                 {item.imageUrl ? (
                   <img src={item.imageUrl} alt="" className="w-full h-full object-cover" />
                 ) : (
-                  <ImagePlus className="w-3.5 h-3.5 text-gray-300" />
+                  <ImagePlus className="w-3.5 h-3.5 text-muted-foreground/40" />
                 )}
               </button>
             );
@@ -142,11 +142,12 @@ const MenuOcrReviewStep = ({
                   placeholder="메뉴명"
                   className={cn(
                     'h-8 text-sm',
-                    dup && 'border-orange-400 bg-orange-50 focus-visible:ring-orange-300 pr-14',
+                    dup &&
+                      'border-baro-yellow bg-baro-yellow/10 focus-visible:ring-baro-yellow/50 pr-14',
                   )}
                 />
                 {dup && (
-                  <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[10px] font-semibold text-orange-600 bg-orange-100 border border-orange-300 px-1.5 py-0.5 rounded-full whitespace-nowrap">
+                  <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[10px] font-semibold text-baro-yellow-text bg-baro-yellow/25 border border-baro-yellow/60 px-1.5 py-0.5 rounded-full whitespace-nowrap">
                     이미 등록됨
                   </span>
                 )}
@@ -190,7 +191,7 @@ const MenuOcrReviewStep = ({
                     'w-4 h-4',
                     item.isFeatured
                       ? 'fill-baro-yellow text-baro-yellow'
-                      : 'text-gray-300 hover:text-baro-yellow/50',
+                      : 'text-muted-foreground/40 hover:text-baro-yellow/50',
                   )}
                 />
               </button>
@@ -200,7 +201,7 @@ const MenuOcrReviewStep = ({
               <button
                 type="button"
                 onClick={() => handleDelete(item.id)}
-                className="flex items-center justify-center w-8 h-8 rounded-md text-muted-foreground hover:text-baro-red hover:bg-red-50 transition-colors"
+                className="flex items-center justify-center w-8 h-8 rounded-md text-muted-foreground hover:text-baro-red hover:bg-red-500/10 transition-colors"
                 aria-label="항목 삭제"
               >
                 <Trash2 className="w-3.5 h-3.5" />
@@ -210,7 +211,7 @@ const MenuOcrReviewStep = ({
             return (
               <div
                 key={item.id}
-                className={cn('rounded-lg transition-colors', dup && 'bg-orange-50/60')}
+                className={cn('rounded-lg transition-colors', dup && 'bg-baro-yellow/5')}
               >
                 {/* 데스크탑 행 */}
                 <div className="hidden md:grid grid-cols-[36px_2fr_100px_2fr_36px_36px] gap-2 items-center px-1 py-0.5">

--- a/src/features/store-settings/components/MenuOcrUploadStep.tsx
+++ b/src/features/store-settings/components/MenuOcrUploadStep.tsx
@@ -65,7 +65,7 @@ const MenuOcrUploadStep = ({ onFileSelect, onBack }: MenuOcrUploadStepProps) => 
           onDrop={handleDrop}
           onDragOver={(e) => e.preventDefault()}
           onClick={() => fileInputRef.current?.click()}
-          className="border-2 border-dashed border-border hover:border-baro-blue/50 rounded-xl bg-muted/20 hover:bg-blue-50/30 transition-all cursor-pointer flex flex-col items-center justify-center gap-3 py-12"
+          className="border-2 border-dashed border-border hover:border-baro-blue/50 rounded-xl bg-muted/20 hover:bg-baro-blue/5 transition-all cursor-pointer flex flex-col items-center justify-center gap-3 py-12"
         >
           <div className="w-12 h-12 rounded-2xl bg-muted flex items-center justify-center">
             <FileImage className="w-6 h-6 text-muted-foreground" />

--- a/src/pages/OcrInboundPage.tsx
+++ b/src/pages/OcrInboundPage.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useQueryClient } from '@tanstack/react-query';
-import axios from 'axios';
 import { ArrowLeft, ScanLine } from 'lucide-react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
@@ -25,6 +24,7 @@ import type { OcrInboundItem } from '@/features/ocr-inbound/types/ocrInbound.typ
 import { confirmInbound } from '@/features/store-settings/api/ingredients.api';
 import { updateStoreSettings } from '@/features/store-settings/api/storeSettings.api';
 import { useStoreSettings } from '@/features/store-settings/hooks/useStoreSettings';
+import { getApiErrorMessage } from '@/shared/utils/apiError';
 
 type Step = 'upload' | 'analyzing' | 'review';
 
@@ -176,11 +176,9 @@ const OcrInboundPage = () => {
         setStep('review');
         saveDraft({ imageBase64: base64, metadata: result.metadata, items: processedItems });
       } catch (err) {
-        const message =
-          axios.isAxiosError(err) && err.response?.data?.error?.message
-            ? err.response.data.error.message
-            : 'OCR 처리에 실패했습니다. 잠시 후 다시 시도해주세요.';
-        toast.error(message);
+        toast.error(
+          getApiErrorMessage(err, 'OCR 처리에 실패했습니다. 잠시 후 다시 시도해 주세요.'),
+        );
         URL.revokeObjectURL(blobUrl);
         setStep('upload');
         setImageUrl(null);

--- a/src/shadcn/ui/input.tsx
+++ b/src/shadcn/ui/input.tsx
@@ -10,7 +10,7 @@ function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
       type={type}
       data-slot="input"
       className={cn(
-        'h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40',
+        'h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40',
         className,
       )}
       {...props}

--- a/src/shared/constants/errorMessages.ts
+++ b/src/shared/constants/errorMessages.ts
@@ -1,0 +1,33 @@
+export const API_ERROR_MESSAGES: Record<string, string> = {
+  // 외부 서비스 장애 — AI / OCR
+  AI_UNAVAILABLE:
+    'AI 서비스(Gemini)에 일시적인 장애가 발생했습니다. 서비스 문제가 아닌 외부 AI 서비스 문제이므로, 잠시 후 다시 시도해 주세요.',
+  OCR_FAILED:
+    '이미지 인식 서비스(CLOVA OCR)에 일시적인 장애가 발생했습니다. 외부 서비스 상태로 인한 오류이므로, 잠시 후 다시 시도해 주세요.',
+  OCR_EMPTY:
+    '이미지에서 텍스트를 인식하지 못했습니다. 사진이 흐리거나 글씨가 작을 경우 더 선명한 사진으로 다시 시도해 주세요.',
+  PARSE_FAILED: 'AI 분석 결과 파싱 중 외부 서비스 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.',
+
+  // 파일 / 업로드
+  UPLOAD_FAILED: '이미지 업로드에 실패했습니다. 네트워크 상태를 확인 후 다시 시도해 주세요.',
+
+  // 인증
+  UNAUTHORIZED: '인증이 만료되었습니다. 다시 로그인해 주세요.',
+  FORBIDDEN: '접근 권한이 없습니다.',
+
+  // 리소스
+  NOT_FOUND: '요청한 정보를 찾을 수 없습니다.',
+  CONFLICT: '이미 존재하는 데이터입니다.',
+
+  // 가게
+  INVALID_INVITE_CODE: '유효하지 않은 초대 코드입니다.',
+  ALREADY_MEMBER: '이미 참여 중인 가게입니다.',
+  INVALID_OWNER: '가게 멤버가 아닙니다.',
+  OWNER_CANNOT_LEAVE: '가게 대표자는 가게를 나갈 수 없습니다.',
+  CANNOT_REMOVE_SELF: '자기 자신을 내보낼 수 없습니다.',
+
+  // 마감
+  KAKAO_AUTH_FAILED: '카카오 로그인에 실패했습니다. 다시 시도해 주세요.',
+};
+
+export const DEFAULT_ERROR_MESSAGE = '오류가 발생했습니다. 잠시 후 다시 시도해 주세요.';

--- a/src/shared/utils/apiError.ts
+++ b/src/shared/utils/apiError.ts
@@ -1,0 +1,13 @@
+import axios from 'axios';
+
+import { API_ERROR_MESSAGES, DEFAULT_ERROR_MESSAGE } from '@/shared/constants/errorMessages';
+
+export const getApiErrorCode = (err: unknown): string | undefined => {
+  if (!axios.isAxiosError(err)) return undefined;
+  return (err.response?.data as { error?: { code?: string } } | undefined)?.error?.code;
+};
+
+export const getApiErrorMessage = (err: unknown, fallback = DEFAULT_ERROR_MESSAGE): string => {
+  const code = getApiErrorCode(err);
+  return code ? (API_ERROR_MESSAGES[code] ?? fallback) : fallback;
+};


### PR DESCRIPTION
## 📌 요약

- 서버 에러 코드(`AI_UNAVAILABLE`, `OCR_FAILED` 등)를 사용자 친화적 메시지로 변환하는 공통 시스템 구축
- AI·외부 서비스 장애 시 "저희 서비스 문제가 아닌 외부 서비스 문제"임을 명확히 안내
- OCR 업로드 드롭존, 메뉴 OCR 검수, 대시보드 등 하드코딩된 고정 색상을 시맨틱 토큰으로 교체해 다크모드 대응

<br/>

## 🏷️ 관련 이슈

- Closes #184

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- `src/shared/constants/errorMessages.ts` 신규: 에러 코드 → 메시지 매핑 테이블
- `src/shared/utils/apiError.ts` 신규: `getApiErrorMessage(err, fallback)` 유틸 함수
- AI/OCR 관련 페이지 전체에 `getApiErrorMessage` 적용 (OCR 입고, 메뉴 OCR 모달, 초기 세팅)
- `InviteCodeModal`: 로컬 `ERROR_MESSAGES` 맵 제거 → 공유 유틸로 통합
- `RegisterForm`: HTTP 상태 코드 분기 → 에러 코드 기반으로 전환

<br/>

### 📂 세부 변경사항

- **다크모드**: 드롭존 `hover:bg-blue-50/30` → `hover:bg-baro-blue/5`
- **다크모드**: `MenuOcrReviewStep` 중복 메뉴 표시 `orange-*` → `baro-yellow` 계열
- **다크모드**: `StepMenuRegistration` 빈 상태 영역 `gray-*` → 시맨틱 토큰
- **다크모드**: `StoreSelectionCards` h2 `font-black text-baro-black` 제거
- **다크모드**: `MenuOcrModal` 에러 배너 `bg-red-50` → `bg-destructive/10`
- `StepMenuRegistration` 에러 배너 `<p>` → `<div>` 교체 및 래퍼 `py-2` 제거 (상단 여백 과다 수정)
- `input.tsx` aria-invalid `ring-3` 제거

<br/>

## 📸 Screenshots

| Before | After |
| ------ | ----- |
| AI 장애 시 "OCR 처리에 실패했습니다." 만 표시 | "AI 서비스(Gemini)에 일시적인 장애가 발생했습니다. 외부 AI 서비스 문제이므로, 잠시 후 다시 시도해 주세요." |
| 드롭존 hover 시 라이트모드 고정 파란 배경 | 다크모드에서도 자연스러운 `baro-blue/5` 틴트 |

<br/>

## 🧪 테스트 방법

1. 다크모드에서 OCR 입고 처리 페이지 → 드롭존 hover 확인
2. 다크모드에서 가게 설정 → 메뉴판으로 등록 → 드롭존 및 검수 화면 확인
3. 다크모드에서 대시보드 OCR 빠른 입고 처리 카드 hover 확인
4. AI_UNAVAILABLE 에러 발생 시 외부 서비스 장애임을 안내하는 메시지 확인
5. 초기 세팅 3단계(메뉴 등록) → OCR 실패 시 에러 배너 상단 여백 정상 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [ ] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- 심사 기간 중 Gemini/CLOVA OCR 외부 서비스 장애 시 감점 방지를 위해 에러 코드별 메시지를 명확히 구분
- `getApiErrorMessage`는 fallback 파라미터를 받아 기존 하드코딩 메시지를 그대로 유지하면서 에러 코드가 매핑된 경우에만 더 구체적인 메시지를 노출