### PR TITLE
🚀 (#186) deploy: v1.1.1 버그 수정·UI 개선·에러 처리 강화 배포

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,19 +4,22 @@ import { BrowserRouter } from 'react-router-dom';
 import AppInitializer from '@/app/AppInitializer';
 import Router from '@/app/routes/Router';
 import { Toaster } from '@/shadcn/ui/sonner';
+import ErrorBoundary from '@/shared/components/ErrorBoundary';
 
 const queryClient = new QueryClient();
 
 function App() {
   return (
-    <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <AppInitializer>
-          <Router />
-          <Toaster position="top-center" />
-        </AppInitializer>
-      </BrowserRouter>
-    </QueryClientProvider>
+    <ErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter>
+          <AppInitializer>
+            <Router />
+            <Toaster position="top-center" />
+          </AppInitializer>
+        </BrowserRouter>
+      </QueryClientProvider>
+    </ErrorBoundary>
   );
 }
 

--- a/src/app/routes/ProtectedRoute.tsx
+++ b/src/app/routes/ProtectedRoute.tsx
@@ -1,0 +1,17 @@
+import { Navigate, Outlet } from 'react-router-dom';
+
+import { routePaths } from './routePaths';
+
+import useAuthStore from '@/features/auth/store/authStore';
+
+const ProtectedRoute = () => {
+  const accessToken = useAuthStore((s) => s.accessToken);
+
+  if (!accessToken) {
+    return <Navigate to={routePaths.login} replace />;
+  }
+
+  return <Outlet />;
+};
+
+export default ProtectedRoute;

--- a/src/app/routes/Router.tsx
+++ b/src/app/routes/Router.tsx
@@ -1,6 +1,7 @@
 import { Routes, Route, useLocation } from 'react-router-dom';
 
 import AppLayout from '@/app/layouts/AppLayout';
+import ProtectedRoute from '@/app/routes/ProtectedRoute';
 import { routePaths } from '@/app/routes/routePaths';
 import SettingsPage from '@/pages/AccountSettingsPage';
 import AuthCallbackPage from '@/pages/AuthCallbackPage';
@@ -62,34 +63,6 @@ export default function Router() {
         element={<StandalonePageWrapper element={<RegisterPage />} />}
       />
       <Route
-        path={routePaths.storeSelection}
-        element={<StandalonePageWrapper element={<StoreSelectionPage />} />}
-      />
-      <Route
-        path={routePaths.myStores}
-        element={<StandalonePageWrapper element={<MyStoresPage />} />}
-      />
-      <Route
-        path={routePaths.initialSetup}
-        element={<StandalonePageWrapper element={<InitialSetupPage />} />}
-      />
-      <Route
-        path={routePaths.storeHome}
-        element={<StandalonePageWrapper element={<StoreHomePage />} />}
-      />
-      <Route
-        path={routePaths.dayClosed}
-        element={<StandalonePageWrapper element={<DayClosedPage />} />}
-      />
-      <Route
-        path={routePaths.closingOrderGuideDetail}
-        element={<StandalonePageWrapper element={<ClosingOrderGuidePage />} />}
-      />
-      <Route
-        path={routePaths.ocrInbound}
-        element={<StandalonePageWrapper element={<OcrInboundPage />} />}
-      />
-      <Route
         path={routePaths.customerOrder}
         element={<StandalonePageWrapper element={<CustomerOrderPage />} />}
       />
@@ -110,21 +83,53 @@ export default function Router() {
         element={<StandalonePageWrapper element={<NotFoundPage />} />}
       />
 
-      {/* 사이드바 + 상단바 공통 레이아웃 */}
-      <Route element={<AppLayout />}>
-        <Route path={routePaths.dashboard} element={<DashboardPage />} />
-        <Route path={routePaths.inventory} element={<InventoryPage />} />
-        <Route path={routePaths.orderGuide} element={<OrderGuidePage />} />
-        <Route path={routePaths.closing} element={<ClosingPage />} />
-        {/* 가게 설정 */}
-        <Route path={routePaths.storeSettings} element={<StoreSettingsPage />} />
-        <Route path={routePaths.storeSettingsMenus} element={<SettingsMenusPage />} />
-        <Route path={routePaths.storeSettingsMenuBoard} element={<SettingsMenuBoardPage />} />
-        <Route path={routePaths.storeSettingsTable} element={<SettingsTablePage />} />
-        <Route path={routePaths.storeSettingsRecipes} element={<SettingsRecipesPage />} />
-        <Route path={routePaths.storeSettingsIngredients} element={<SettingsIngredientsPage />} />
-        {/* 회원 설정 */}
-        <Route path={routePaths.settings} element={<SettingsPage />} />
+      {/* 로그인 필요 */}
+      <Route element={<ProtectedRoute />}>
+        <Route
+          path={routePaths.storeSelection}
+          element={<StandalonePageWrapper element={<StoreSelectionPage />} />}
+        />
+        <Route
+          path={routePaths.myStores}
+          element={<StandalonePageWrapper element={<MyStoresPage />} />}
+        />
+        <Route
+          path={routePaths.initialSetup}
+          element={<StandalonePageWrapper element={<InitialSetupPage />} />}
+        />
+        <Route
+          path={routePaths.storeHome}
+          element={<StandalonePageWrapper element={<StoreHomePage />} />}
+        />
+        <Route
+          path={routePaths.dayClosed}
+          element={<StandalonePageWrapper element={<DayClosedPage />} />}
+        />
+        <Route
+          path={routePaths.closingOrderGuideDetail}
+          element={<StandalonePageWrapper element={<ClosingOrderGuidePage />} />}
+        />
+        <Route
+          path={routePaths.ocrInbound}
+          element={<StandalonePageWrapper element={<OcrInboundPage />} />}
+        />
+
+        {/* 사이드바 + 상단바 공통 레이아웃 */}
+        <Route element={<AppLayout />}>
+          <Route path={routePaths.dashboard} element={<DashboardPage />} />
+          <Route path={routePaths.inventory} element={<InventoryPage />} />
+          <Route path={routePaths.orderGuide} element={<OrderGuidePage />} />
+          <Route path={routePaths.closing} element={<ClosingPage />} />
+          {/* 가게 설정 */}
+          <Route path={routePaths.storeSettings} element={<StoreSettingsPage />} />
+          <Route path={routePaths.storeSettingsMenus} element={<SettingsMenusPage />} />
+          <Route path={routePaths.storeSettingsMenuBoard} element={<SettingsMenuBoardPage />} />
+          <Route path={routePaths.storeSettingsTable} element={<SettingsTablePage />} />
+          <Route path={routePaths.storeSettingsRecipes} element={<SettingsRecipesPage />} />
+          <Route path={routePaths.storeSettingsIngredients} element={<SettingsIngredientsPage />} />
+          {/* 회원 설정 */}
+          <Route path={routePaths.settings} element={<SettingsPage />} />
+        </Route>
       </Route>
     </Routes>
   );

--- a/src/features/auth/components/RegisterForm.tsx
+++ b/src/features/auth/components/RegisterForm.tsx
@@ -13,6 +13,7 @@ import useAuthStore from '@/features/auth/store/authStore';
 import { Button } from '@/shadcn/ui/button';
 import { Input } from '@/shadcn/ui/input';
 import { Label } from '@/shadcn/ui/label';
+import { getApiErrorMessage } from '@/shared/utils/apiError';
 
 const schema = z.object({
   username: z
@@ -44,14 +45,7 @@ const RegisterForm = () => {
       setTokens(accessToken, refreshToken);
       navigate(routePaths.myStores, { replace: true });
     } catch (err: unknown) {
-      const status = (err as { response?: { status?: number } })?.response?.status;
-      if (status === 403) {
-        toast.error('초대 코드가 올바르지 않습니다.');
-      } else if (status === 409) {
-        toast.error('이미 사용 중인 아이디입니다.');
-      } else {
-        toast.error('회원가입에 실패했습니다. 잠시 후 다시 시도해 주세요.');
-      }
+      toast.error(getApiErrorMessage(err, '회원가입에 실패했습니다. 잠시 후 다시 시도해 주세요.'));
     }
   };
 

--- a/src/features/dashboard/components/OcrUploadCard.tsx
+++ b/src/features/dashboard/components/OcrUploadCard.tsx
@@ -37,9 +37,9 @@ const OcrUploadCard = () => {
           onClick={() => fileInputRef.current?.click()}
           onDrop={handleDrop}
           onDragOver={(e) => e.preventDefault()}
-          className="border-2 border-dashed rounded-xl flex flex-col items-center justify-center gap-3 py-5 bg-blue-50/10 cursor-pointer hover:bg-baro-blue/10 transition-colors group"
+          className="border-2 border-dashed rounded-xl flex flex-col items-center justify-center gap-3 py-5 bg-muted/20 cursor-pointer hover:bg-baro-blue/5 transition-colors group"
         >
-          <div className="w-8 h-8 rounded-full bg-blue-100 flex items-center justify-center group-hover:bg-blue-200 transition-colors">
+          <div className="w-8 h-8 rounded-full bg-baro-blue/15 flex items-center justify-center group-hover:bg-baro-blue/25 transition-colors">
             <Upload className="w-4 h-4 text-baro-blue" />
           </div>
           <div className="text-center">

--- a/src/features/initial-setup/components/MenuRegistrationModal.tsx
+++ b/src/features/initial-setup/components/MenuRegistrationModal.tsx
@@ -104,7 +104,7 @@ const MenuRegistrationModal = ({
 
   return (
     <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
-      <DialogContent showCloseButton={false}>
+      <DialogContent showCloseButton={false} className="max-h-[calc(100svh-4rem)] overflow-hidden">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <UtensilsCrossed className="size-4 text-muted-foreground" />
@@ -112,7 +112,7 @@ const MenuRegistrationModal = ({
           </DialogTitle>
         </DialogHeader>
 
-        <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-4 overflow-y-auto min-h-0">
           {/* 사진 업로드 */}
           <div className="space-y-1.5">
             <Label>메뉴 사진</Label>

--- a/src/features/initial-setup/components/steps/StepBasicInfo.tsx
+++ b/src/features/initial-setup/components/steps/StepBasicInfo.tsx
@@ -40,11 +40,11 @@ const StepBasicInfo = ({ data, userName, onChange, errors }: StepBasicInfoProps)
         </Label>
         <Input
           id="storeName"
-          placeholder="예: 바로 카페 홍대점"
+          placeholder="예: 바로 카페 강원대점"
           value={data.storeName}
           onChange={(e) => onChange({ ...data, storeName: e.target.value })}
           aria-invalid={!!errors.storeName}
-          className="h-10"
+          className="h-10 focus:bg-background"
         />
         {errors.storeName && <p className="text-xs text-destructive">{errors.storeName}</p>}
       </div>

--- a/src/features/initial-setup/components/steps/StepIngredientsAndRecipes.tsx
+++ b/src/features/initial-setup/components/steps/StepIngredientsAndRecipes.tsx
@@ -330,9 +330,9 @@ const StepIngredientsAndRecipes = ({
   };
 
   return (
-    <div className="flex flex-1 min-h-0 flex-col gap-4 md:flex-row">
+    <div className="flex flex-col gap-4 md:flex-1 md:min-h-0 md:flex-row">
       {/* ── 왼쪽 패널: 식자재 등록 ── */}
-      <div className="flex flex-1 min-h-0 flex-col overflow-hidden rounded-xl border">
+      <div className="flex flex-col overflow-hidden rounded-xl border md:flex-1 md:min-h-0">
         {/* 패널 헤더 */}
         <div className="shrink-0 border-b px-4 py-3">
           <h3 className="text-sm font-semibold">식자재 등록</h3>
@@ -395,9 +395,9 @@ const StepIngredientsAndRecipes = ({
         </div>
 
         {/* 식자재 태그 목록 — 스크롤 영역 */}
-        <div className="flex-1 min-h-0 overflow-y-auto p-3">
+        <div className="overflow-y-auto p-3 md:flex-1 md:min-h-0">
           {ingredients.length === 0 ? (
-            <div className="flex h-full items-center justify-center rounded-xl border-2 border-dashed border-gray-200 text-center">
+            <div className="flex min-h-25 items-center justify-center rounded-xl border-2 border-dashed border-gray-200 text-center md:h-full md:min-h-0">
               <p className="text-xs text-muted-foreground">
                 식자재를 입력하면 여기에 태그로 표시됩니다
               </p>
@@ -417,7 +417,7 @@ const StepIngredientsAndRecipes = ({
       </div>
 
       {/* ── 오른쪽 패널: 레시피 등록 ── */}
-      <div className="flex flex-1 min-h-0 flex-col overflow-hidden rounded-xl border">
+      <div className="flex flex-col overflow-hidden rounded-xl border md:flex-1 md:min-h-0">
         {/* 패널 헤더 */}
         <div className="shrink-0 border-b px-4 py-3">
           <h3 className="text-sm font-semibold">메뉴별 레시피</h3>
@@ -427,9 +427,9 @@ const StepIngredientsAndRecipes = ({
         </div>
 
         {/* 레시피 패널 목록 — 스크롤 영역 */}
-        <div className="flex-1 min-h-0 overflow-y-auto p-3">
+        <div className="overflow-y-auto p-3 md:flex-1 md:min-h-0">
           {menuItems.length === 0 ? (
-            <div className="flex h-full items-center justify-center rounded-xl border-2 border-dashed border-gray-200 text-center">
+            <div className="flex min-h-25 items-center justify-center rounded-xl border-2 border-dashed border-gray-200 text-center md:h-full md:min-h-0">
               <div>
                 <p className="text-sm text-muted-foreground">등록된 메뉴가 없습니다</p>
                 <p className="mt-0.5 text-xs text-muted-foreground">

--- a/src/features/initial-setup/components/steps/StepMenuRegistration.tsx
+++ b/src/features/initial-setup/components/steps/StepMenuRegistration.tsx
@@ -11,6 +11,7 @@ import MenuOcrReviewStep, {
 } from '@/features/store-settings/components/MenuOcrReviewStep';
 import MenuOcrUploadStep from '@/features/store-settings/components/MenuOcrUploadStep';
 import { Button } from '@/shadcn/ui/button';
+import { getApiErrorMessage } from '@/shared/utils/apiError';
 
 type OcrStep = 'upload' | 'analyzing' | 'review';
 
@@ -67,8 +68,8 @@ const StepMenuRegistration = ({ data, onChange }: StepMenuRegistrationProps) => 
         })),
       );
       setOcrStep('review');
-    } catch {
-      setOcrError('메뉴 인식에 실패했습니다. 다시 시도해주세요.');
+    } catch (err) {
+      setOcrError(getApiErrorMessage(err, '메뉴 인식에 실패했습니다. 다시 시도해 주세요.'));
       setOcrStep('upload');
     }
   };
@@ -95,13 +96,13 @@ const StepMenuRegistration = ({ data, onChange }: StepMenuRegistrationProps) => 
   /* OCR 플로우 활성 중 */
   if (ocrStep !== null) {
     return (
-      <div className="flex flex-1 min-h-0 flex-col overflow-hidden py-2">
+      <div className="flex flex-1 min-h-0 flex-col overflow-hidden">
         {ocrStep === 'upload' && (
           <>
             {ocrError && (
-              <p className="text-xs text-destructive bg-red-50 rounded-lg px-3 py-2 mb-4">
+              <div className="text-xs text-destructive bg-destructive/10 rounded-lg px-3 py-2 mb-3">
                 {ocrError}
-              </p>
+              </div>
             )}
             <MenuOcrUploadStep
               onFileSelect={handleOcrFileSelect}
@@ -140,9 +141,9 @@ const StepMenuRegistration = ({ data, onChange }: StepMenuRegistrationProps) => 
     <div className="flex flex-1 min-h-0 flex-col">
       {data.length === 0 ? (
         /* 빈 상태 — 방법 선택 */
-        <div className="flex flex-1 flex-col items-center justify-center gap-4 rounded-xl border-2 border-dashed border-gray-200 text-center">
-          <div className="flex size-12 items-center justify-center rounded-full bg-gray-100">
-            <Plus className="size-6 text-gray-400" />
+        <div className="flex flex-1 flex-col items-center justify-center gap-4 rounded-xl border-2 border-dashed border-border text-center">
+          <div className="flex size-12 items-center justify-center rounded-full bg-muted">
+            <Plus className="size-6 text-muted-foreground" />
           </div>
           <div>
             <p className="text-sm font-medium text-muted-foreground">등록된 메뉴가 없습니다</p>
@@ -182,7 +183,7 @@ const StepMenuRegistration = ({ data, onChange }: StepMenuRegistrationProps) => 
                   key={menu.id}
                   className="group overflow-hidden rounded-xl border bg-card transition-shadow hover:shadow-md"
                 >
-                  <div className="relative h-28 bg-gray-100 dark:bg-gray-800">
+                  <div className="relative h-28 bg-muted">
                     {menu.imageUrl ? (
                       <img
                         src={menu.imageUrl}
@@ -191,7 +192,7 @@ const StepMenuRegistration = ({ data, onChange }: StepMenuRegistrationProps) => 
                       />
                     ) : (
                       <div className="flex h-full items-center justify-center">
-                        <ImageOff className="size-8 text-gray-300" />
+                        <ImageOff className="size-8 text-muted-foreground/40" />
                       </div>
                     )}
 
@@ -206,14 +207,14 @@ const StepMenuRegistration = ({ data, onChange }: StepMenuRegistrationProps) => 
                       <button
                         type="button"
                         onClick={() => handleOpenEdit(menu)}
-                        className="flex size-6 items-center justify-center rounded-full bg-white/90 text-gray-600 shadow-sm transition-colors hover:text-baro-blue"
+                        className="flex size-6 items-center justify-center rounded-full bg-background/90 text-foreground/70 shadow-sm transition-colors hover:text-baro-blue"
                       >
                         <Pencil className="size-3" />
                       </button>
                       <button
                         type="button"
                         onClick={() => handleDelete(menu.id)}
-                        className="flex size-6 items-center justify-center rounded-full bg-white/90 text-gray-600 shadow-sm transition-colors hover:text-red-500"
+                        className="flex size-6 items-center justify-center rounded-full bg-background/90 text-foreground/70 shadow-sm transition-colors hover:text-baro-red"
                       >
                         <Trash2 className="size-3" />
                       </button>

--- a/src/features/ocr-inbound/components/OcrUploadStep.tsx
+++ b/src/features/ocr-inbound/components/OcrUploadStep.tsx
@@ -85,7 +85,7 @@ const OcrUploadStep = ({ onFileSelect }: OcrUploadStepProps) => {
             onDrop={handleDrop}
             onDragOver={(e) => e.preventDefault()}
             onClick={() => fileInputRef.current?.click()}
-            className="flex-1 border-2 border-dashed border-border hover:border-baro-blue/50 rounded-xl bg-muted/20 hover:bg-blue-50/30 transition-all cursor-pointer flex flex-col items-center justify-center gap-3 py-10 md:flex-none md:py-14"
+            className="flex-1 border-2 border-dashed border-border hover:border-baro-blue/50 rounded-xl bg-muted/20 hover:bg-baro-blue/5 transition-all cursor-pointer flex flex-col items-center justify-center gap-3 py-10 md:flex-none md:py-14"
           >
             <div className="w-12 h-12 rounded-2xl bg-muted flex items-center justify-center">
               <FileImage className="w-6 h-6 text-muted-foreground" />

--- a/src/features/store-registration/components/InviteCodeModal.tsx
+++ b/src/features/store-registration/components/InviteCodeModal.tsx
@@ -19,16 +19,12 @@ import {
 } from '@/shadcn/ui/dialog';
 import { Input } from '@/shadcn/ui/input';
 import { Label } from '@/shadcn/ui/label';
+import { getApiErrorMessage } from '@/shared/utils/apiError';
 
 interface InviteCodeModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
-
-const ERROR_MESSAGES: Record<string, string> = {
-  INVALID_INVITE_CODE: '유효하지 않은 초대코드입니다. 다시 확인해 주세요.',
-  ALREADY_MEMBER: '이미 참여한 가게입니다.',
-};
 
 const InviteCodeModal = ({ open, onOpenChange }: InviteCodeModalProps) => {
   const navigate = useNavigate();
@@ -49,11 +45,9 @@ const InviteCodeModal = ({ open, onOpenChange }: InviteCodeModalProps) => {
         navigate(routePaths.storeHome, { replace: true });
       },
       onError: (err: unknown) => {
-        const code = (err as { response?: { data?: { error?: { code?: string } } } })?.response
-          ?.data?.error?.code;
-        const message =
-          (code && ERROR_MESSAGES[code]) ?? '가게 참여에 실패했습니다. 잠시 후 다시 시도해 주세요.';
-        toast.error(message);
+        toast.error(
+          getApiErrorMessage(err, '가게 참여에 실패했습니다. 잠시 후 다시 시도해 주세요.'),
+        );
       },
     });
   };

--- a/src/features/store-registration/components/MyStoresList.tsx
+++ b/src/features/store-registration/components/MyStoresList.tsx
@@ -1,7 +1,8 @@
-import { useRef, useState } from 'react';
+import { useRef, useState, useEffect } from 'react';
 
 import {
   Check,
+  ChevronDown,
   ChevronRight,
   Globe,
   Info,
@@ -77,8 +78,20 @@ function getInitials(name?: string | null) {
   return name?.trim().slice(0, 2) ?? '?';
 }
 
+const useIsMobile = () => {
+  const [isMobile, setIsMobile] = useState(() => window.innerWidth < 768);
+  useEffect(() => {
+    const mq = window.matchMedia('(max-width: 767px)');
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+  return isMobile;
+};
+
 const MyStoresList = () => {
   const navigate = useNavigate();
+  const isMobile = useIsMobile();
   const { data: userInfo, isLoading: isUserLoading } = useUserInfo();
   const { data: stores, isLoading: isStoresLoading } = useMyStores();
   const { mutate: updateName, isPending: isUpdatingName } = useUpdateUserName();
@@ -307,10 +320,18 @@ const MyStoresList = () => {
                     <Info className="h-4 w-4 text-muted-foreground" />
                     <span>서비스 정보</span>
                   </div>
-                  <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                  {isMobile ? (
+                    <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                  ) : (
+                    <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                  )}
                 </button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent side="right" align="start" className="w-48">
+              <DropdownMenuContent
+                side={isMobile ? 'bottom' : 'right'}
+                align="start"
+                className="w-48"
+              >
                 <DropdownMenuItem disabled className="text-xs text-muted-foreground">
                   버전 {APP_VERSION}
                 </DropdownMenuItem>
@@ -373,7 +394,7 @@ const MyStoresList = () => {
           </div>
 
           {/* Stores grid — scrolls internally */}
-          <div className="flex-1 overflow-y-auto p-1 pt-3 md:overflow-y-auto">
+          <div className="flex-1 overflow-y-auto px-2 pt-3 pb-2 md:overflow-y-auto">
             {isStoresLoading ? (
               <div className="grid grid-cols-2 gap-3 md:grid-cols-2 md:gap-4 lg:grid-cols-3">
                 {Array.from({ length: 3 }).map((_, i) => (

--- a/src/features/store-registration/components/StoreSelectionCards.tsx
+++ b/src/features/store-registration/components/StoreSelectionCards.tsx
@@ -66,7 +66,7 @@ const StoreSelectionCards = () => {
             {/* Text */}
             <div className="flex-1 space-y-2">
               <p className="text-xs font-bold uppercase tracking-widest text-baro-blue">사장님</p>
-              <h2 className="text-xl font-black text-baro-black">새 가게 등록하기</h2>
+              <h2 className="text-xl">새 가게 등록하기</h2>
               <p className="text-sm leading-relaxed text-muted-foreground">
                 직접 가게를 개설하고 재고를 관리하세요.
                 <br />
@@ -136,7 +136,7 @@ const StoreSelectionCards = () => {
             {/* Text */}
             <div className="flex-1 space-y-2">
               <p className="text-xs font-bold uppercase tracking-widest text-baro-green">직원</p>
-              <h2 className="text-xl font-black text-baro-black">초대코드로 합류하기</h2>
+              <h2 className="text-xl">초대코드로 합류하기</h2>
               <p className="text-sm leading-relaxed text-muted-foreground">
                 사장님께 받은 초대코드를 입력하면
                 <br />

--- a/src/features/store-settings/api/storeSettings.api.ts
+++ b/src/features/store-settings/api/storeSettings.api.ts
@@ -29,7 +29,7 @@ export async function fetchStoreSettings(storeId: string): Promise<StoreSettings
 
 export async function updateStoreSettings(
   storeId: string,
-  data: Partial<Omit<StoreSettings, 'operatingHours'>>,
+  data: Partial<Omit<StoreSettings, 'operatingHours'>> & { ownerId?: string },
 ): Promise<void> {
   await axiosInstance.patch(`/stores/${storeId}`, data);
 }

--- a/src/features/store-settings/components/MenuOcrModal.tsx
+++ b/src/features/store-settings/components/MenuOcrModal.tsx
@@ -97,7 +97,7 @@ const MenuOcrModal = ({
 
   return (
     <Dialog open={open} onOpenChange={(v) => !v && handleClose()}>
-      <DialogContent className="sm:max-w-3xl max-h-[90vh] flex flex-col">
+      <DialogContent className="sm:max-w-3xl max-h-[90svh] flex flex-col overflow-hidden">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <ScanLine className="size-4 text-muted-foreground" />
@@ -117,7 +117,7 @@ const MenuOcrModal = ({
         )}
 
         {step === 'analyzing' && (
-          <div className="flex flex-col items-center justify-center gap-4 py-16">
+          <div className="flex flex-col items-center justify-center gap-4 py-16 min-h-80">
             <Loader2 className="w-10 h-10 animate-spin text-baro-blue" />
             <div className="text-center">
               <p className="text-sm font-semibold">메뉴를 인식하는 중입니다</p>
@@ -127,7 +127,7 @@ const MenuOcrModal = ({
         )}
 
         {step === 'review' && (
-          <div className="flex-1 min-h-0">
+          <div className="flex-1 min-h-0 flex flex-col">
             <MenuOcrReviewStep
               items={reviewItems}
               existingNames={existingNames}

--- a/src/features/store-settings/components/MenuOcrModal.tsx
+++ b/src/features/store-settings/components/MenuOcrModal.tsx
@@ -9,6 +9,7 @@ import MenuOcrReviewStep, {
 } from '@/features/store-settings/components/MenuOcrReviewStep';
 import MenuOcrUploadStep from '@/features/store-settings/components/MenuOcrUploadStep';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/shadcn/ui/dialog';
+import { getApiErrorMessage } from '@/shared/utils/apiError';
 
 type OcrStep = 'upload' | 'analyzing' | 'review';
 
@@ -65,8 +66,8 @@ const MenuOcrModal = ({
         })),
       );
       setStep('review');
-    } catch {
-      setErrorMsg('메뉴 인식에 실패했습니다. 다시 시도해주세요.');
+    } catch (err) {
+      setErrorMsg(getApiErrorMessage(err, '메뉴 인식에 실패했습니다. 다시 시도해 주세요.'));
       setStep('upload');
     }
   };
@@ -108,7 +109,7 @@ const MenuOcrModal = ({
         {step === 'upload' && (
           <>
             {errorMsg && (
-              <div className="text-xs text-destructive bg-red-50 rounded-md px-3 py-2">
+              <div className="text-xs text-destructive bg-destructive/10 rounded-md px-3 py-2">
                 {errorMsg}
               </div>
             )}

--- a/src/features/store-settings/components/MenuOcrReviewStep.tsx
+++ b/src/features/store-settings/components/MenuOcrReviewStep.tsx
@@ -83,7 +83,7 @@ const MenuOcrReviewStep = ({
   const duplicateCount = items.filter((item) => item.name.trim() && isDuplicate(item.name)).length;
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col flex-1 min-h-0">
       {/* 스크롤 영역: 헤더 + 항목 목록 + 추가 버튼 */}
       <div className="flex-1 min-h-0 overflow-y-auto flex flex-col gap-4 pb-2 pr-1">
         <div className="flex items-center justify-between">

--- a/src/features/store-settings/components/MenuOcrReviewStep.tsx
+++ b/src/features/store-settings/components/MenuOcrReviewStep.tsx
@@ -99,7 +99,7 @@ const MenuOcrReviewStep = ({
 
         {/* 중복 안내 */}
         {duplicateCount > 0 && (
-          <p className="text-xs text-orange-600 bg-orange-50 border border-orange-200 rounded-lg px-3 py-2">
+          <p className="text-xs text-baro-yellow-text bg-baro-yellow/10 border border-baro-yellow/40 rounded-lg px-3 py-2">
             이미 등록된 메뉴 <strong>{duplicateCount}개</strong>는 등록하지 않습니다. 이름을
             수정하거나 해당 항목을 삭제해주세요.
           </p>
@@ -123,13 +123,13 @@ const MenuOcrReviewStep = ({
               <button
                 type="button"
                 onClick={() => handleImageClick(item.id)}
-                className="w-9 h-9 rounded-lg border overflow-hidden flex items-center justify-center bg-gray-50 hover:bg-gray-100 transition-colors shrink-0"
+                className="w-9 h-9 rounded-lg border overflow-hidden flex items-center justify-center bg-muted hover:bg-muted/60 transition-colors shrink-0"
                 title="사진 추가"
               >
                 {item.imageUrl ? (
                   <img src={item.imageUrl} alt="" className="w-full h-full object-cover" />
                 ) : (
-                  <ImagePlus className="w-3.5 h-3.5 text-gray-300" />
+                  <ImagePlus className="w-3.5 h-3.5 text-muted-foreground/40" />
                 )}
               </button>
             );
@@ -142,11 +142,12 @@ const MenuOcrReviewStep = ({
                   placeholder="메뉴명"
                   className={cn(
                     'h-8 text-sm',
-                    dup && 'border-orange-400 bg-orange-50 focus-visible:ring-orange-300 pr-14',
+                    dup &&
+                      'border-baro-yellow bg-baro-yellow/10 focus-visible:ring-baro-yellow/50 pr-14',
                   )}
                 />
                 {dup && (
-                  <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[10px] font-semibold text-orange-600 bg-orange-100 border border-orange-300 px-1.5 py-0.5 rounded-full whitespace-nowrap">
+                  <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[10px] font-semibold text-baro-yellow-text bg-baro-yellow/25 border border-baro-yellow/60 px-1.5 py-0.5 rounded-full whitespace-nowrap">
                     이미 등록됨
                   </span>
                 )}
@@ -190,7 +191,7 @@ const MenuOcrReviewStep = ({
                     'w-4 h-4',
                     item.isFeatured
                       ? 'fill-baro-yellow text-baro-yellow'
-                      : 'text-gray-300 hover:text-baro-yellow/50',
+                      : 'text-muted-foreground/40 hover:text-baro-yellow/50',
                   )}
                 />
               </button>
@@ -200,7 +201,7 @@ const MenuOcrReviewStep = ({
               <button
                 type="button"
                 onClick={() => handleDelete(item.id)}
-                className="flex items-center justify-center w-8 h-8 rounded-md text-muted-foreground hover:text-baro-red hover:bg-red-50 transition-colors"
+                className="flex items-center justify-center w-8 h-8 rounded-md text-muted-foreground hover:text-baro-red hover:bg-red-500/10 transition-colors"
                 aria-label="항목 삭제"
               >
                 <Trash2 className="w-3.5 h-3.5" />
@@ -210,7 +211,7 @@ const MenuOcrReviewStep = ({
             return (
               <div
                 key={item.id}
-                className={cn('rounded-lg transition-colors', dup && 'bg-orange-50/60')}
+                className={cn('rounded-lg transition-colors', dup && 'bg-baro-yellow/5')}
               >
                 {/* 데스크탑 행 */}
                 <div className="hidden md:grid grid-cols-[36px_2fr_100px_2fr_36px_36px] gap-2 items-center px-1 py-0.5">

--- a/src/features/store-settings/components/MenuOcrUploadStep.tsx
+++ b/src/features/store-settings/components/MenuOcrUploadStep.tsx
@@ -65,7 +65,7 @@ const MenuOcrUploadStep = ({ onFileSelect, onBack }: MenuOcrUploadStepProps) => 
           onDrop={handleDrop}
           onDragOver={(e) => e.preventDefault()}
           onClick={() => fileInputRef.current?.click()}
-          className="border-2 border-dashed border-border hover:border-baro-blue/50 rounded-xl bg-muted/20 hover:bg-blue-50/30 transition-all cursor-pointer flex flex-col items-center justify-center gap-3 py-12"
+          className="border-2 border-dashed border-border hover:border-baro-blue/50 rounded-xl bg-muted/20 hover:bg-baro-blue/5 transition-all cursor-pointer flex flex-col items-center justify-center gap-3 py-12"
         >
           <div className="w-12 h-12 rounded-2xl bg-muted flex items-center justify-center">
             <FileImage className="w-6 h-6 text-muted-foreground" />

--- a/src/features/store-settings/components/MenuOcrUploadStep.tsx
+++ b/src/features/store-settings/components/MenuOcrUploadStep.tsx
@@ -32,7 +32,7 @@ const MenuOcrUploadStep = ({ onFileSelect, onBack }: MenuOcrUploadStepProps) => 
   };
 
   return (
-    <div className="flex flex-col gap-6 pr-2">
+    <div className="flex flex-col gap-6 flex-1 min-h-0 overflow-y-auto">
       <div className="flex flex-col gap-4">
         <div className="text-center">
           <p className="text-sm font-semibold">메뉴판을 등록해주세요</p>
@@ -88,7 +88,7 @@ const MenuOcrUploadStep = ({ onFileSelect, onBack }: MenuOcrUploadStepProps) => 
         <div className="flex flex-col gap-3 md:flex-row">
           <Button
             variant="outline"
-            className="w-full"
+            className="w-full md:flex-1"
             onClick={() => fileInputRef.current?.click()}
           >
             <FileImage className="w-4 h-4" />
@@ -96,7 +96,7 @@ const MenuOcrUploadStep = ({ onFileSelect, onBack }: MenuOcrUploadStepProps) => 
           </Button>
           <Button
             variant="outline"
-            className="w-full"
+            className="w-full md:flex-1"
             onClick={() => cameraInputRef.current?.click()}
           >
             <Camera className="w-4 h-4" />

--- a/src/features/store-settings/components/sections/StoreInfoSection.tsx
+++ b/src/features/store-settings/components/sections/StoreInfoSection.tsx
@@ -5,6 +5,7 @@ import { Store } from 'lucide-react';
 import {
   useStoreSettings,
   useUpdateStoreSettings,
+  useStoreMembers,
 } from '@/features/store-settings/hooks/useStoreSettings';
 import type { StoreSettings } from '@/features/store-settings/types/store-settings.types';
 import { Button } from '@/shadcn/ui/button';
@@ -44,21 +45,31 @@ const labelOf = (options: { value: string; label: string }[], val: string) =>
 const StoreInfoSection = () => {
   const { data, isLoading } = useStoreSettings();
   const { mutate: updateStore, isPending } = useUpdateStoreSettings();
+  const { data: members = [] } = useStoreMembers();
   const [isEditing, setIsEditing] = useState(false);
   const [form, setForm] = useState<StoreSettings | null>(null);
+  const [pendingOwnerId, setPendingOwnerId] = useState<string | null>(null);
 
   const handleEdit = () => {
     if (data) setForm(data);
+    setPendingOwnerId(null);
     setIsEditing(true);
   };
 
   const handleSave = () => {
     if (!form) return;
-    updateStore(form, { onSuccess: () => setIsEditing(false) });
+    const updateData = pendingOwnerId ? { ...form, ownerId: pendingOwnerId } : form;
+    updateStore(updateData, {
+      onSuccess: () => {
+        setPendingOwnerId(null);
+        setIsEditing(false);
+      },
+    });
   };
 
   const handleCancel = () => {
     if (data) setForm(data);
+    setPendingOwnerId(null);
     setIsEditing(false);
   };
 
@@ -106,10 +117,44 @@ const StoreInfoSection = () => {
           </div>
           <div className="space-y-1.5">
             <Label className="text-xs text-muted-foreground">대표자명</Label>
-            <Input value={form.owner.name} disabled />
-            <p className="text-[11px] text-muted-foreground">
-              직원 추가 기능 오픈 후 변경 가능합니다.
-            </p>
+            {members.length <= 1 ? (
+              <>
+                <Input value={form.owner.name} disabled />
+                <p className="text-[11px] text-muted-foreground">
+                  팀 멤버가 없어 대표자를 변경할 수 없습니다.
+                </p>
+              </>
+            ) : (
+              <>
+                <Select
+                  value={pendingOwnerId ?? data?.owner.id ?? ''}
+                  onValueChange={(val) => setPendingOwnerId(val === data?.owner.id ? null : val)}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue>
+                      {pendingOwnerId
+                        ? members.find((m) => m.userId === pendingOwnerId)?.name
+                        : data?.owner.name}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    {members.map((member) => (
+                      <SelectItem key={member.userId} value={member.userId}>
+                        {member.name}
+                        {member.role === 'owner' && (
+                          <span className="ml-1.5 text-xs text-muted-foreground">(현재 대표)</span>
+                        )}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {pendingOwnerId && (
+                  <p className="text-[11px] text-amber-600">
+                    저장 시 해당 멤버에게 대표자 권한이 이전됩니다.
+                  </p>
+                )}
+              </>
+            )}
           </div>
           <div className="space-y-1.5">
             <Label className="text-xs text-muted-foreground">사업 유형</Label>

--- a/src/features/store-settings/hooks/useStoreSettings.ts
+++ b/src/features/store-settings/hooks/useStoreSettings.ts
@@ -27,7 +27,7 @@ export function useUpdateStoreSettings() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (data: Partial<Omit<StoreSettings, 'operatingHours'>>) =>
+    mutationFn: (data: Partial<Omit<StoreSettings, 'operatingHours'>> & { ownerId?: string }) =>
       updateStoreSettings(storeId!, data),
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: ['storeSettings', storeId] });

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -1,7 +1,26 @@
+import { useNavigate } from 'react-router-dom';
+
+import { routePaths } from '@/app/routes/routePaths';
+import { Button } from '@/shadcn/ui/button';
+
 const NotFoundPage = () => {
+  const navigate = useNavigate();
+
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen">
-      <h1 className="text-4xl font-bold">404 - 페이지를 찾을 수 없습니다</h1>
+    <div className="flex min-h-screen flex-col items-center justify-center gap-6 bg-background px-6">
+      <div className="text-center">
+        <p className="select-none text-8xl font-black text-baro-blue/20">404</p>
+        <h1 className="mt-2 text-xl font-bold text-foreground">페이지를 찾을 수 없어요</h1>
+        <p className="pt-2 text-sm text-muted-foreground">
+          요청하신 페이지가 존재하지 않거나 이동되었어요.
+        </p>
+      </div>
+      <Button
+        onClick={() => navigate(routePaths.storeHome)}
+        className="rounded-full bg-baro-blue px-6 py-5 text-white hover:bg-baro-blue/80"
+      >
+        홈으로 돌아가기
+      </Button>
     </div>
   );
 };

--- a/src/pages/OcrInboundPage.tsx
+++ b/src/pages/OcrInboundPage.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useQueryClient } from '@tanstack/react-query';
-import axios from 'axios';
 import { ArrowLeft, ScanLine } from 'lucide-react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
@@ -25,6 +24,7 @@ import type { OcrInboundItem } from '@/features/ocr-inbound/types/ocrInbound.typ
 import { confirmInbound } from '@/features/store-settings/api/ingredients.api';
 import { updateStoreSettings } from '@/features/store-settings/api/storeSettings.api';
 import { useStoreSettings } from '@/features/store-settings/hooks/useStoreSettings';
+import { getApiErrorMessage } from '@/shared/utils/apiError';
 
 type Step = 'upload' | 'analyzing' | 'review';
 
@@ -176,11 +176,9 @@ const OcrInboundPage = () => {
         setStep('review');
         saveDraft({ imageBase64: base64, metadata: result.metadata, items: processedItems });
       } catch (err) {
-        const message =
-          axios.isAxiosError(err) && err.response?.data?.error?.message
-            ? err.response.data.error.message
-            : 'OCR 처리에 실패했습니다. 잠시 후 다시 시도해주세요.';
-        toast.error(message);
+        toast.error(
+          getApiErrorMessage(err, 'OCR 처리에 실패했습니다. 잠시 후 다시 시도해 주세요.'),
+        );
         URL.revokeObjectURL(blobUrl);
         setStep('upload');
         setImageUrl(null);

--- a/src/pages/SettingsMenuBoardPage.tsx
+++ b/src/pages/SettingsMenuBoardPage.tsx
@@ -192,7 +192,7 @@ const SettingsMenuBoardPage = () => {
               {/* 레이아웃 */}
               <div className="px-4 py-3">
                 <p className="mb-3 text-xs font-medium text-muted-foreground">레이아웃</p>
-                <div className="inline-flex gap-0.5 rounded-lg bg-gray-100 p-1">
+                <div className="inline-flex gap-0.5 rounded-lg bg-muted p-1">
                   {(
                     [
                       { key: 'list', label: '리스트', icon: AlignJustify },
@@ -206,8 +206,8 @@ const SettingsMenuBoardPage = () => {
                       className={cn(
                         'flex items-center gap-2 rounded-md px-5 py-2 text-sm transition-all',
                         form.layout === key
-                          ? 'bg-white font-medium text-gray-900 shadow-sm'
-                          : 'text-gray-400 hover:text-gray-600',
+                          ? 'bg-background font-medium text-foreground shadow-sm'
+                          : 'text-muted-foreground hover:text-foreground',
                       )}
                     >
                       <Icon className="size-4" />
@@ -295,9 +295,9 @@ const SettingsMenuBoardPage = () => {
                   <button
                     type="button"
                     onClick={() => bannerInputRef.current?.click()}
-                    className="flex h-20 w-full flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-200 bg-gray-50/60 transition-colors hover:border-baro-blue/40 hover:bg-baro-blue/5"
+                    className="flex h-20 w-full flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed border-border bg-muted/40 transition-colors hover:border-baro-blue/40 hover:bg-baro-blue/5 dark:bg-transparent"
                   >
-                    <ImagePlus className="size-5 text-gray-300" />
+                    <ImagePlus className="size-5 text-muted-foreground/40" />
                     <span className="text-xs text-muted-foreground">배너 이미지 추가</span>
                   </button>
                 )}

--- a/src/pages/SettingsMenusPage.tsx
+++ b/src/pages/SettingsMenusPage.tsx
@@ -140,15 +140,15 @@ const MenuModal = ({
 
   return (
     <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
-      <DialogContent showCloseButton={false} className="max-h-[calc(100svh-4rem)] overflow-hidden">
-        <DialogHeader>
+      <DialogContent showCloseButton={false} className="max-h-[calc(100svh-4rem)] flex flex-col">
+        <DialogHeader className="shrink-0">
           <DialogTitle className="flex items-center gap-2">
             <UtensilsCrossed className="size-4 text-muted-foreground" />
             {editing ? '메뉴 수정' : '메뉴 등록'}
           </DialogTitle>
         </DialogHeader>
 
-        <div className="flex flex-col gap-4 overflow-y-auto min-h-0">
+        <div className="flex flex-1 flex-col gap-4 overflow-y-auto min-h-0">
           {/* 사진 업로드 */}
           <div className="space-y-1.5">
             <Label>메뉴 사진</Label>
@@ -268,15 +268,15 @@ const MenuModal = ({
           </div>
         </div>
 
-        <DialogFooter>
-          <Button type="button" variant="outline" onClick={onClose}>
+        <DialogFooter className="shrink-0">
+          <Button type="button" variant="outline" onClick={onClose} className="shrink-0">
             취소
           </Button>
           <Button
             type="button"
             onClick={handleSave}
             disabled={isSaving || isUploading}
-            className="bg-baro-blue hover:bg-baro-blue/80"
+            className="shrink-0 bg-baro-blue hover:bg-baro-blue/80"
           >
             {editing ? '수정 완료' : '등록하기'}
           </Button>

--- a/src/pages/SettingsMenusPage.tsx
+++ b/src/pages/SettingsMenusPage.tsx
@@ -140,7 +140,7 @@ const MenuModal = ({
 
   return (
     <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
-      <DialogContent showCloseButton={false}>
+      <DialogContent showCloseButton={false} className="max-h-[calc(100svh-4rem)] overflow-hidden">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <UtensilsCrossed className="size-4 text-muted-foreground" />
@@ -148,7 +148,7 @@ const MenuModal = ({
           </DialogTitle>
         </DialogHeader>
 
-        <div className="flex gap-4 flex-col">
+        <div className="flex flex-col gap-4 overflow-y-auto min-h-0">
           {/* 사진 업로드 */}
           <div className="space-y-1.5">
             <Label>메뉴 사진</Label>

--- a/src/shadcn/ui/input.tsx
+++ b/src/shadcn/ui/input.tsx
@@ -10,7 +10,7 @@ function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
       type={type}
       data-slot="input"
       className={cn(
-        'h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40',
+        'h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40',
         className,
       )}
       {...props}

--- a/src/shared/components/ErrorBoundary.tsx
+++ b/src/shared/components/ErrorBoundary.tsx
@@ -1,0 +1,71 @@
+import { Component } from 'react';
+
+import { AlertTriangle } from 'lucide-react';
+
+import { Button } from '@/shadcn/ui/button';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  errorMessage: string | null;
+}
+
+class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, errorMessage: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, errorMessage: error.message || null };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex min-h-screen flex-col items-center justify-center gap-8 bg-background px-6">
+          <div className="relative flex items-center justify-center">
+            <div className="absolute size-28 rounded-full bg-baro-red/8 blur-2xl" />
+            <AlertTriangle className="relative size-16 text-baro-red" strokeWidth={1.5} />
+          </div>
+          <div className="text-center">
+            <h1 className="text-2xl font-bold text-foreground">오류가 발생했습니다</h1>
+            <p className="pt-3 text-sm leading-relaxed text-muted-foreground">
+              서비스를 이용하는 중 문제가 발생했어요.
+              <br />
+              잠시 후 다시 시도해 주세요.
+            </p>
+          </div>
+          {this.state.errorMessage && (
+            <p className="w-auto rounded-lg bg-muted px-4 py-3 font-mono text-xs leading-relaxed text-muted-foreground">
+              {this.state.errorMessage}
+            </p>
+          )}
+          <div className="mt-2 flex flex-col items-center gap-3">
+            <Button
+              size="lg"
+              onClick={() => window.location.reload()}
+              className="bg-baro-red px-8 text-white hover:bg-baro-red/80 rounded-full"
+            >
+              새로고침
+            </Button>
+            <button
+              type="button"
+              onClick={() => (window.location.href = '/')}
+              className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
+            >
+              홈으로 돌아가기
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/shared/constants/errorMessages.ts
+++ b/src/shared/constants/errorMessages.ts
@@ -1,0 +1,33 @@
+export const API_ERROR_MESSAGES: Record<string, string> = {
+  // 외부 서비스 장애 — AI / OCR
+  AI_UNAVAILABLE:
+    'AI 서비스(Gemini)에 일시적인 장애가 발생했습니다. 서비스 문제가 아닌 외부 AI 서비스 문제이므로, 잠시 후 다시 시도해 주세요.',
+  OCR_FAILED:
+    '이미지 인식 서비스(CLOVA OCR)에 일시적인 장애가 발생했습니다. 외부 서비스 상태로 인한 오류이므로, 잠시 후 다시 시도해 주세요.',
+  OCR_EMPTY:
+    '이미지에서 텍스트를 인식하지 못했습니다. 사진이 흐리거나 글씨가 작을 경우 더 선명한 사진으로 다시 시도해 주세요.',
+  PARSE_FAILED: 'AI 분석 결과 파싱 중 외부 서비스 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.',
+
+  // 파일 / 업로드
+  UPLOAD_FAILED: '이미지 업로드에 실패했습니다. 네트워크 상태를 확인 후 다시 시도해 주세요.',
+
+  // 인증
+  UNAUTHORIZED: '인증이 만료되었습니다. 다시 로그인해 주세요.',
+  FORBIDDEN: '접근 권한이 없습니다.',
+
+  // 리소스
+  NOT_FOUND: '요청한 정보를 찾을 수 없습니다.',
+  CONFLICT: '이미 존재하는 데이터입니다.',
+
+  // 가게
+  INVALID_INVITE_CODE: '유효하지 않은 초대 코드입니다.',
+  ALREADY_MEMBER: '이미 참여 중인 가게입니다.',
+  INVALID_OWNER: '가게 멤버가 아닙니다.',
+  OWNER_CANNOT_LEAVE: '가게 대표자는 가게를 나갈 수 없습니다.',
+  CANNOT_REMOVE_SELF: '자기 자신을 내보낼 수 없습니다.',
+
+  // 마감
+  KAKAO_AUTH_FAILED: '카카오 로그인에 실패했습니다. 다시 시도해 주세요.',
+};
+
+export const DEFAULT_ERROR_MESSAGE = '오류가 발생했습니다. 잠시 후 다시 시도해 주세요.';

--- a/src/shared/utils/apiError.ts
+++ b/src/shared/utils/apiError.ts
@@ -1,0 +1,13 @@
+import axios from 'axios';
+
+import { API_ERROR_MESSAGES, DEFAULT_ERROR_MESSAGE } from '@/shared/constants/errorMessages';
+
+export const getApiErrorCode = (err: unknown): string | undefined => {
+  if (!axios.isAxiosError(err)) return undefined;
+  return (err.response?.data as { error?: { code?: string } } | undefined)?.error?.code;
+};
+
+export const getApiErrorMessage = (err: unknown, fallback = DEFAULT_ERROR_MESSAGE): string => {
+  const code = getApiErrorCode(err);
+  return code ? (API_ERROR_MESSAGES[code] ?? fallback) : fallback;
+};


### PR DESCRIPTION
## 📌 요약

- v1.1.0 이후 버그 수정, UI 개선, 에러 처리 강화를 통합한 v1.1.1 패치 배포
- 에러 페이지 및 보호 라우트 도입, 서버 에러 코드 기반 사용자 안내 메시지 시스템 구축
- OCR·메뉴·초기 세팅 전반의 모달 안정화 및 다크모드 개선

<br/>

## 🏷️ 관련 이슈

- Closes #186
- Related to #173, #174, #177, #178, #180, #181, #182, #184

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- **에러 페이지 강화**: ErrorBoundary, ProtectedRoute 도입 및 404 페이지 리디자인 (#173, PR #176)
- **가게 설정 대표자 변경**: 대표자 변경 기능 신규 구현 (#180, PR #183)
- **에러 메시지 고도화**: 서버 에러 코드 기반 사용자 안내 메시지 시스템 — AI/OCR 외부 서비스 장애 시 명확한 안내 제공 (#184, PR #185)
- **다크모드 전반 개선**: OCR 드롭존, 메뉴 OCR 검수, 대시보드 카드, 초기 세팅 등 미적용 영역 수정 (#182, #184, PR #183, #185)

<br/>

### 📂 세부 변경사항

#### ✨ 에러 페이지 (#173, PR #176)
- ErrorBoundary 전역 적용
- ProtectedRoute 도입 (미인증 접근 차단)
- 404 Not Found 페이지 리디자인

#### 🐛 모달 UI 안정화 (#174, #177, PR #175, #183)
- 메뉴·OCR 모달 콘텐츠 오버플로우 및 스크롤 버그 수정
- 메뉴 등록/수정 모달 내부 스크롤 및 하단 버튼 고정

#### 🐛 모바일 레이아웃 (#178, PR #183)
- 초기 세팅 식자재·레시피 단계 모바일 콘텐츠 잘림 수정

#### ✨ 가게 설정 (#180, PR #183)
- 가게 대표자 변경 기능 구현

#### 🐛 버그 수정 (#181, #182, PR #183)
- 계정 홈 서비스 정보 드롭다운 방향 및 가게 편집 버튼 오버플로우 수정
- 메뉴판 설정 레이아웃·배너 버튼 다크모드 미적용 수정

#### ♻️ 에러 메시지 시스템 (#184, PR #185)
- `src/shared/constants/errorMessages.ts` 신규: 에러 코드 → 메시지 매핑 테이블
- `src/shared/utils/apiError.ts` 신규: `getApiErrorMessage` 유틸 함수
- `AI_UNAVAILABLE`: "AI 서비스(Gemini)에 일시적인 장애 — 외부 서비스 문제" 명시
- `OCR_FAILED`, `OCR_EMPTY`, `PARSE_FAILED` 등 외부 서비스 장애 코드 대응
- OCR 입고, 메뉴 OCR, 초기 세팅, InviteCodeModal, RegisterForm 일괄 적용

#### 💄 다크모드 개선 (#184, PR #185)
- OcrUploadCard, OcrUploadStep, MenuOcrUploadStep: 드롭존 hover `bg-blue-50/30` → `bg-baro-blue/5`
- MenuOcrReviewStep: 중복 메뉴 표시 `orange-*` → `baro-yellow` 계열
- StepMenuRegistration: 빈 상태·카드 오버레이 버튼 시맨틱 토큰 교체
- StoreSelectionCards: `text-baro-black` 제거

<br/>

## 📸 Screenshots

| Before | After |
| ------ | ----- |
| AI 장애 시 "OCR 처리에 실패했습니다." 만 표시 | "AI 서비스(Gemini)에 일시적 장애 — 외부 서비스 문제" 명시 |
| OCR 드롭존 hover 라이트 고정 배경 | 다크모드에서 자연스러운 `baro-blue/5` 틴트 |

<br/>

## 🧪 테스트 방법

1. `pnpm dev` 로컬 서버 실행
2. 없는 경로 접근 → 404 에러 페이지 확인
3. 미인증 상태로 보호 라우트 접근 → 로그인 페이지 리다이렉트 확인
4. 다크모드에서 OCR 입고 처리 드롭존 hover 확인
5. 다크모드에서 가게 설정 → 메뉴판으로 등록 → 검수 화면 확인
6. OCR/AI 실패 에러 발생 시 외부 서비스 장애임을 안내하는 구체적 메시지 확인
7. 가게 설정 → 대표자 변경 기능 동작 확인
8. 초기 세팅 3단계(식자재·레시피) 모바일 화면 잘림 없음 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [ ] API
- [ ] Database
- [x] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- 이전 버전: v1.1.0 (롤백 시 해당 태그로 revert)
- 심사 기간 중 AI/OCR 외부 서비스 장애 시 감점 방지를 위한 에러 메시지 명확화 포함
- 보안 취약점 알림(Dependabot) 확인 필요 (4 high, 16 moderate, 1 low)