### PR TITLE
🐛 (#191) fix: OCR 입고 확정 시 변환 계수 문자열 전송 문제 수정

### DIFF
--- a/src/pages/OcrInboundPage.tsx
+++ b/src/pages/OcrInboundPage.tsx
@@ -70,11 +70,12 @@ function applyStoredConversions(items: OcrInboundItem[], map: UnitConversionMap)
       return item;
     const conv = map.get(makeConversionKey(item.matchedInventoryId, item.purchaseUnit));
     if (!conv) return item;
+    const factor = Number(conv.factor);
     return {
       ...item,
       unit: conv.baseUnit,
-      quantity: (item.purchaseQuantity ?? 0) * conv.factor,
-      conversionFactor: conv.factor,
+      quantity: (item.purchaseQuantity ?? 0) * factor,
+      conversionFactor: factor,
     };
   });
 }
@@ -251,7 +252,7 @@ const OcrInboundPage = () => {
         ingredientId: (item.matchedInventoryId ?? item.newIngredientId)!,
         purchaseUnit: item.purchaseUnit!,
         baseUnit: item.unit,
-        factor: item.conversionFactor!,
+        factor: Number(item.conversionFactor!),
       }));
 
     setIsConfirming(true);


### PR DESCRIPTION
## 📌 요약

- OCR 입고 확정 시 `PUT /unit-conversions` 요청의 `factor` 필드가 `string`으로 전송되어 서버 ZodError(400) 발생하던 문제 수정

<br/>

## 🏷️ 관련 이슈

- Closes #191

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- `applyStoredConversions`: 서버 응답의 `conv.factor`를 `Number()`로 변환 후 저장
- `conversionsToSave` 매핑: PUT 요청 직전 `Number(item.conversionFactor!)`로 명시적 타입 보장

<br/>

### 📂 세부 변경사항

- `src/pages/OcrInboundPage.tsx`

<br/>

## 📸 Screenshots

| Before | After |
| ------ | ----- |
| 입고 확정 시 400 ZodError (`factor` string) | 정상 처리 |

<br/>

## 🧪 테스트 방법

1. OCR 입고 처리 페이지에서 비표준 단위(KG, BOX 등) 포함된 거래명세서 업로드
2. 기존에 저장된 변환 계수가 있는 식자재와 매칭
3. 입고 확정 버튼 클릭 → 정상 처리 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [ ] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- 근본 원인은 백엔드 `PUT /unit-conversions` 핸들러에서 `factor: String(item.factor)`로 DB에 문자열 저장 후 GET 응답 시 그대로 반환하는 것
- 백엔드 수정 전까지 프론트에서 `Number()` 변환으로 방어 처리