### PR TITLE
🐛 (#193) fix: accessToken 만료 시 자동 갱신 및 요청 재시도 로직 추가

### DIFF
--- a/src/shared/api/axiosInstance.ts
+++ b/src/shared/api/axiosInstance.ts
@@ -17,22 +17,70 @@ axiosInstance.interceptors.request.use((config) => {
 
 const AUTH_REQUEST_URLS = ['/auth/login', '/auth/register'];
 
+let isRefreshing = false;
+let failedQueue: Array<{ resolve: (token: string) => void; reject: (err: unknown) => void }> = [];
+
+const processQueue = (error: unknown, token: string | null) => {
+  failedQueue.forEach((p) => (error ? p.reject(error) : p.resolve(token!)));
+  failedQueue = [];
+};
+
+const redirectToLogin = () => {
+  const currentPath = window.location.pathname + window.location.search;
+  const AUTH_PAGE_PREFIXES = ['/login', '/auth/', '/register'];
+  const isAuthPage = AUTH_PAGE_PREFIXES.some((p) => currentPath.startsWith(p));
+  if (!isAuthPage && currentPath !== '/') {
+    sessionStorage.setItem('baro-redirect-after-login', currentPath);
+  }
+  useAuthStore.getState().clearAuth();
+  window.location.href = '/login';
+};
+
 axiosInstance.interceptors.response.use(
   (response) => response,
-  (error) => {
-    const requestUrl: string = error.config?.url ?? '';
+  async (error) => {
+    const originalRequest = error.config;
+    const requestUrl: string = originalRequest?.url ?? '';
     const isRefreshRequest = requestUrl.includes('/auth/refresh');
     const isAuthRequest = AUTH_REQUEST_URLS.some((url) => requestUrl.includes(url));
+
     if (error.response?.status === 401 && !isRefreshRequest && !isAuthRequest) {
-      const currentPath = window.location.pathname + window.location.search;
-      const AUTH_PAGE_PREFIXES = ['/login', '/auth/', '/register'];
-      const isAuthPage = AUTH_PAGE_PREFIXES.some((p) => currentPath.startsWith(p));
-      if (!isAuthPage && currentPath !== '/') {
-        sessionStorage.setItem('baro-redirect-after-login', currentPath);
+      const { refreshToken } = useAuthStore.getState();
+
+      if (!refreshToken) {
+        redirectToLogin();
+        return Promise.reject(error);
       }
-      useAuthStore.getState().clearAuth();
-      window.location.href = '/login';
+
+      if (isRefreshing) {
+        return new Promise((resolve, reject) => {
+          failedQueue.push({ resolve, reject });
+        }).then((token) => {
+          originalRequest.headers.Authorization = `Bearer ${token}`;
+          return axiosInstance(originalRequest);
+        });
+      }
+
+      isRefreshing = true;
+
+      try {
+        const res = await axios.post(`${import.meta.env.VITE_API_BASE_URL}/auth/refresh`, {
+          refreshToken,
+        });
+        const newAccessToken: string = res.data.data.accessToken;
+        useAuthStore.getState().setAccessToken(newAccessToken);
+        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+        processQueue(null, newAccessToken);
+        return axiosInstance(originalRequest);
+      } catch (refreshError) {
+        processQueue(refreshError, null);
+        redirectToLogin();
+        return Promise.reject(refreshError);
+      } finally {
+        isRefreshing = false;
+      }
     }
+
     return Promise.reject(error);
   },
 );


### PR DESCRIPTION
## 📌 요약

- accessToken이 만료되어 API 요청에 401이 반환될 때, 토큰 갱신 없이 즉시 로그인 페이지로 이동하던 문제를 해결
- `POST /auth/refresh`로 토큰 갱신 후 실패했던 원래 요청을 자동 재시도하도록 Axios 인터셉터 개선

<br/>

## 🏷️ 관련 이슈

- Closes #193

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

`src/shared/api/axiosInstance.ts` 의 response 인터셉터를 아래와 같이 개선했습니다.

**기존 동작 (문제)**
```
API 요청 → 401 응답 → 즉시 clearAuth() → /login 리다이렉트
```
accessToken이 만료될 때마다 사용자가 작업 중 갑자기 로그인 화면으로 튕겼습니다.
authStore에 refreshToken이 저장되어 있었지만 전혀 사용되지 않았습니다.

**변경 후 동작**
```
API 요청 → 401 응답
  → refreshToken 있음 → POST /auth/refresh 호출
      → 갱신 성공 → 새 accessToken 저장 → 원래 요청 재시도 → 정상 응답
      → 갱신 실패 → clearAuth() → /login 리다이렉트
  → refreshToken 없음 → clearAuth() → /login 리다이렉트
```

<br/>

### 📂 세부 변경사항

**`redirectToLogin` 헬퍼 추출**
- 기존 인터셉터에 인라인으로 있던 리다이렉트 로직을 함수로 분리
- redirect 전 현재 경로를 `sessionStorage`에 저장하는 기존 동작 유지

**`isRefreshing` 플래그 + `failedQueue` 큐 패턴 도입**
- 여러 요청이 동시에 401을 받을 경우 `POST /auth/refresh`가 중복 호출되는 문제 방지
- refresh 진행 중 들어오는 요청들은 `failedQueue`에 쌓아두었다가, 갱신 완료 후 `processQueue`로 일괄 재시도
- 갱신 실패 시 큐에 대기 중인 모든 요청에도 에러 전파

**refresh 호출에 plain `axios` 사용**
- `axiosInstance`가 아닌 기본 `axios.post`로 refresh 요청
- 인터셉터가 다시 타는 무한 루프 방지 (`isRefreshRequest` 체크도 유지)

<br/>

## 🧪 테스트 방법

1. 로그인 후 브라우저 개발자도구 → Application → Local Storage → `baro-auth`에서 `accessToken` 값을 임의로 변조
2. 식자재 등록, 메뉴 등록 등 API 요청이 필요한 작업 수행
3. **기대 결과**: 로그인 페이지로 이동하지 않고 정상 처리됨 (내부적으로 refresh 후 재시도)
4. `refreshToken`도 변조하면 로그인 페이지로 이동하는지 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [x] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- 토큰 저장 방식 자체(localStorage)의 보안 개선은 별도 이슈 #194 에서 백엔드와 협의 후 진행 예정
- refresh 응답에 새 refreshToken이 포함되지 않으므로 기존 refreshToken을 계속 사용 (백엔드 `POST /auth/refresh` 응답이 `accessToken`만 반환)