### PR TITLE
✨ (#197) feat: 가게 설정 하위 페이지 이동 후 복귀 시 스크롤 위치 복원

### DIFF
--- a/src/app/layouts/AppLayout.tsx
+++ b/src/app/layouts/AppLayout.tsx
@@ -18,9 +18,26 @@ const ROLE_LABEL: Record<string, string> = {
   staff: '직원',
 };
 
+const STORE_SETTINGS_PATH = routePaths.storeSettings;
+const STORE_SETTINGS_SUB_PATHS = [
+  routePaths.storeSettingsMenus,
+  routePaths.storeSettingsMenuBoard,
+  routePaths.storeSettingsTable,
+  routePaths.storeSettingsRecipes,
+  routePaths.storeSettingsIngredients,
+];
+const SCROLL_STORAGE_KEY = 'baro-store-settings-scroll';
+
+const isStoreSettingsSubPath = (path: string) =>
+  STORE_SETTINGS_SUB_PATHS.some((p) => path.startsWith(p));
+
+// 모듈 레벨: React 생명주기와 무관하게 스크롤 위치를 동기적으로 보존
+let settingsScrollTop = 0;
+
 const AppLayout = () => {
   const scrollRef = useRef<HTMLDivElement>(null);
   const { pathname } = useLocation();
+  const prevPathnameRef = useRef<string>(pathname);
   const navigate = useNavigate();
 
   const { isOpen } = useClosingStore((s) => s.businessSession);
@@ -38,8 +55,46 @@ const AppLayout = () => {
   const { data: dashboardStats } = useDashboardStats(isOpen ? storeId : null);
   const { data: closingHistory } = useClosingHistory(isOpen ? storeId : null);
 
+  // 가게 설정 페이지에 있는 동안 스크롤 위치를 동기적으로 추적
   useEffect(() => {
-    scrollRef.current?.scrollTo(0, 0);
+    if (pathname !== STORE_SETTINGS_PATH) return;
+    const el = scrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      settingsScrollTop = el.scrollTop;
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, [pathname]);
+
+  useEffect(() => {
+    const prev = prevPathnameRef.current;
+    prevPathnameRef.current = pathname;
+
+    const comingBackToSettings = pathname === STORE_SETTINGS_PATH && isStoreSettingsSubPath(prev);
+    const goingToSubPage = prev === STORE_SETTINGS_PATH && isStoreSettingsSubPath(pathname);
+    const movingBetweenSubPages = isStoreSettingsSubPath(prev) && isStoreSettingsSubPath(pathname);
+
+    if (goingToSubPage) {
+      // 가게 설정 → 하위 페이지: 리스너로 수집한 위치 저장 후 최상단 이동
+      sessionStorage.setItem(SCROLL_STORAGE_KEY, String(settingsScrollTop));
+      scrollRef.current?.scrollTo(0, 0);
+    } else if (comingBackToSettings) {
+      // 하위 페이지 → 가게 설정: 복원할 위치를 미리 동기적으로 반영 후 레이아웃 완료 시 스크롤
+      const saved = Number(sessionStorage.getItem(SCROLL_STORAGE_KEY) ?? 0);
+      settingsScrollTop = saved;
+      requestAnimationFrame(() => {
+        scrollRef.current?.scrollTo({ top: saved, behavior: 'instant' });
+      });
+    } else if (movingBetweenSubPages) {
+      // 하위 페이지 간 이동: 저장된 위치는 유지하고 최상단으로만 이동
+      scrollRef.current?.scrollTo(0, 0);
+    } else {
+      // 설정 영역을 완전히 벗어남: 저장 위치 제거 후 최상단 이동
+      sessionStorage.removeItem(SCROLL_STORAGE_KEY);
+      settingsScrollTop = 0;
+      scrollRef.current?.scrollTo(0, 0);
+    }
   }, [pathname]);
 
   return (


### PR DESCRIPTION
## 📌 요약

- 가게 설정 페이지(`/store-settings`)에서 하위 페이지(메뉴 관리, 식자재 설정 등)로 이동했다가 돌아올 때 스크롤 위치가 최상단으로 리셋되던 문제 해결
- 이동 전 스크롤 위치를 저장하고 복귀 시 복원하도록 `AppLayout.tsx` 개선

<br/>

## 🏷️ 관련 이슈

- Closes #197

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

**기존 동작 (문제)**
- `AppLayout.tsx`에서 `pathname` 변경 시 무조건 `scrollTo(0, 0)` 호출
- 가게 설정 → 하위 페이지 → 가게 설정 복귀 시 항상 최상단(가게 정보 섹션)으로 리셋

**변경 후 동작**

| 이동 방향 | 스크롤 동작 |
|---|---|
| `/store-settings` → 하위 페이지 | 하위 페이지는 최상단 (기존과 동일) |
| 하위 페이지 → `/store-settings` | 이전에 보던 스크롤 위치 복원 |
| 다른 페이지 → `/store-settings` | 최상단 (기존과 동일) |

<br/>

### 📂 세부 변경사항

**`src/app/layouts/AppLayout.tsx`**

1. **모듈 레벨 `settingsScrollTop` 변수**: React 생명주기와 무관하게 가게 설정 페이지의 스크롤 위치를 동기적으로 보존

2. **스크롤 이벤트 리스너**: 가게 설정 페이지에 있는 동안 스크롤 이벤트로 `settingsScrollTop`을 실시간 추적. `useEffect` 내에서 `scrollTop`을 읽으면 React가 DOM을 업데이트한 후라 이미 0으로 바뀐 경우가 있어 리스너 방식 채택

3. **이동 방향별 4가지 분기 처리**
   - `goingToSubPage`: `settingsScrollTop` → `sessionStorage` 저장 후 최상단 이동
   - `comingBackToSettings`: `sessionStorage`에서 복원 (`requestAnimationFrame`으로 콘텐츠 레이아웃 완료 후 실행) + `settingsScrollTop` 즉시 동기화
   - `movingBetweenSubPages`: 저장값 유지, 최상단 이동만
   - 그 외: `sessionStorage` 제거, `settingsScrollTop` 초기화, 최상단 이동

4. **Race condition 해결**: 복귀 직후 rAF 실행 전에 즉시 다시 하위 페이지로 이동하면 `settingsScrollTop`이 0인 채로 저장되던 문제 → `settingsScrollTop = saved`를 rAF보다 먼저 동기적으로 세팅하여 해결

<br/>

## 🧪 테스트 방법

1. 가게 설정 페이지에서 아래쪽 섹션(예: 손님 주문, 운영 정보)까지 스크롤
2. 하위 페이지(메뉴 관리 등)로 이동 → 최상단 확인
3. 뒤로 가기로 가게 설정 복귀 → 이전 스크롤 위치 복원 확인
4. 복귀 직후 바로 다시 하위 페이지로 이동 → 복귀 시 동일 위치 유지 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [ ] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- `StoreSettingsContent`의 IntersectionObserver 기반 active 탭은 스크롤 복원 후 자동으로 현재 섹션으로 동기화되므로 별도 수정 불필요