### PR TITLE
♻️ (#199) refactor: API 에러 응답의 구체적인 메시지를 사용자에게 표시

### DIFF
--- a/src/features/closing/components/ClosingCancelModal.tsx
+++ b/src/features/closing/components/ClosingCancelModal.tsx
@@ -25,6 +25,7 @@ import {
   DialogTitle,
 } from '@/shadcn/ui/dialog';
 import { Skeleton } from '@/shadcn/ui/skeleton';
+import { getApiErrorMessage } from '@/shared/utils/apiError';
 
 interface ClosingCancelModalProps {
   open: boolean;
@@ -74,8 +75,10 @@ const ClosingCancelModal = ({ open, onClose, storeId }: ClosingCancelModalProps)
         setConfirmingItem(null);
         onClose();
       },
-      onError: () => {
-        toast.error('마감 취소에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+      onError: (err) => {
+        toast.error(
+          getApiErrorMessage(err, '마감 취소에 실패했습니다. 잠시 후 다시 시도해 주세요.'),
+        );
         setConfirmingItem(null);
       },
     });

--- a/src/features/initial-setup/components/InitialSetupForm.tsx
+++ b/src/features/initial-setup/components/InitialSetupForm.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
 
 import { routePaths } from '@/app/routes/routePaths';
 import useAuthStore from '@/features/auth/store/authStore';
@@ -23,6 +24,7 @@ import { cn } from '@/lib/utils';
 import { Button } from '@/shadcn/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shadcn/ui/card';
 import BackButton from '@/shared/components/BackButton';
+import { getApiErrorMessage } from '@/shared/utils/apiError';
 
 type BasicInfoErrors = Partial<Record<keyof StoreBasicInfo, string>>;
 
@@ -102,8 +104,10 @@ const InitialSetupForm = () => {
       });
 
       navigate(routePaths.dashboard);
-    } catch {
-      alert('초기 설정 저장에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+    } catch (err) {
+      toast.error(
+        getApiErrorMessage(err, '초기 설정 저장에 실패했습니다. 잠시 후 다시 시도해 주세요.'),
+      );
     }
   };
 

--- a/src/features/store-registration/components/MyStoresList.tsx
+++ b/src/features/store-registration/components/MyStoresList.tsx
@@ -67,6 +67,7 @@ import { Input } from '@/shadcn/ui/input';
 import { Separator } from '@/shadcn/ui/separator';
 import { Skeleton } from '@/shadcn/ui/skeleton';
 import baroLogo from '@/shared/assets/images/baro-logo.png';
+import { getApiErrorMessage } from '@/shared/utils/apiError';
 
 const ROLE_LABEL: Record<MyStore['role'], string> = { owner: '사장님', staff: '직원' };
 const ROLE_STYLE: Record<MyStore['role'], string> = {
@@ -140,8 +141,8 @@ const MyStoresList = () => {
       await withdrawUser();
       clearAuth();
       navigate(routePaths.login, { replace: true });
-    } catch {
-      toast.error('회원 탈퇴에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, '회원 탈퇴에 실패했습니다. 잠시 후 다시 시도해 주세요.'));
       setIsWithdrawing(false);
       setWithdrawOpen(false);
     }
@@ -158,7 +159,10 @@ const MyStoresList = () => {
     if (!trimmed) return;
     updateName(trimmed, {
       onSuccess: () => setIsEditingName(false),
-      onError: () => toast.error('이름 변경에 실패했습니다. 잠시 후 다시 시도해 주세요.'),
+      onError: (err) =>
+        toast.error(
+          getApiErrorMessage(err, '이름 변경에 실패했습니다. 잠시 후 다시 시도해 주세요.'),
+        ),
     });
   };
 
@@ -176,8 +180,10 @@ const MyStoresList = () => {
         setDeleteTargetId(null);
         setIsEditMode(false);
       },
-      onError: () => {
-        toast.error('가게 삭제에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+      onError: (err) => {
+        toast.error(
+          getApiErrorMessage(err, '가게 삭제에 실패했습니다. 잠시 후 다시 시도해 주세요.'),
+        );
       },
     });
   };
@@ -191,8 +197,10 @@ const MyStoresList = () => {
         setLeaveTargetId(null);
         setIsEditMode(false);
       },
-      onError: () => {
-        toast.error('가게 나가기에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+      onError: (err) => {
+        toast.error(
+          getApiErrorMessage(err, '가게 나가기에 실패했습니다. 잠시 후 다시 시도해 주세요.'),
+        );
       },
     });
   };

--- a/src/features/store-settings/components/sections/DataSection.tsx
+++ b/src/features/store-settings/components/sections/DataSection.tsx
@@ -24,6 +24,7 @@ import {
 import { Button } from '@/shadcn/ui/button';
 import SettingRow from '@/shared/components/SettingRow';
 import SettingsSection from '@/shared/components/SettingsSection';
+import { getApiErrorMessage } from '@/shared/utils/apiError';
 
 const DataSection = () => {
   const navigate = useNavigate();
@@ -43,8 +44,10 @@ const DataSection = () => {
         toast.success('가게 데이터가 초기화되었습니다.');
         setOpen(false);
       },
-      onError: () => {
-        toast.error('데이터 초기화에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+      onError: (err) => {
+        toast.error(
+          getApiErrorMessage(err, '데이터 초기화에 실패했습니다. 잠시 후 다시 시도해 주세요.'),
+        );
         setOpen(false);
       },
     });
@@ -58,8 +61,10 @@ const DataSection = () => {
         useAuthStore.setState({ storeId: null });
         navigate(routePaths.myStores, { replace: true });
       },
-      onError: () => {
-        toast.error('가게 삭제에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+      onError: (err) => {
+        toast.error(
+          getApiErrorMessage(err, '가게 삭제에 실패했습니다. 잠시 후 다시 시도해 주세요.'),
+        );
         setDeleteOpen(false);
       },
     });
@@ -73,8 +78,10 @@ const DataSection = () => {
         useAuthStore.setState({ storeId: null });
         navigate(routePaths.myStores, { replace: true });
       },
-      onError: () => {
-        toast.error('가게 나가기에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+      onError: (err) => {
+        toast.error(
+          getApiErrorMessage(err, '가게 나가기에 실패했습니다. 잠시 후 다시 시도해 주세요.'),
+        );
         setLeaveOpen(false);
       },
     });

--- a/src/features/store-settings/components/sections/StaffSection.tsx
+++ b/src/features/store-settings/components/sections/StaffSection.tsx
@@ -24,6 +24,7 @@ import {
 import { Skeleton } from '@/shadcn/ui/skeleton';
 import SettingRow from '@/shared/components/SettingRow';
 import SettingsSection from '@/shared/components/SettingsSection';
+import { getApiErrorMessage } from '@/shared/utils/apiError';
 
 const MemberAvatar = ({ member }: { member: StoreMember }) => {
   if (member.profileImage) {
@@ -64,8 +65,10 @@ const StaffSection = () => {
       await regenerateInviteCode(storeId);
       await queryClient.invalidateQueries({ queryKey: ['storeSettings', storeId] });
       toast.success('초대코드가 발급되었습니다.');
-    } catch {
-      toast.error('초대코드 발급에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+    } catch (err) {
+      toast.error(
+        getApiErrorMessage(err, '초대코드 발급에 실패했습니다. 잠시 후 다시 시도해 주세요.'),
+      );
     } finally {
       setIsIssuing(false);
       setConfirmReissueOpen(false);
@@ -87,8 +90,10 @@ const StaffSection = () => {
         toast.success(`${targetMember.name}님을 내보냈습니다.`);
         setTargetMember(null);
       },
-      onError: () => {
-        toast.error('멤버 내보내기에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+      onError: (err) => {
+        toast.error(
+          getApiErrorMessage(err, '멤버 내보내기에 실패했습니다. 잠시 후 다시 시도해 주세요.'),
+        );
         setTargetMember(null);
       },
     });

--- a/src/pages/ClosingPage.tsx
+++ b/src/pages/ClosingPage.tsx
@@ -28,6 +28,7 @@ import {
   DialogTitle,
 } from '@/shadcn/ui/dialog';
 import { Skeleton } from '@/shadcn/ui/skeleton';
+import { getApiErrorMessage } from '@/shared/utils/apiError';
 
 const formatCurrency = (amount: number) => `${amount.toLocaleString('ko-KR')}원`;
 
@@ -137,8 +138,10 @@ const ClosingPage = () => {
           void queryClient.invalidateQueries({ queryKey: ['closing', 'preview'] });
           setAfterModalOpen(true);
         },
-        onError: () => {
-          toast.error('마감 처리에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+        onError: (err) => {
+          toast.error(
+            getApiErrorMessage(err, '마감 처리에 실패했습니다. 잠시 후 다시 시도해 주세요.'),
+          );
         },
       },
     );

--- a/src/pages/OcrInboundPage.tsx
+++ b/src/pages/OcrInboundPage.tsx
@@ -278,8 +278,8 @@ const OcrInboundPage = () => {
       qc.invalidateQueries({ queryKey: ['storeSettings', storeId] });
       toast.success('재고 등록이 완료되었습니다.');
       navigate(routePaths.inventory);
-    } catch {
-      toast.error('입고 확정에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, '입고 확정에 실패했습니다. 잠시 후 다시 시도해 주세요.'));
     } finally {
       setIsConfirming(false);
     }

--- a/src/pages/SettingsTablePage.tsx
+++ b/src/pages/SettingsTablePage.tsx
@@ -16,6 +16,7 @@ import {
 import { Button } from '@/shadcn/ui/button';
 import { Input } from '@/shadcn/ui/input';
 import { Skeleton } from '@/shadcn/ui/skeleton';
+import { getApiErrorMessage } from '@/shared/utils/apiError';
 
 const BASE_URL = window.location.origin;
 
@@ -92,8 +93,8 @@ const SettingsTablePage = () => {
           toast.success('테이블 수가 저장되었습니다.');
           setIsEditing(false);
         },
-        onError: () => {
-          toast.error('저장에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+        onError: (err) => {
+          toast.error(getApiErrorMessage(err, '저장에 실패했습니다. 잠시 후 다시 시도해 주세요.'));
         },
       },
     );

--- a/src/pages/StoreHomePage.tsx
+++ b/src/pages/StoreHomePage.tsx
@@ -36,6 +36,7 @@ import {
 } from '@/shadcn/ui/dialog';
 import { Skeleton } from '@/shadcn/ui/skeleton';
 import baroLogo from '@/shared/assets/images/baro-logo.png';
+import { getApiErrorMessage } from '@/shared/utils/apiError';
 import {
   getBusinessDate,
   getTodayOpenTime,
@@ -120,8 +121,8 @@ const StoreHomePage = () => {
       await openBusiness(storeId, { businessDate: targetDate });
       setBusinessSession({ isOpen: true, businessDate: targetDate });
       navigate('/dashboard');
-    } catch {
-      toast.error('영업 시작에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, '영업 시작에 실패했습니다. 잠시 후 다시 시도해 주세요.'));
     } finally {
       setIsStarting(false);
     }

--- a/src/shared/components/IngredientRegisterModal.tsx
+++ b/src/shared/components/IngredientRegisterModal.tsx
@@ -24,6 +24,7 @@ import {
 import { Input } from '@/shadcn/ui/input';
 import { Label } from '@/shadcn/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/shadcn/ui/select';
+import { getApiErrorMessage } from '@/shared/utils/apiError';
 
 type IngredientUnit = 'g' | 'ml' | '개';
 
@@ -125,7 +126,8 @@ const IngredientRegisterModal = ({
   const handleDeleteConversion = (conv: UnitConversionDto) => {
     deleteConversion(conv.id, {
       onSuccess: () => toast.success(`${conv.purchaseUnit} 변환 계수가 삭제되었습니다.`),
-      onError: () => toast.error('삭제에 실패했습니다. 잠시 후 다시 시도해 주세요.'),
+      onError: (err) =>
+        toast.error(getApiErrorMessage(err, '삭제에 실패했습니다. 잠시 후 다시 시도해 주세요.')),
     });
   };
 
@@ -153,7 +155,8 @@ const IngredientRegisterModal = ({
           setIsAddingConversion(false);
           setNewConversion({ purchaseUnit: '', factor: '' });
         },
-        onError: () => toast.error('추가에 실패했습니다. 잠시 후 다시 시도해 주세요.'),
+        onError: (err) =>
+          toast.error(getApiErrorMessage(err, '추가에 실패했습니다. 잠시 후 다시 시도해 주세요.')),
       },
     );
   };

--- a/src/shared/utils/apiError.ts
+++ b/src/shared/utils/apiError.ts
@@ -2,12 +2,22 @@ import axios from 'axios';
 
 import { API_ERROR_MESSAGES, DEFAULT_ERROR_MESSAGE } from '@/shared/constants/errorMessages';
 
+type ApiErrorData = { error?: { code?: string; message?: string } };
+
 export const getApiErrorCode = (err: unknown): string | undefined => {
   if (!axios.isAxiosError(err)) return undefined;
-  return (err.response?.data as { error?: { code?: string } } | undefined)?.error?.code;
+  return (err.response?.data as ApiErrorData | undefined)?.error?.code;
+};
+
+const getApiErrorServerMessage = (err: unknown): string | undefined => {
+  if (!axios.isAxiosError(err)) return undefined;
+  return (err.response?.data as ApiErrorData | undefined)?.error?.message;
 };
 
 export const getApiErrorMessage = (err: unknown, fallback = DEFAULT_ERROR_MESSAGE): string => {
   const code = getApiErrorCode(err);
-  return code ? (API_ERROR_MESSAGES[code] ?? fallback) : fallback;
+  if (code && API_ERROR_MESSAGES[code]) return API_ERROR_MESSAGES[code];
+  const serverMessage = getApiErrorServerMessage(err);
+  if (serverMessage) return serverMessage;
+  return fallback;
 };


### PR DESCRIPTION
## 📌 요약

- `getApiErrorMessage`에 서버 `error.message` 폴백 추가 (코드 매핑 → 서버 메시지 → fallback 순)
- 전체 `onError` 핸들러에서 `err` 객체를 무시하던 패턴을 `getApiErrorMessage(err, ...)` 로 교체
- `InitialSetupForm`의 `alert()` → `toast.error()` 교체

<br/>

## 🏷️ 관련 이슈

- Closes #199

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- `getApiErrorMessage` 로직 개선: `API_ERROR_MESSAGES[code]` → `error.message`(서버) → fallback 순으로 시도
  - 백엔드가 내려주는 구체적인 메시지 (`"유효하지 않은 식자재가 포함되어 있습니다."`, `"소급 마감은 어제까지만 가능합니다."` 등)를 자동으로 활용
  - 상수에 등록된 코드(AI_UNAVAILABLE, OCR_FAILED 등 외부 서비스)는 기존 프론트 메시지 우선 유지

<br/>

### 📂 세부 변경사항

- `src/shared/utils/apiError.ts` — `getApiErrorServerMessage` 추가 및 `getApiErrorMessage` 로직 개선
- `src/pages/OcrInboundPage.tsx` — 입고 확정 catch 블록
- `src/pages/ClosingPage.tsx` — 마감 처리 onError
- `src/pages/StoreHomePage.tsx` — 영업 시작 catch 블록
- `src/pages/SettingsTablePage.tsx` — 테이블 수 저장 onError
- `src/features/closing/components/ClosingCancelModal.tsx` — 마감 취소 onError
- `src/features/store-settings/components/sections/StaffSection.tsx` — 초대코드 발급 / 멤버 내보내기
- `src/features/store-settings/components/sections/DataSection.tsx` — 데이터 초기화 / 가게 삭제 / 가게 나가기
- `src/features/store-registration/components/MyStoresList.tsx` — 회원 탈퇴 / 이름 변경 / 가게 삭제 / 가게 나가기
- `src/shared/components/IngredientRegisterModal.tsx` — 변환 계수 삭제 / 추가
- `src/features/initial-setup/components/InitialSetupForm.tsx` — `alert()` → `toast.error()` 교체

<br/>

## 📸 Screenshots

| Before | After |
| ------ | ----- |
| "입고 확정에 실패했습니다. 잠시 후 다시 시도해 주세요." | "유효하지 않은 식자재가 포함되어 있습니다." (서버 메시지) |
| "마감 처리에 실패했습니다. 잠시 후 다시 시도해 주세요." | "이미 마감된 날짜입니다." / "소급 마감은 어제까지만 가능합니다." |

<br/>

## 🧪 테스트 방법

1. 입고 확정 시 잘못된 식자재 포함 → 구체적인 에러 메시지 확인
2. 이미 마감된 날짜 재마감 시도 → 구체적인 에러 메시지 확인
3. OCR 실패 시 → 기존 외부 서비스 메시지 유지 확인 (회귀)

<br/>

## 🚨 영향 범위

- [x] Frontend

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음

<br/>

## 💬 Additional Notes

- `API_ERROR_MESSAGES` 상수는 "프론트가 더 잘 설명할 수 있는 코드"에만 등록 (외부 서비스 코드, 비즈니스 규칙 코드). 나머지는 서버 메시지가 자동으로 처리.