### PR TITLE
🚀 (#201) deploy: v1.1.2 에러 메시지 개선 및 버그 수정 배포

### DIFF
--- a/src/app/layouts/AppLayout.tsx
+++ b/src/app/layouts/AppLayout.tsx
@@ -18,9 +18,26 @@ const ROLE_LABEL: Record<string, string> = {
   staff: '직원',
 };
 
+const STORE_SETTINGS_PATH = routePaths.storeSettings;
+const STORE_SETTINGS_SUB_PATHS = [
+  routePaths.storeSettingsMenus,
+  routePaths.storeSettingsMenuBoard,
+  routePaths.storeSettingsTable,
+  routePaths.storeSettingsRecipes,
+  routePaths.storeSettingsIngredients,
+];
+const SCROLL_STORAGE_KEY = 'baro-store-settings-scroll';
+
+const isStoreSettingsSubPath = (path: string) =>
+  STORE_SETTINGS_SUB_PATHS.some((p) => path.startsWith(p));
+
+// 모듈 레벨: React 생명주기와 무관하게 스크롤 위치를 동기적으로 보존
+let settingsScrollTop = 0;
+
 const AppLayout = () => {
   const scrollRef = useRef<HTMLDivElement>(null);
   const { pathname } = useLocation();
+  const prevPathnameRef = useRef<string>(pathname);
   const navigate = useNavigate();
 
   const { isOpen } = useClosingStore((s) => s.businessSession);
@@ -38,8 +55,46 @@ const AppLayout = () => {
   const { data: dashboardStats } = useDashboardStats(isOpen ? storeId : null);
   const { data: closingHistory } = useClosingHistory(isOpen ? storeId : null);
 
+  // 가게 설정 페이지에 있는 동안 스크롤 위치를 동기적으로 추적
   useEffect(() => {
-    scrollRef.current?.scrollTo(0, 0);
+    if (pathname !== STORE_SETTINGS_PATH) return;
+    const el = scrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      settingsScrollTop = el.scrollTop;
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, [pathname]);
+
+  useEffect(() => {
+    const prev = prevPathnameRef.current;
+    prevPathnameRef.current = pathname;
+
+    const comingBackToSettings = pathname === STORE_SETTINGS_PATH && isStoreSettingsSubPath(prev);
+    const goingToSubPage = prev === STORE_SETTINGS_PATH && isStoreSettingsSubPath(pathname);
+    const movingBetweenSubPages = isStoreSettingsSubPath(prev) && isStoreSettingsSubPath(pathname);
+
+    if (goingToSubPage) {
+      // 가게 설정 → 하위 페이지: 리스너로 수집한 위치 저장 후 최상단 이동
+      sessionStorage.setItem(SCROLL_STORAGE_KEY, String(settingsScrollTop));
+      scrollRef.current?.scrollTo(0, 0);
+    } else if (comingBackToSettings) {
+      // 하위 페이지 → 가게 설정: 복원할 위치를 미리 동기적으로 반영 후 레이아웃 완료 시 스크롤
+      const saved = Number(sessionStorage.getItem(SCROLL_STORAGE_KEY) ?? 0);
+      settingsScrollTop = saved;
+      requestAnimationFrame(() => {
+        scrollRef.current?.scrollTo({ top: saved, behavior: 'instant' });
+      });
+    } else if (movingBetweenSubPages) {
+      // 하위 페이지 간 이동: 저장된 위치는 유지하고 최상단으로만 이동
+      scrollRef.current?.scrollTo(0, 0);
+    } else {
+      // 설정 영역을 완전히 벗어남: 저장 위치 제거 후 최상단 이동
+      sessionStorage.removeItem(SCROLL_STORAGE_KEY);
+      settingsScrollTop = 0;
+      scrollRef.current?.scrollTo(0, 0);
+    }
   }, [pathname]);
 
   return (

--- a/src/features/closing/components/ClosingCancelModal.tsx
+++ b/src/features/closing/components/ClosingCancelModal.tsx
@@ -25,6 +25,7 @@ import {
   DialogTitle,
 } from '@/shadcn/ui/dialog';
 import { Skeleton } from '@/shadcn/ui/skeleton';
+import { getApiErrorMessage } from '@/shared/utils/apiError';
 
 interface ClosingCancelModalProps {
   open: boolean;
@@ -74,8 +75,10 @@ const ClosingCancelModal = ({ open, onClose, storeId }: ClosingCancelModalProps)
         setConfirmingItem(null);
         onClose();
       },
-      onError: () => {
-        toast.error('마감 취소에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+      onError: (err) => {
+        toast.error(
+          getApiErrorMessage(err, '마감 취소에 실패했습니다. 잠시 후 다시 시도해 주세요.'),
+        );
         setConfirmingItem(null);
       },
     });

--- a/src/features/initial-setup/components/InitialSetupForm.tsx
+++ b/src/features/initial-setup/components/InitialSetupForm.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
 
 import { routePaths } from '@/app/routes/routePaths';
 import useAuthStore from '@/features/auth/store/authStore';
@@ -23,6 +24,7 @@ import { cn } from '@/lib/utils';
 import { Button } from '@/shadcn/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shadcn/ui/card';
 import BackButton from '@/shared/components/BackButton';
+import { getApiErrorMessage } from '@/shared/utils/apiError';
 
 type BasicInfoErrors = Partial<Record<keyof StoreBasicInfo, string>>;
 
@@ -102,8 +104,10 @@ const InitialSetupForm = () => {
       });
 
       navigate(routePaths.dashboard);
-    } catch {
-      alert('초기 설정 저장에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+    } catch (err) {
+      toast.error(
+        getApiErrorMessage(err, '초기 설정 저장에 실패했습니다. 잠시 후 다시 시도해 주세요.'),
+      );
     }
   };
 

--- a/src/features/store-registration/components/MyStoresList.tsx
+++ b/src/features/store-registration/components/MyStoresList.tsx
@@ -67,6 +67,7 @@ import { Input } from '@/shadcn/ui/input';
 import { Separator } from '@/shadcn/ui/separator';
 import { Skeleton } from '@/shadcn/ui/skeleton';
 import baroLogo from '@/shared/assets/images/baro-logo.png';
+import { getApiErrorMessage } from '@/shared/utils/apiError';
 
 const ROLE_LABEL: Record<MyStore['role'], string> = { owner: '사장님', staff: '직원' };
 const ROLE_STYLE: Record<MyStore['role'], string> = {
@@ -140,8 +141,8 @@ const MyStoresList = () => {
       await withdrawUser();
       clearAuth();
       navigate(routePaths.login, { replace: true });
-    } catch {
-      toast.error('회원 탈퇴에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, '회원 탈퇴에 실패했습니다. 잠시 후 다시 시도해 주세요.'));
       setIsWithdrawing(false);
       setWithdrawOpen(false);
     }
@@ -158,7 +159,10 @@ const MyStoresList = () => {
     if (!trimmed) return;
     updateName(trimmed, {
       onSuccess: () => setIsEditingName(false),
-      onError: () => toast.error('이름 변경에 실패했습니다. 잠시 후 다시 시도해 주세요.'),
+      onError: (err) =>
+        toast.error(
+          getApiErrorMessage(err, '이름 변경에 실패했습니다. 잠시 후 다시 시도해 주세요.'),
+        ),
     });
   };
 
@@ -176,8 +180,10 @@ const MyStoresList = () => {
         setDeleteTargetId(null);
         setIsEditMode(false);
       },
-      onError: () => {
-        toast.error('가게 삭제에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+      onError: (err) => {
+        toast.error(
+          getApiErrorMessage(err, '가게 삭제에 실패했습니다. 잠시 후 다시 시도해 주세요.'),
+        );
       },
     });
   };
@@ -191,8 +197,10 @@ const MyStoresList = () => {
         setLeaveTargetId(null);
         setIsEditMode(false);
       },
-      onError: () => {
-        toast.error('가게 나가기에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+      onError: (err) => {
+        toast.error(
+          getApiErrorMessage(err, '가게 나가기에 실패했습니다. 잠시 후 다시 시도해 주세요.'),
+        );
       },
     });
   };

--- a/src/features/store-settings/components/sections/DataSection.tsx
+++ b/src/features/store-settings/components/sections/DataSection.tsx
@@ -24,6 +24,7 @@ import {
 import { Button } from '@/shadcn/ui/button';
 import SettingRow from '@/shared/components/SettingRow';
 import SettingsSection from '@/shared/components/SettingsSection';
+import { getApiErrorMessage } from '@/shared/utils/apiError';
 
 const DataSection = () => {
   const navigate = useNavigate();
@@ -43,8 +44,10 @@ const DataSection = () => {
         toast.success('가게 데이터가 초기화되었습니다.');
         setOpen(false);
       },
-      onError: () => {
-        toast.error('데이터 초기화에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+      onError: (err) => {
+        toast.error(
+          getApiErrorMessage(err, '데이터 초기화에 실패했습니다. 잠시 후 다시 시도해 주세요.'),
+        );
         setOpen(false);
       },
     });
@@ -58,8 +61,10 @@ const DataSection = () => {
         useAuthStore.setState({ storeId: null });
         navigate(routePaths.myStores, { replace: true });
       },
-      onError: () => {
-        toast.error('가게 삭제에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+      onError: (err) => {
+        toast.error(
+          getApiErrorMessage(err, '가게 삭제에 실패했습니다. 잠시 후 다시 시도해 주세요.'),
+        );
         setDeleteOpen(false);
       },
     });
@@ -73,8 +78,10 @@ const DataSection = () => {
         useAuthStore.setState({ storeId: null });
         navigate(routePaths.myStores, { replace: true });
       },
-      onError: () => {
-        toast.error('가게 나가기에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+      onError: (err) => {
+        toast.error(
+          getApiErrorMessage(err, '가게 나가기에 실패했습니다. 잠시 후 다시 시도해 주세요.'),
+        );
         setLeaveOpen(false);
       },
     });

--- a/src/features/store-settings/components/sections/StaffSection.tsx
+++ b/src/features/store-settings/components/sections/StaffSection.tsx
@@ -24,6 +24,7 @@ import {
 import { Skeleton } from '@/shadcn/ui/skeleton';
 import SettingRow from '@/shared/components/SettingRow';
 import SettingsSection from '@/shared/components/SettingsSection';
+import { getApiErrorMessage } from '@/shared/utils/apiError';
 
 const MemberAvatar = ({ member }: { member: StoreMember }) => {
   if (member.profileImage) {
@@ -64,8 +65,10 @@ const StaffSection = () => {
       await regenerateInviteCode(storeId);
       await queryClient.invalidateQueries({ queryKey: ['storeSettings', storeId] });
       toast.success('초대코드가 발급되었습니다.');
-    } catch {
-      toast.error('초대코드 발급에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+    } catch (err) {
+      toast.error(
+        getApiErrorMessage(err, '초대코드 발급에 실패했습니다. 잠시 후 다시 시도해 주세요.'),
+      );
     } finally {
       setIsIssuing(false);
       setConfirmReissueOpen(false);
@@ -87,8 +90,10 @@ const StaffSection = () => {
         toast.success(`${targetMember.name}님을 내보냈습니다.`);
         setTargetMember(null);
       },
-      onError: () => {
-        toast.error('멤버 내보내기에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+      onError: (err) => {
+        toast.error(
+          getApiErrorMessage(err, '멤버 내보내기에 실패했습니다. 잠시 후 다시 시도해 주세요.'),
+        );
         setTargetMember(null);
       },
     });

--- a/src/pages/ClosingPage.tsx
+++ b/src/pages/ClosingPage.tsx
@@ -28,6 +28,7 @@ import {
   DialogTitle,
 } from '@/shadcn/ui/dialog';
 import { Skeleton } from '@/shadcn/ui/skeleton';
+import { getApiErrorMessage } from '@/shared/utils/apiError';
 
 const formatCurrency = (amount: number) => `${amount.toLocaleString('ko-KR')}원`;
 
@@ -137,8 +138,10 @@ const ClosingPage = () => {
           void queryClient.invalidateQueries({ queryKey: ['closing', 'preview'] });
           setAfterModalOpen(true);
         },
-        onError: () => {
-          toast.error('마감 처리에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+        onError: (err) => {
+          toast.error(
+            getApiErrorMessage(err, '마감 처리에 실패했습니다. 잠시 후 다시 시도해 주세요.'),
+          );
         },
       },
     );

--- a/src/pages/OcrInboundPage.tsx
+++ b/src/pages/OcrInboundPage.tsx
@@ -70,11 +70,12 @@ function applyStoredConversions(items: OcrInboundItem[], map: UnitConversionMap)
       return item;
     const conv = map.get(makeConversionKey(item.matchedInventoryId, item.purchaseUnit));
     if (!conv) return item;
+    const factor = Number(conv.factor);
     return {
       ...item,
       unit: conv.baseUnit,
-      quantity: (item.purchaseQuantity ?? 0) * conv.factor,
-      conversionFactor: conv.factor,
+      quantity: (item.purchaseQuantity ?? 0) * factor,
+      conversionFactor: factor,
     };
   });
 }
@@ -251,7 +252,7 @@ const OcrInboundPage = () => {
         ingredientId: (item.matchedInventoryId ?? item.newIngredientId)!,
         purchaseUnit: item.purchaseUnit!,
         baseUnit: item.unit,
-        factor: item.conversionFactor!,
+        factor: Number(item.conversionFactor!),
       }));
 
     setIsConfirming(true);

--- a/src/pages/OcrInboundPage.tsx
+++ b/src/pages/OcrInboundPage.tsx
@@ -278,8 +278,8 @@ const OcrInboundPage = () => {
       qc.invalidateQueries({ queryKey: ['storeSettings', storeId] });
       toast.success('재고 등록이 완료되었습니다.');
       navigate(routePaths.inventory);
-    } catch {
-      toast.error('입고 확정에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, '입고 확정에 실패했습니다. 잠시 후 다시 시도해 주세요.'));
     } finally {
       setIsConfirming(false);
     }

--- a/src/pages/SettingsTablePage.tsx
+++ b/src/pages/SettingsTablePage.tsx
@@ -16,6 +16,7 @@ import {
 import { Button } from '@/shadcn/ui/button';
 import { Input } from '@/shadcn/ui/input';
 import { Skeleton } from '@/shadcn/ui/skeleton';
+import { getApiErrorMessage } from '@/shared/utils/apiError';
 
 const BASE_URL = window.location.origin;
 
@@ -92,8 +93,8 @@ const SettingsTablePage = () => {
           toast.success('테이블 수가 저장되었습니다.');
           setIsEditing(false);
         },
-        onError: () => {
-          toast.error('저장에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+        onError: (err) => {
+          toast.error(getApiErrorMessage(err, '저장에 실패했습니다. 잠시 후 다시 시도해 주세요.'));
         },
       },
     );

--- a/src/pages/StoreHomePage.tsx
+++ b/src/pages/StoreHomePage.tsx
@@ -36,6 +36,7 @@ import {
 } from '@/shadcn/ui/dialog';
 import { Skeleton } from '@/shadcn/ui/skeleton';
 import baroLogo from '@/shared/assets/images/baro-logo.png';
+import { getApiErrorMessage } from '@/shared/utils/apiError';
 import {
   getBusinessDate,
   getTodayOpenTime,
@@ -120,8 +121,8 @@ const StoreHomePage = () => {
       await openBusiness(storeId, { businessDate: targetDate });
       setBusinessSession({ isOpen: true, businessDate: targetDate });
       navigate('/dashboard');
-    } catch {
-      toast.error('영업 시작에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, '영업 시작에 실패했습니다. 잠시 후 다시 시도해 주세요.'));
     } finally {
       setIsStarting(false);
     }

--- a/src/shared/api/axiosInstance.ts
+++ b/src/shared/api/axiosInstance.ts
@@ -17,22 +17,70 @@ axiosInstance.interceptors.request.use((config) => {
 
 const AUTH_REQUEST_URLS = ['/auth/login', '/auth/register'];
 
+let isRefreshing = false;
+let failedQueue: Array<{ resolve: (token: string) => void; reject: (err: unknown) => void }> = [];
+
+const processQueue = (error: unknown, token: string | null) => {
+  failedQueue.forEach((p) => (error ? p.reject(error) : p.resolve(token!)));
+  failedQueue = [];
+};
+
+const redirectToLogin = () => {
+  const currentPath = window.location.pathname + window.location.search;
+  const AUTH_PAGE_PREFIXES = ['/login', '/auth/', '/register'];
+  const isAuthPage = AUTH_PAGE_PREFIXES.some((p) => currentPath.startsWith(p));
+  if (!isAuthPage && currentPath !== '/') {
+    sessionStorage.setItem('baro-redirect-after-login', currentPath);
+  }
+  useAuthStore.getState().clearAuth();
+  window.location.href = '/login';
+};
+
 axiosInstance.interceptors.response.use(
   (response) => response,
-  (error) => {
-    const requestUrl: string = error.config?.url ?? '';
+  async (error) => {
+    const originalRequest = error.config;
+    const requestUrl: string = originalRequest?.url ?? '';
     const isRefreshRequest = requestUrl.includes('/auth/refresh');
     const isAuthRequest = AUTH_REQUEST_URLS.some((url) => requestUrl.includes(url));
+
     if (error.response?.status === 401 && !isRefreshRequest && !isAuthRequest) {
-      const currentPath = window.location.pathname + window.location.search;
-      const AUTH_PAGE_PREFIXES = ['/login', '/auth/', '/register'];
-      const isAuthPage = AUTH_PAGE_PREFIXES.some((p) => currentPath.startsWith(p));
-      if (!isAuthPage && currentPath !== '/') {
-        sessionStorage.setItem('baro-redirect-after-login', currentPath);
+      const { refreshToken } = useAuthStore.getState();
+
+      if (!refreshToken) {
+        redirectToLogin();
+        return Promise.reject(error);
       }
-      useAuthStore.getState().clearAuth();
-      window.location.href = '/login';
+
+      if (isRefreshing) {
+        return new Promise((resolve, reject) => {
+          failedQueue.push({ resolve, reject });
+        }).then((token) => {
+          originalRequest.headers.Authorization = `Bearer ${token}`;
+          return axiosInstance(originalRequest);
+        });
+      }
+
+      isRefreshing = true;
+
+      try {
+        const res = await axios.post(`${import.meta.env.VITE_API_BASE_URL}/auth/refresh`, {
+          refreshToken,
+        });
+        const newAccessToken: string = res.data.data.accessToken;
+        useAuthStore.getState().setAccessToken(newAccessToken);
+        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+        processQueue(null, newAccessToken);
+        return axiosInstance(originalRequest);
+      } catch (refreshError) {
+        processQueue(refreshError, null);
+        redirectToLogin();
+        return Promise.reject(refreshError);
+      } finally {
+        isRefreshing = false;
+      }
     }
+
     return Promise.reject(error);
   },
 );

--- a/src/shared/components/IngredientRegisterModal.tsx
+++ b/src/shared/components/IngredientRegisterModal.tsx
@@ -24,6 +24,7 @@ import {
 import { Input } from '@/shadcn/ui/input';
 import { Label } from '@/shadcn/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/shadcn/ui/select';
+import { getApiErrorMessage } from '@/shared/utils/apiError';
 
 type IngredientUnit = 'g' | 'ml' | '개';
 
@@ -125,7 +126,8 @@ const IngredientRegisterModal = ({
   const handleDeleteConversion = (conv: UnitConversionDto) => {
     deleteConversion(conv.id, {
       onSuccess: () => toast.success(`${conv.purchaseUnit} 변환 계수가 삭제되었습니다.`),
-      onError: () => toast.error('삭제에 실패했습니다. 잠시 후 다시 시도해 주세요.'),
+      onError: (err) =>
+        toast.error(getApiErrorMessage(err, '삭제에 실패했습니다. 잠시 후 다시 시도해 주세요.')),
     });
   };
 
@@ -153,7 +155,8 @@ const IngredientRegisterModal = ({
           setIsAddingConversion(false);
           setNewConversion({ purchaseUnit: '', factor: '' });
         },
-        onError: () => toast.error('추가에 실패했습니다. 잠시 후 다시 시도해 주세요.'),
+        onError: (err) =>
+          toast.error(getApiErrorMessage(err, '추가에 실패했습니다. 잠시 후 다시 시도해 주세요.')),
       },
     );
   };

--- a/src/shared/utils/apiError.ts
+++ b/src/shared/utils/apiError.ts
@@ -2,12 +2,22 @@ import axios from 'axios';
 
 import { API_ERROR_MESSAGES, DEFAULT_ERROR_MESSAGE } from '@/shared/constants/errorMessages';
 
+type ApiErrorData = { error?: { code?: string; message?: string } };
+
 export const getApiErrorCode = (err: unknown): string | undefined => {
   if (!axios.isAxiosError(err)) return undefined;
-  return (err.response?.data as { error?: { code?: string } } | undefined)?.error?.code;
+  return (err.response?.data as ApiErrorData | undefined)?.error?.code;
+};
+
+const getApiErrorServerMessage = (err: unknown): string | undefined => {
+  if (!axios.isAxiosError(err)) return undefined;
+  return (err.response?.data as ApiErrorData | undefined)?.error?.message;
 };
 
 export const getApiErrorMessage = (err: unknown, fallback = DEFAULT_ERROR_MESSAGE): string => {
   const code = getApiErrorCode(err);
-  return code ? (API_ERROR_MESSAGES[code] ?? fallback) : fallback;
+  if (code && API_ERROR_MESSAGES[code]) return API_ERROR_MESSAGES[code];
+  const serverMessage = getApiErrorServerMessage(err);
+  if (serverMessage) return serverMessage;
+  return fallback;
 };


### PR DESCRIPTION
## 📌 요약

- v1.1.1 → v1.1.2 패치 배포
- API 에러 메시지 개선, 스크롤 위치 복원, accessToken 자동 갱신, OCR 변환 계수 버그 수정

<br/>

## 🏷️ 관련 이슈

- Closes #201
- Related to #199
- Related to #197
- Related to #193
- Related to #191

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- ♻️ API 에러 응답의 구체적인 메시지를 사용자에게 표시 (#199)
- ✨ 가게 설정 하위 페이지 이동 후 복귀 시 스크롤 위치 복원 (#197)
- 🐛 accessToken 만료 시 자동 갱신 및 요청 재시도 로직 추가 (#193)
- 🐛 OCR 입고 확정 시 변환 계수 문자열 전송 문제 수정 (#191)

<br/>

### 📂 세부 변경사항

- API 에러 응답 메시지를 토스트 등 UI에 직접 노출하도록 refactor
- 가게 설정 하위 페이지에서 뒤로 가기 시 이전 스크롤 위치 복원
- Axios interceptor에서 401 감지 시 refresh token으로 accessToken 재발급 후 원래 요청 재시도
- OCR 입고 확정 API 호출 시 변환 계수(factor)를 문자열이 아닌 숫자로 전송하도록 수정

<br/>

## 📸 Screenshots

| Before | After |
| ------ | ----- |
| -      | -     |

<br/>

## 🧪 테스트 방법

1. accessToken 만료 상황에서 API 호출 시 자동 갱신 후 재시도 확인
2. 가게 설정 하위 페이지 이동 후 뒤로 가기 시 스크롤 위치 복원 확인
3. OCR 입고 확정 정상 처리 확인
4. API 에러 발생 시 구체적인 에러 메시지 표시 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [x] API
- [ ] Database
- [x] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [ ] 빌드 정상 동작 확인
- [ ] 콘솔 에러 없음
- [ ] 불필요한 코드 제거
- [ ] 타입 에러 없음
- [ ] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- 이전 버전 태그: v1.1.1 (문제 발생 시 롤백 기준)