### PR TITLE
🚀 (#211) deploy: v1.2.0 실시간 재고 차감 시스템 개편 배포

### DIFF
--- a/src/app/layouts/AppLayout.tsx
+++ b/src/app/layouts/AppLayout.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 
@@ -8,7 +8,17 @@ import useAuthStore from '@/features/auth/store/authStore';
 import { useClosingHistory } from '@/features/closing/hooks/useClosingHistory';
 import useClosingStore from '@/features/closing/store/closingStore';
 import { useDashboardStats } from '@/features/dashboard/hooks/useDashboardStats';
+import { useOrders } from '@/features/dashboard/hooks/useOrders';
 import { useStoreSettings } from '@/features/store-settings/hooks/useStoreSettings';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/shadcn/ui/alert-dialog';
+import { Button } from '@/shadcn/ui/button';
 import { SidebarInset, SidebarProvider } from '@/shadcn/ui/sidebar';
 import AppHeader from '@/widgets/AppHeader';
 import AppSidebar from '@/widgets/AppSidebar';
@@ -49,11 +59,34 @@ const AppLayout = () => {
     }
   }, [isOpen, pathname, navigate]);
 
+  const [showActiveOrdersWarning, setShowActiveOrdersWarning] = useState(false);
+
   const storeId = useAuthStore((s) => s.storeId);
   const { data: storeData, isLoading: isStoreLoading } = useStoreSettings();
   const { data: userData, isLoading: isUserLoading } = useUserInfo();
   const { data: dashboardStats } = useDashboardStats(isOpen ? storeId : null);
   const { data: closingHistory } = useClosingHistory(isOpen ? storeId : null);
+  const { data: orders = [] } = useOrders(isOpen ? storeId : null);
+  const businessDate = useClosingStore((s) => s.businessSession.businessDate);
+
+  const toKSTDate = (isoString: string) =>
+    new Date(new Date(isoString).getTime() + 9 * 60 * 60 * 1000).toISOString().slice(0, 10);
+
+  const todayOrders = businessDate
+    ? orders.filter((o) => toKSTDate(o.createdAt) === businessDate)
+    : orders;
+
+  const activeOrders = todayOrders.filter(
+    (o) => o.status === 'pending' || o.status === 'preparing',
+  );
+
+  const handleClosingClick = () => {
+    if (activeOrders.length > 0) {
+      setShowActiveOrdersWarning(true);
+    } else {
+      navigate('/closing');
+    }
+  };
 
   // 가게 설정 페이지에 있는 동안 스크롤 위치를 동기적으로 추적
   useEffect(() => {
@@ -110,7 +143,7 @@ const AppLayout = () => {
           userName={userData?.name ?? ''}
           userRole={ROLE_LABEL[storeData?.myRole ?? ''] ?? ''}
           isLoading={isUserLoading || isStoreLoading}
-          onClosingClick={() => navigate('/closing')}
+          onClosingClick={handleClosingClick}
           missedClosing={
             (dashboardStats?.missedClosing ?? false) && (closingHistory?.closings.length ?? 0) > 0
           }
@@ -121,6 +154,43 @@ const AppLayout = () => {
           </div>
         </div>
       </SidebarInset>
+      <AlertDialog open={showActiveOrdersWarning} onOpenChange={setShowActiveOrdersWarning}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>아직 완료되지 않은 주문이 있어요</AlertDialogTitle>
+            <AlertDialogDescription>
+              {activeOrders.filter((o) => o.status === 'pending').length > 0 && (
+                <>
+                  신규 주문{' '}
+                  <strong>{activeOrders.filter((o) => o.status === 'pending').length}건</strong>
+                  {activeOrders.filter((o) => o.status === 'preparing').length > 0 && ', '}
+                </>
+              )}
+              {activeOrders.filter((o) => o.status === 'preparing').length > 0 && (
+                <>
+                  준비 중{' '}
+                  <strong>{activeOrders.filter((o) => o.status === 'preparing').length}건</strong>
+                </>
+              )}
+              이 남아있어요. 마감 전에 주문을 모두 처리해 주세요.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <Button variant="outline" onClick={() => setShowActiveOrdersWarning(false)}>
+              돌아가기
+            </Button>
+            <Button
+              className="bg-baro-blue text-white hover:bg-baro-blue/80"
+              onClick={() => {
+                setShowActiveOrdersWarning(false);
+                navigate('/closing');
+              }}
+            >
+              그래도 마감하기
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </SidebarProvider>
   );
 };

--- a/src/features/closing/components/AfterClosingModal.tsx
+++ b/src/features/closing/components/AfterClosingModal.tsx
@@ -43,9 +43,8 @@ const URGENCY_CONFIG: Record<
   },
   warning: {
     label: '주의',
-    badgeClass:
-      'bg-orange-100 text-orange-600 border border-orange-200 dark:bg-orange-950/40 dark:text-orange-400 dark:border-orange-800/40',
-    borderClass: 'border-l-2 border-l-orange-400',
+    badgeClass: 'bg-baro-red/10 text-baro-red border border-baro-red/20',
+    borderClass: 'border-l-2 border-l-baro-red',
     icon: <AlertTriangle className="w-3 h-3" />,
   },
   recommended: {

--- a/src/features/closing/components/ClosingHistorySheet.tsx
+++ b/src/features/closing/components/ClosingHistorySheet.tsx
@@ -141,12 +141,14 @@ const DetailView = ({ storeId, item, onBack }: DetailViewProps) => {
                 <p className="text-sm text-muted-foreground pl-6">차감된 재고가 없습니다.</p>
               ) : (
                 <div className="rounded-lg border overflow-hidden overflow-x-auto">
-                  <table className="w-full min-w-[280px] text-sm">
+                  <table className="w-full min-w-[400px] text-sm">
                     <thead>
                       <tr className="bg-muted/50 text-muted-foreground">
                         <th className="text-left px-3 py-2 font-medium">식자재</th>
-                        <th className="text-right px-3 py-2 font-medium">사용량</th>
-                        <th className="text-right px-3 py-2 font-medium">차감 후 재고</th>
+                        <th className="text-right px-3 py-2 font-medium">주문 차감</th>
+                        <th className="text-right px-3 py-2 font-medium">실제 사용량</th>
+                        <th className="text-right px-3 py-2 font-medium">보정값</th>
+                        <th className="text-right px-3 py-2 font-medium">마감 후 재고</th>
                       </tr>
                     </thead>
                     <tbody>
@@ -154,7 +156,16 @@ const DetailView = ({ storeId, item, onBack }: DetailViewProps) => {
                         <tr key={deduction.ingredientId} className="border-t">
                           <td className="px-3 py-2.5 font-medium">{deduction.ingredientName}</td>
                           <td className="px-3 py-2.5 text-right text-muted-foreground">
-                            {deduction.usedAmount.toLocaleString('ko-KR')}
+                            {deduction.orderDeductedAmount.toLocaleString('ko-KR')}
+                            {deduction.unit}
+                          </td>
+                          <td className="px-3 py-2.5 text-right">
+                            {deduction.actualUsage.toLocaleString('ko-KR')}
+                            {deduction.unit}
+                          </td>
+                          <td className="px-3 py-2.5 text-right text-muted-foreground">
+                            {deduction.adjustmentAmount > 0 ? '+' : ''}
+                            {deduction.adjustmentAmount.toLocaleString('ko-KR')}
                             {deduction.unit}
                           </td>
                           <td className="px-3 py-2.5 text-right">

--- a/src/features/closing/components/ClosingInventoryDeductionSection.tsx
+++ b/src/features/closing/components/ClosingInventoryDeductionSection.tsx
@@ -1,35 +1,25 @@
-import { Info, Package, Plus, X } from 'lucide-react';
+import { AlertTriangle, Info, Package } from 'lucide-react';
 
-import type { ExtraDeductionRow } from '@/features/closing/components/ClosingExtraDeductionDialog';
 import type { ClosingInventoryDeduction } from '@/features/closing/types/closing.types';
 import { Badge } from '@/shadcn/ui/badge';
-import { Button } from '@/shadcn/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/shadcn/ui/card';
 import { Input } from '@/shadcn/ui/input';
 
-export type { ExtraDeductionRow };
-
 export interface DeductionRow extends ClosingInventoryDeduction {
-  actualUsage: number;
+  remainingStock: number;
 }
 
 interface ClosingInventoryDeductionSectionProps {
   rows: DeductionRow[];
-  onChange: (ingredientId: string, actualUsage: number) => void;
-  extraRows: ExtraDeductionRow[];
-  onAddExtra: () => void;
-  onExtraAmountChange: (ingredientId: string, amount: number) => void;
-  onExtraRemove: (ingredientId: string) => void;
+  onChange: (ingredientId: string, remainingStock: number) => void;
 }
 
 const ClosingInventoryDeductionSection = ({
   rows,
   onChange,
-  extraRows,
-  onAddExtra,
-  onExtraAmountChange,
-  onExtraRemove,
 }: ClosingInventoryDeductionSectionProps) => {
+  const negativeRows = rows.filter((r) => r.isNegative);
+
   return (
     <Card className="pb-0">
       <CardHeader className="pb-3">
@@ -38,299 +28,155 @@ const ClosingInventoryDeductionSection = ({
             <Package className="w-4 h-4 text-muted-foreground" />
             재고 차감 현황
             <span className="text-xs font-normal text-muted-foreground">
-              — {rows.length + extraRows.length}종 식자재
+              — {rows.length}종 식자재
             </span>
           </CardTitle>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="h-7 gap-1 text-xs"
-            onClick={onAddExtra}
-          >
-            <Plus className="w-3 h-3" />
-            추가 차감
-          </Button>
         </div>
         <div className="flex items-start gap-1.5 text-xs text-muted-foreground mt-1">
           <Info className="w-3.5 h-3.5 shrink-0 mt-0.5" />
-          <span>
-            이론 사용량은 레시피 기반 계산값입니다. 실제 사용량이 다르다면 직접 수정하세요.
-          </span>
+          <span>예상 잔량을 확인하고, 실제 남은 재고가 다르다면 직접 수정하세요.</span>
         </div>
+
+        {/* 마이너스 재고 경고 */}
+        {negativeRows.length > 0 && (
+          <div className="flex items-start gap-2 rounded-md bg-baro-red/5 border border-baro-red/30 px-3 py-2 text-xs mt-2">
+            <AlertTriangle className="w-3.5 h-3.5 text-baro-red shrink-0 mt-0.5" />
+            <div>
+              <p className="font-semibold text-baro-red">재고가 마이너스인 항목이 있어요.</p>
+              <p className="text-baro-red/80 mt-0.5">
+                {negativeRows.map((r) => r.ingredientName).join(', ')} — 실제 재고를 확인하고 보정해
+                주세요.
+              </p>
+            </div>
+          </div>
+        )}
       </CardHeader>
       <CardContent className="p-0">
-        {rows.length === 0 && extraRows.length === 0 ? (
+        {rows.length === 0 ? (
           <div className="flex items-center justify-center min-h-24 text-sm text-muted-foreground">
             차감할 재고 항목이 없어요.
           </div>
         ) : (
           <>
-            {rows.length > 0 && (
-              <>
-                <div className="hidden md:grid grid-cols-[2fr_1fr_1fr_1fr_1fr] gap-4 px-5 py-2.5 bg-muted/40 border-t border-b text-xs font-semibold text-muted-foreground uppercase tracking-wide">
-                  <span>식자재명</span>
-                  <span className="text-right">현재 재고</span>
-                  <span className="text-right">이론 사용량</span>
-                  <span className="text-center">실제 사용량</span>
-                  <span className="text-right">차감 후 재고</span>
-                </div>
-                <div className="divide-y max-h-80 overflow-y-auto">
-                  {rows.map((row) => {
-                    const remaining = row.currentStock - row.actualUsage;
-                    const isNegative = remaining < 0;
+            {/* 데스크탑 헤더 */}
+            <div className="hidden md:grid grid-cols-[2fr_1fr_1fr_1fr_1fr] gap-4 px-5 py-2.5 bg-muted/40 border-t border-b text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+              <span>식자재명</span>
+              <span className="text-right">개점 재고</span>
+              <span className="text-right">주문 차감량</span>
+              <span className="text-right">예상 잔량</span>
+              <span className="text-center">실제 잔량</span>
+            </div>
+            <div className="divide-y max-h-80 overflow-y-auto">
+              {rows.map((row) => (
+                <div key={row.ingredientId} className="hover:bg-muted/20 transition-colors">
+                  {/* 데스크탑 행 */}
+                  <div className="hidden md:grid grid-cols-[2fr_1fr_1fr_1fr_1fr] gap-4 px-5 py-4 items-center">
+                    <div className="flex items-center gap-1.5">
+                      <span className="text-sm font-medium">{row.ingredientName}</span>
+                      <span className="text-xs text-muted-foreground">({row.unit})</span>
+                      {row.isNegative && (
+                        <Badge
+                          variant="outline"
+                          className="text-[10px] px-1.5 py-0 h-4 border-baro-red/40 text-baro-red shrink-0"
+                        >
+                          마이너스
+                        </Badge>
+                      )}
+                    </div>
+                    <span className="text-sm text-muted-foreground text-right">
+                      {row.openingStock.toLocaleString()}
+                      {row.unit}
+                    </span>
+                    <span className="text-sm text-muted-foreground text-right">
+                      {row.orderDeductedAmount.toLocaleString()}
+                      {row.unit}
+                    </span>
+                    <span
+                      className={`text-sm font-semibold text-right ${
+                        row.isNegative ? 'text-baro-red' : 'text-foreground'
+                      }`}
+                    >
+                      {row.currentStock.toLocaleString()}
+                      {row.unit}
+                    </span>
+                    <div className="flex items-center gap-1 justify-center">
+                      <Input
+                        type="number"
+                        min={0}
+                        value={row.remainingStock}
+                        onChange={(e) =>
+                          onChange(row.ingredientId, Math.max(0, Number(e.target.value)))
+                        }
+                        className="h-8 w-24 text-sm text-center"
+                      />
+                      <span className="text-xs text-muted-foreground">{row.unit}</span>
+                    </div>
+                  </div>
 
-                    return (
-                      <div key={row.ingredientId} className="hover:bg-muted/20 transition-colors">
-                        {/* 데스크탑 행 */}
-                        <div className="hidden md:grid grid-cols-[2fr_1fr_1fr_1fr_1fr] gap-4 px-5 py-4 items-center">
-                          <div>
-                            <span className="text-sm font-medium">{row.ingredientName}</span>
-                            <span className="ml-1.5 text-xs text-muted-foreground">
-                              ({row.unit})
-                            </span>
-                          </div>
-                          <span className="text-sm text-muted-foreground text-right">
-                            {row.currentStock.toLocaleString()}
-                            {row.unit}
-                          </span>
-                          <span className="text-sm text-muted-foreground text-right">
-                            {row.theoreticalUsage.toLocaleString()}
-                            {row.unit}
-                          </span>
-                          <div className="flex items-center gap-1 justify-center">
-                            <Input
-                              type="number"
-                              min={0}
-                              value={row.actualUsage}
-                              onChange={(e) =>
-                                onChange(row.ingredientId, Math.max(0, Number(e.target.value)))
-                              }
-                              className="h-8 w-24 text-sm text-center"
-                            />
-                            <span className="text-xs text-muted-foreground">{row.unit}</span>
-                          </div>
-                          <span
-                            className={`text-sm font-semibold text-right ${isNegative ? 'text-baro-red' : 'text-foreground'}`}
+                  {/* 모바일 카드 */}
+                  <div className="md:hidden px-4 py-3 space-y-1.5">
+                    <div className="flex items-center justify-between gap-2">
+                      <div className="flex items-center gap-1 min-w-0">
+                        <span className="text-sm font-medium truncate">{row.ingredientName}</span>
+                        <span className="text-xs text-muted-foreground shrink-0">({row.unit})</span>
+                        {row.isNegative && (
+                          <Badge
+                            variant="outline"
+                            className="text-[10px] px-1.5 py-0 h-4 border-baro-red/40 text-baro-red shrink-0"
                           >
-                            {remaining.toLocaleString()}
+                            마이너스
+                          </Badge>
+                        )}
+                      </div>
+                      <div className="text-right shrink-0">
+                        <p className="text-[10px] text-muted-foreground">예상 잔량</p>
+                        <p
+                          className={`text-sm font-semibold ${
+                            row.isNegative ? 'text-baro-red' : 'text-foreground'
+                          }`}
+                        >
+                          {row.currentStock.toLocaleString()}
+                          {row.unit}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="grid grid-cols-3 gap-2 pt-0.5 text-xs text-muted-foreground">
+                      <div>
+                        <p className="text-[10px] mb-0.5">개점 재고</p>
+                        <p>
+                          {row.openingStock.toLocaleString()}
+                          {row.unit}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-[10px] mb-0.5">주문 차감</p>
+                        <p>
+                          {row.orderDeductedAmount.toLocaleString()}
+                          {row.unit}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-[10px] mb-0.5">실제 잔량</p>
+                        <div className="flex items-center gap-1">
+                          <Input
+                            type="number"
+                            min={0}
+                            value={row.remainingStock}
+                            onChange={(e) =>
+                              onChange(row.ingredientId, Math.max(0, Number(e.target.value)))
+                            }
+                            className="h-7 w-full text-xs text-center"
+                          />
+                          <span className="text-[10px] text-muted-foreground shrink-0">
                             {row.unit}
-                            {isNegative && (
-                              <span className="ml-1 text-xs font-normal text-baro-red">(부족)</span>
-                            )}
                           </span>
                         </div>
-                        {/* 모바일 카드 */}
-                        <div className="md:hidden px-4 py-3 space-y-1.5">
-                          <div className="flex items-center justify-between gap-2">
-                            <div className="flex items-center gap-1 min-w-0">
-                              <span className="text-sm font-medium truncate">
-                                {row.ingredientName}
-                              </span>
-                              <span className="text-xs text-muted-foreground shrink-0">
-                                ({row.unit})
-                              </span>
-                            </div>
-                            <div className="text-right shrink-0">
-                              <p className="text-[10px] text-muted-foreground">차감 후 재고</p>
-                              <p
-                                className={`text-sm font-semibold ${isNegative ? 'text-baro-red' : 'text-foreground'}`}
-                              >
-                                {remaining.toLocaleString()}
-                                {row.unit}
-                                {isNegative && (
-                                  <span className="ml-1 text-xs font-normal">(부족)</span>
-                                )}
-                              </p>
-                            </div>
-                          </div>
-                          <p className="text-xs text-muted-foreground">
-                            현재 {row.currentStock.toLocaleString()}
-                            {row.unit}
-                          </p>
-                          <div className="grid grid-cols-2 gap-2 pt-0.5">
-                            <div>
-                              <p className="text-[10px] text-muted-foreground mb-1">이론 사용량</p>
-                              <p className="text-sm text-muted-foreground">
-                                {row.theoreticalUsage.toLocaleString()}
-                                {row.unit}
-                              </p>
-                            </div>
-                            <div>
-                              <p className="text-[10px] text-muted-foreground mb-1">실제 사용량</p>
-                              <div className="flex items-center gap-1">
-                                <Input
-                                  type="number"
-                                  min={0}
-                                  value={row.actualUsage}
-                                  onChange={(e) =>
-                                    onChange(row.ingredientId, Math.max(0, Number(e.target.value)))
-                                  }
-                                  className="h-8 w-full text-sm text-center"
-                                />
-                                <span className="text-xs text-muted-foreground shrink-0">
-                                  {row.unit}
-                                </span>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
                       </div>
-                    );
-                  })}
+                    </div>
+                  </div>
                 </div>
-              </>
-            )}
-
-            {/* 추가 차감 행 */}
-            {extraRows.length > 0 && (
-              <>
-                <div className="flex items-center gap-2 px-5 py-2 bg-red-50/60 dark:bg-red-950/20 border-t border-b">
-                  <span className="text-xs font-semibold text-baro-red uppercase tracking-wide">
-                    추가 차감
-                  </span>
-                </div>
-                <div className="divide-y max-h-48 overflow-y-auto">
-                  {extraRows.map((row) => {
-                    const remaining = row.currentStock - row.amount;
-                    const isNegative = remaining < 0;
-
-                    return (
-                      <div key={row.ingredientId} className="hover:bg-muted/20 transition-colors">
-                        {/* 데스크탑 행 */}
-                        <div className="hidden md:grid grid-cols-[2fr_1fr_1fr_1fr_1fr] gap-4 px-5 py-4 items-center">
-                          <div className="flex items-center gap-2">
-                            <span className="text-sm font-medium">{row.ingredientName}</span>
-                            <span className="text-xs text-muted-foreground">({row.unit})</span>
-                            <Badge
-                              variant="outline"
-                              className="text-[10px] px-1.5 py-0 h-4 border-baro-red/30 text-baro-red shrink-0"
-                            >
-                              추가
-                            </Badge>
-                          </div>
-                          <span className="text-sm text-muted-foreground text-right">
-                            {row.currentStock.toLocaleString()}
-                            {row.unit}
-                          </span>
-                          <span className="text-sm text-muted-foreground text-right">—</span>
-                          <div className="flex items-center gap-1 justify-center">
-                            <Input
-                              type="number"
-                              min={0.001}
-                              step="any"
-                              value={row.amount}
-                              onChange={(e) =>
-                                onExtraAmountChange(
-                                  row.ingredientId,
-                                  Math.max(0, Number(e.target.value)),
-                                )
-                              }
-                              className="h-8 w-24 text-sm text-center"
-                            />
-                            <span className="text-xs text-muted-foreground">{row.unit}</span>
-                          </div>
-                          <div className="flex items-center gap-2 justify-end">
-                            <span
-                              className={`text-sm font-semibold ${isNegative ? 'text-baro-red' : 'text-foreground'}`}
-                            >
-                              {remaining.toLocaleString()}
-                              {row.unit}
-                              {isNegative && (
-                                <span className="ml-1 text-xs font-normal text-baro-red">
-                                  (부족)
-                                </span>
-                              )}
-                            </span>
-                            <Button
-                              type="button"
-                              size="icon"
-                              variant="ghost"
-                              className="h-7 w-7 text-muted-foreground hover:text-baro-red hover:bg-red-50 shrink-0"
-                              onClick={() => onExtraRemove(row.ingredientId)}
-                            >
-                              <X className="w-3 h-3" />
-                            </Button>
-                          </div>
-                        </div>
-                        {/* 모바일 카드 */}
-                        <div className="md:hidden px-4 py-3 space-y-1.5">
-                          <div className="flex items-center justify-between gap-2">
-                            <div className="flex items-center gap-1 min-w-0">
-                              <span className="text-sm font-medium truncate">
-                                {row.ingredientName}
-                              </span>
-                              <span className="text-xs text-muted-foreground shrink-0">
-                                ({row.unit})
-                              </span>
-                              <Badge
-                                variant="outline"
-                                className="text-[10px] px-1.5 py-0 h-4 border-baro-red/30 text-baro-red shrink-0"
-                              >
-                                추가
-                              </Badge>
-                            </div>
-                            <div className="flex items-center gap-1 shrink-0">
-                              <div className="text-right">
-                                <p className="text-[10px] text-muted-foreground">차감 후 재고</p>
-                                <p
-                                  className={`text-sm font-semibold ${isNegative ? 'text-baro-red' : 'text-foreground'}`}
-                                >
-                                  {remaining.toLocaleString()}
-                                  {row.unit}
-                                  {isNegative && (
-                                    <span className="ml-1 text-xs font-normal">(부족)</span>
-                                  )}
-                                </p>
-                              </div>
-                              <Button
-                                type="button"
-                                size="icon"
-                                variant="ghost"
-                                className="h-7 w-7 text-muted-foreground hover:text-baro-red hover:bg-red-50"
-                                onClick={() => onExtraRemove(row.ingredientId)}
-                              >
-                                <X className="w-3 h-3" />
-                              </Button>
-                            </div>
-                          </div>
-                          <div className="grid grid-cols-2 gap-2 pt-0.5">
-                            <div>
-                              <p className="text-[10px] text-muted-foreground mb-1">현재 재고</p>
-                              <p className="text-sm text-muted-foreground">
-                                {row.currentStock.toLocaleString()}
-                                {row.unit}
-                              </p>
-                            </div>
-                            <div>
-                              <p className="text-[10px] text-muted-foreground mb-1">사용량</p>
-                              <div className="flex items-center gap-1">
-                                <Input
-                                  type="number"
-                                  min={0.001}
-                                  step="any"
-                                  value={row.amount}
-                                  onChange={(e) =>
-                                    onExtraAmountChange(
-                                      row.ingredientId,
-                                      Math.max(0, Number(e.target.value)),
-                                    )
-                                  }
-                                  className="h-8 w-full text-sm text-center"
-                                />
-                                <span className="text-xs text-muted-foreground shrink-0">
-                                  {row.unit}
-                                </span>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
-              </>
-            )}
+              ))}
+            </div>
           </>
         )}
       </CardContent>

--- a/src/features/closing/types/closing.types.ts
+++ b/src/features/closing/types/closing.types.ts
@@ -10,8 +10,10 @@ export interface ClosingInventoryDeduction {
   ingredientId: string;
   ingredientName: string;
   unit: 'g' | 'ml' | '개';
-  theoreticalUsage: number;
+  openingStock: number;
+  orderDeductedAmount: number;
   currentStock: number;
+  isNegative: boolean;
 }
 
 export interface ClosingPreview {
@@ -25,7 +27,7 @@ export interface ClosingPreview {
 
 export interface ClosingDeductionItem {
   ingredientId: string;
-  actualUsage: number;
+  remainingStock: number;
 }
 
 export interface ClosingRequest {
@@ -37,7 +39,9 @@ export interface ClosingDeductionResult {
   ingredientId: string;
   ingredientName: string;
   unit: string;
-  usedAmount: number;
+  orderDeductedAmount: number;
+  actualUsage: number;
+  adjustmentAmount: number;
   remainingStock: number;
 }
 
@@ -92,7 +96,9 @@ export interface ClosingDetailInventoryDeduction {
   ingredientId: string;
   ingredientName: string;
   unit: 'g' | 'ml' | '개';
-  usedAmount: number;
+  orderDeductedAmount: number;
+  actualUsage: number;
+  adjustmentAmount: number;
   remainingStock: number;
 }
 

--- a/src/features/customer-order/api/menu.api.ts
+++ b/src/features/customer-order/api/menu.api.ts
@@ -5,6 +5,11 @@ import type {
 } from '@/features/customer-order/types/customerOrder.api.types';
 import publicAxiosInstance from '@/shared/api/publicAxiosInstance';
 
+export const fetchPublicStoreOpenStatus = (storeId: string): Promise<{ isOpen: boolean }> =>
+  publicAxiosInstance
+    .get<{ success: boolean; data: { isOpen: boolean } }>(`/stores/${storeId}/open/status`)
+    .then((res) => res.data.data);
+
 // ⚠️ GET /stores/:storeId/menus 는 현재 백엔드에서 인증 필수.
 // 손님(비회원) 접근을 위해 백엔드에 공개 엔드포인트 추가 필요.
 export const fetchStoreMenus = (storeId: string): Promise<ApiMenu[]> =>

--- a/src/features/customer-order/components/CustomerOrderStatusBadge.tsx
+++ b/src/features/customer-order/components/CustomerOrderStatusBadge.tsx
@@ -1,8 +1,14 @@
 import type { OrderStatus } from '@/features/customer-order/types/customerOrder.types';
 
 const STATUS_CONFIG: Record<OrderStatus, { label: string; className: string }> = {
-  pending: { label: '신규 주문', className: 'bg-baro-yellow/10 text-baro-yellow-text' },
-  preparing: { label: '준비중', className: 'bg-sky-50 text-sky-500' },
+  pending: {
+    label: '신규 주문',
+    className: 'bg-baro-green/10 text-baro-green border border-baro-green/50',
+  },
+  preparing: {
+    label: '준비중',
+    className: 'bg-baro-green/10 text-baro-green border border-baro-green/50',
+  },
   completed: { label: '완료', className: 'bg-slate-100 text-slate-400' },
   cancelled: { label: '취소', className: 'bg-zinc-100 text-zinc-400' },
 };

--- a/src/features/customer-order/components/CustomerOrderStatusCard.tsx
+++ b/src/features/customer-order/components/CustomerOrderStatusCard.tsx
@@ -1,12 +1,21 @@
 import { useState } from 'react';
 
-import { Clock, ShoppingBag } from 'lucide-react';
+import { AlertTriangle, Clock, ShoppingBag } from 'lucide-react';
 
 import useClosingStore from '@/features/closing/store/closingStore';
 import OrderStatusBadge from '@/features/customer-order/components/CustomerOrderStatusBadge';
 import type { ApiOrder } from '@/features/customer-order/types/customerOrder.api.types';
 import { useOrders, useUpdateOrderStatus } from '@/features/dashboard/hooks/useOrders';
 import { useOrderSSE } from '@/features/dashboard/hooks/useOrderSSE';
+import useOrderWarningsStore from '@/features/dashboard/store/orderWarningsStore';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/shadcn/ui/alert-dialog';
 import { Button } from '@/shadcn/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/shadcn/ui/card';
 import { Skeleton } from '@/shadcn/ui/skeleton';
@@ -32,14 +41,55 @@ const formatTimeAgo = (isoString: string): string => {
   return `${Math.floor(diffMin / 60)}시간 전`;
 };
 
+/* ── 완료 주문 취소 모달 ── */
+interface CancelCompletedOrderModalProps {
+  open: boolean;
+  onConfirm: (restoreStock: boolean) => void;
+  onClose: () => void;
+}
+
+const CancelCompletedOrderModal = ({
+  open,
+  onConfirm,
+  onClose,
+}: CancelCompletedOrderModalProps) => (
+  <AlertDialog open={open} onOpenChange={(o) => !o && onClose()}>
+    <AlertDialogContent>
+      <AlertDialogHeader>
+        <AlertDialogTitle>완료된 주문을 취소할까요?</AlertDialogTitle>
+        <AlertDialogDescription>
+          취소 방식을 선택해 주세요. 재고 복원은 수락 시 차감된 재고를 되돌립니다.
+        </AlertDialogDescription>
+      </AlertDialogHeader>
+      <AlertDialogFooter className="flex-col gap-2 sm:flex-col">
+        <Button variant="outline" className="w-full" onClick={() => onConfirm(true)}>
+          재고도 복원
+        </Button>
+        <Button
+          variant="outline"
+          className="w-full text-muted-foreground"
+          onClick={() => onConfirm(false)}
+        >
+          매출에서만 제외
+        </Button>
+        <Button variant="ghost" className="w-full" onClick={onClose}>
+          돌아가기
+        </Button>
+      </AlertDialogFooter>
+    </AlertDialogContent>
+  </AlertDialog>
+);
+
 /* ── 개별 주문 카드 ── */
 interface OrderCardProps {
   order: ApiOrder;
   storeId: string;
+  onCancelCompleted: (orderId: string) => void;
 }
 
-const OrderCard = ({ order, storeId }: OrderCardProps) => {
+const OrderCard = ({ order, storeId, onCancelCompleted }: OrderCardProps) => {
   const { mutate: changeStatus, isPending } = useUpdateOrderStatus(storeId);
+  const stockWarnings = useOrderWarningsStore((s) => s.warnings[order.id]);
 
   const itemSummary = order.items?.map((i) => `${i.menu.name} x${i.quantity}`).join(' · ') ?? '';
 
@@ -58,6 +108,25 @@ const OrderCard = ({ order, storeId }: OrderCardProps) => {
           {formatTimeAgo(order.createdAt)}
         </div>
       </div>
+
+      {/* 재고 부족 경고 배너 */}
+      {stockWarnings && stockWarnings.length > 0 && (
+        <div className="flex items-start gap-2 rounded-md bg-baro-red/5 border border-baro-red/30 px-3 py-2 text-xs">
+          <AlertTriangle className="size-3.5 text-baro-red shrink-0 mt-0.5" />
+          <div>
+            <p className="font-semibold text-baro-red">사장님! 수락 전 확인해 주세요.</p>
+            <p className="text-baro-red/80 mt-0.5">
+              {stockWarnings
+                .map(
+                  (w) =>
+                    `${w.ingredientName} (필요 ${w.required}${w.unit}, 현재 ${w.currentStock}${w.unit})`,
+                )
+                .join(', ')}
+              이 부족해요.
+            </p>
+          </div>
+        </div>
+      )}
 
       {itemSummary && <p className="text-xs text-muted-foreground line-clamp-2">{itemSummary}</p>}
 
@@ -90,13 +159,35 @@ const OrderCard = ({ order, storeId }: OrderCardProps) => {
             </>
           )}
           {order.status === 'preparing' && (
+            <>
+              <Button
+                size="sm"
+                className="h-7 px-2.5 text-xs bg-baro-blue text-white hover:bg-baro-blue/80"
+                disabled={isPending}
+                onClick={() => changeStatus({ orderId: order.id, status: 'completed' })}
+              >
+                완료처리
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-7 px-2.5 text-xs"
+                disabled={isPending}
+                onClick={() => changeStatus({ orderId: order.id, status: 'cancelled' })}
+              >
+                취소
+              </Button>
+            </>
+          )}
+          {order.status === 'completed' && (
             <Button
               size="sm"
-              className="h-7 px-2.5 text-xs bg-slate-600 text-white hover:bg-slate-700"
+              variant="outline"
+              className="h-7 px-2.5 text-xs text-muted-foreground"
               disabled={isPending}
-              onClick={() => changeStatus({ orderId: order.id, status: 'completed' })}
+              onClick={() => onCancelCompleted(order.id)}
             >
-              완료처리
+              취소
             </Button>
           )}
         </div>
@@ -112,79 +203,105 @@ interface OrderStatusCardProps {
 
 const OrderStatusCard = ({ storeId }: OrderStatusCardProps) => {
   const [activeTab, setActiveTab] = useState<TabKey>('pending');
+  const [cancelTarget, setCancelTarget] = useState<string | null>(null);
   const { data: rawOrders = [], isLoading } = useOrders(storeId);
+  const { mutate: changeStatus } = useUpdateOrderStatus(storeId);
   const businessDate = useClosingStore((s) => s.businessSession.businessDate);
 
   useOrderSSE(storeId);
 
-  // 당일 개점 이후 접수된 주문만 표시
+  // 당일 개점 이후 접수된 주문만 표시 (createdAt은 UTC이므로 KST로 변환 후 비교)
+  const toKSTDate = (isoString: string) =>
+    new Date(new Date(isoString).getTime() + 9 * 60 * 60 * 1000).toISOString().slice(0, 10);
+
   const orders = businessDate
-    ? rawOrders.filter((o) => o.createdAt.slice(0, 10) === businessDate)
+    ? rawOrders.filter((o) => toKSTDate(o.createdAt) === businessDate)
     : rawOrders;
 
   const pendingCount = orders.filter((o) => o.status === 'pending').length;
   const filteredOrders = orders.filter((o) => o.status === activeTab);
 
+  const handleCancelCompleted = (restoreStock: boolean) => {
+    if (!cancelTarget) return;
+    changeStatus({ orderId: cancelTarget, status: 'cancelled', restoreStock });
+    setCancelTarget(null);
+  };
+
   return (
-    <Card className="h-full flex flex-col overflow-hidden">
-      <CardHeader className="border-b shrink-0">
-        <CardTitle className="text-sm flex items-center gap-2">
-          <ShoppingBag className="size-4 text-muted-foreground" />
-          오늘 주문 현황
-          {pendingCount > 0 && (
-            <span className="flex size-5 items-center justify-center rounded-full bg-baro-yellow text-xs font-bold text-white">
-              {pendingCount}
-            </span>
+    <>
+      <Card className="h-full flex flex-col overflow-hidden">
+        <CardHeader className="border-b shrink-0">
+          <CardTitle className="text-sm flex items-center gap-2">
+            <ShoppingBag className="size-4 text-muted-foreground" />
+            오늘 주문 현황
+            {pendingCount > 0 && (
+              <span className="flex size-5 items-center justify-center rounded-full bg-baro-yellow text-xs font-bold text-white">
+                {pendingCount}
+              </span>
+            )}
+          </CardTitle>
+        </CardHeader>
+
+        <div className="flex border-b shrink-0">
+          {TABS.map((tab) => {
+            const count = orders.filter((o) => o.status === tab.key).length;
+            const isActive = activeTab === tab.key;
+            return (
+              <button
+                key={tab.key}
+                onClick={() => setActiveTab(tab.key)}
+                className={`flex-1 py-2 text-xs font-medium transition-colors ${
+                  isActive
+                    ? 'border-b-2 border-baro-blue text-baro-blue'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                {tab.label}
+                {count > 0 && (
+                  <span
+                    className={`ml-1 rounded-full px-1.5 py-0.5 text-xs ${
+                      isActive ? 'bg-baro-blue/10 text-baro-blue' : 'bg-muted text-muted-foreground'
+                    }`}
+                  >
+                    {count}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+
+        <CardContent className="flex-1 overflow-y-auto p-3 space-y-2">
+          {isLoading ? (
+            Array.from({ length: 3 }).map((_, i) => (
+              <Skeleton key={i} className="h-24 w-full rounded-lg" />
+            ))
+          ) : filteredOrders.length === 0 ? (
+            <div className="flex flex-col items-center justify-center h-32 text-muted-foreground">
+              <ShoppingBag className="size-8 mb-2 opacity-25" />
+              <p className="text-xs">{EMPTY_MESSAGE[activeTab]}</p>
+            </div>
+          ) : (
+            filteredOrders.map((order) =>
+              storeId ? (
+                <OrderCard
+                  key={order.id}
+                  order={order}
+                  storeId={storeId}
+                  onCancelCompleted={setCancelTarget}
+                />
+              ) : null,
+            )
           )}
-        </CardTitle>
-      </CardHeader>
+        </CardContent>
+      </Card>
 
-      <div className="flex border-b shrink-0">
-        {TABS.map((tab) => {
-          const count = orders.filter((o) => o.status === tab.key).length;
-          const isActive = activeTab === tab.key;
-          return (
-            <button
-              key={tab.key}
-              onClick={() => setActiveTab(tab.key)}
-              className={`flex-1 py-2 text-xs font-medium transition-colors ${
-                isActive
-                  ? 'border-b-2 border-baro-blue text-baro-blue'
-                  : 'text-muted-foreground hover:text-foreground'
-              }`}
-            >
-              {tab.label}
-              {count > 0 && (
-                <span
-                  className={`ml-1 rounded-full px-1.5 py-0.5 text-xs ${
-                    isActive ? 'bg-baro-blue/10 text-baro-blue' : 'bg-muted text-muted-foreground'
-                  }`}
-                >
-                  {count}
-                </span>
-              )}
-            </button>
-          );
-        })}
-      </div>
-
-      <CardContent className="flex-1 overflow-y-auto p-3 space-y-2">
-        {isLoading ? (
-          Array.from({ length: 3 }).map((_, i) => (
-            <Skeleton key={i} className="h-24 w-full rounded-lg" />
-          ))
-        ) : filteredOrders.length === 0 ? (
-          <div className="flex flex-col items-center justify-center h-32 text-muted-foreground">
-            <ShoppingBag className="size-8 mb-2 opacity-25" />
-            <p className="text-xs">{EMPTY_MESSAGE[activeTab]}</p>
-          </div>
-        ) : (
-          filteredOrders.map((order) =>
-            storeId ? <OrderCard key={order.id} order={order} storeId={storeId} /> : null,
-          )
-        )}
-      </CardContent>
-    </Card>
+      <CancelCompletedOrderModal
+        open={cancelTarget !== null}
+        onConfirm={handleCancelCompleted}
+        onClose={() => setCancelTarget(null)}
+      />
+    </>
   );
 };
 

--- a/src/features/customer-order/types/customerOrder.api.types.ts
+++ b/src/features/customer-order/types/customerOrder.api.types.ts
@@ -67,4 +67,22 @@ export interface CreateOrderRequest {
 
 export interface UpdateOrderStatusRequest {
   status: 'preparing' | 'completed' | 'cancelled';
+  restoreStock?: boolean;
+}
+
+export interface StockWarning {
+  ingredientName: string;
+  required: number;
+  currentStock: number;
+  unit: 'g' | 'ml' | '개';
+}
+
+export interface SseNewOrderPayload {
+  id: string;
+  storeId: string;
+  tableNumber: number;
+  status: ApiOrderStatus;
+  totalPrice: number;
+  items?: ApiOrderItem[];
+  stockWarnings: StockWarning[];
 }

--- a/src/features/dashboard/api/order.api.ts
+++ b/src/features/dashboard/api/order.api.ts
@@ -13,10 +13,14 @@ export const updateOrderStatus = (
   storeId: string,
   orderId: string,
   status: UpdateOrderStatusRequest['status'],
+  restoreStock?: boolean,
 ): Promise<ApiOrder> =>
   axiosInstance
     .patch<{
       success: boolean;
       data: ApiOrder;
-    }>(`/stores/${storeId}/orders/${orderId}/status`, { status })
+    }>(`/stores/${storeId}/orders/${orderId}/status`, {
+      status,
+      ...(restoreStock !== undefined && { restoreStock }),
+    })
     .then((res) => res.data.data);

--- a/src/features/dashboard/components/TodayStatusSection.tsx
+++ b/src/features/dashboard/components/TodayStatusSection.tsx
@@ -35,8 +35,8 @@ const TodayStatusSection = ({ stats, onClosingClick }: TodayStatusSectionProps) 
         <StatItem
           label="전체 재고 개수"
           value={`${stats.totalInventory.toLocaleString()} 개`}
-          iconBg="bg-orange-100"
-          icon={<Package className="w-6 h-6 text-orange-400" />}
+          iconBg="bg-baro-red/10"
+          icon={<Package className="w-6 h-6 text-baro-red" />}
           subtitle={`마지막 업데이트  ${stats.lastUpdated}`}
         />
         <StatItem

--- a/src/features/dashboard/hooks/useOrderSSE.ts
+++ b/src/features/dashboard/hooks/useOrderSSE.ts
@@ -3,6 +3,8 @@ import { useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 
 import useAuthStore from '@/features/auth/store/authStore';
+import type { SseNewOrderPayload } from '@/features/customer-order/types/customerOrder.api.types';
+import useOrderWarningsStore from '@/features/dashboard/store/orderWarningsStore';
 
 // EventSource는 커스텀 헤더를 지원하지 않으므로 fetch + ReadableStream으로 SSE 연결
 export const useOrderSSE = (storeId: string | null) => {
@@ -43,7 +45,17 @@ export const useOrderSSE = (storeId: string | null) => {
             if (line.startsWith('event: ')) {
               eventType = line.slice(7).trim();
             } else if (line.startsWith('data: ')) {
-              if (eventType === 'new-order' || eventType === 'order-status-changed') {
+              if (eventType === 'new-order') {
+                try {
+                  const payload = JSON.parse(line.slice(6)) as SseNewOrderPayload;
+                  if (payload.stockWarnings?.length) {
+                    useOrderWarningsStore.getState().setWarnings(payload.id, payload.stockWarnings);
+                  }
+                } catch {
+                  // 파싱 실패 시 무시
+                }
+                queryClient.invalidateQueries({ queryKey: ['orders', storeId] });
+              } else if (eventType === 'order-status-changed') {
                 queryClient.invalidateQueries({ queryKey: ['orders', storeId] });
               }
               eventType = '';

--- a/src/features/dashboard/hooks/useOrders.ts
+++ b/src/features/dashboard/hooks/useOrders.ts
@@ -16,10 +16,12 @@ export const useUpdateOrderStatus = (storeId: string | null) => {
     mutationFn: ({
       orderId,
       status,
+      restoreStock,
     }: {
       orderId: string;
       status: UpdateOrderStatusRequest['status'];
-    }) => updateOrderStatus(storeId!, orderId, status),
+      restoreStock?: boolean;
+    }) => updateOrderStatus(storeId!, orderId, status, restoreStock),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['orders', storeId] }),
   });
 };

--- a/src/features/dashboard/store/orderWarningsStore.ts
+++ b/src/features/dashboard/store/orderWarningsStore.ts
@@ -1,0 +1,23 @@
+import { create } from 'zustand';
+
+import type { StockWarning } from '@/features/customer-order/types/customerOrder.api.types';
+
+interface OrderWarningsState {
+  warnings: Record<string, StockWarning[]>;
+  setWarnings: (orderId: string, warnings: StockWarning[]) => void;
+  clearWarnings: (orderId: string) => void;
+}
+
+const useOrderWarningsStore = create<OrderWarningsState>((set) => ({
+  warnings: {},
+  setWarnings: (orderId, warnings) =>
+    set((state) => ({ warnings: { ...state.warnings, [orderId]: warnings } })),
+  clearWarnings: (orderId) =>
+    set((state) => {
+      const next = { ...state.warnings };
+      delete next[orderId];
+      return { warnings: next };
+    }),
+}));
+
+export default useOrderWarningsStore;

--- a/src/features/order-guide/components/OrderGuideList.tsx
+++ b/src/features/order-guide/components/OrderGuideList.tsx
@@ -40,9 +40,8 @@ const URGENCY_CONFIG: Record<
   },
   warning: {
     label: '주의',
-    badgeClass:
-      'bg-orange-100 text-orange-600 border border-orange-200 dark:bg-orange-950/40 dark:text-orange-400',
-    rowClass: 'border-l-4 border-l-orange-400',
+    badgeClass: 'bg-baro-red/10 text-baro-red border border-baro-red/20',
+    rowClass: 'border-l-4 border-l-baro-red',
     icon: <AlertTriangle className="w-3.5 h-3.5" />,
   },
   recommended: {

--- a/src/pages/ClosingPage.tsx
+++ b/src/pages/ClosingPage.tsx
@@ -7,9 +7,6 @@ import { toast } from 'sonner';
 
 import useAuthStore from '@/features/auth/store/authStore';
 import AfterClosingModal from '@/features/closing/components/AfterClosingModal';
-import ClosingExtraDeductionDialog, {
-  type ExtraDeductionRow,
-} from '@/features/closing/components/ClosingExtraDeductionDialog';
 import ClosingInventoryDeductionSection, {
   type DeductionRow,
 } from '@/features/closing/components/ClosingInventoryDeductionSection';
@@ -54,8 +51,6 @@ const ClosingPage = () => {
   const { data: preview, isLoading, isError } = useClosingPreview(storeId, dateParam);
 
   const [deductionRows, setDeductionRows] = useState<DeductionRow[]>([]);
-  const [extraDeductions, setExtraDeductions] = useState<ExtraDeductionRow[]>([]);
-  const [extraDialogOpen, setExtraDialogOpen] = useState(false);
   const [afterModalOpen, setAfterModalOpen] = useState(false);
   const [alreadyClosedModalOpen, setAlreadyClosedModalOpen] = useState(false);
   const [finalRevenue, setFinalRevenue] = useState(0);
@@ -69,39 +64,16 @@ const ClosingPage = () => {
     setDeductionRows(
       preview.inventoryDeductions.map((d) => ({
         ...d,
-        actualUsage: d.theoreticalUsage,
+        remainingStock: d.currentStock,
       })),
     );
     setIsInitialized(true);
   }
 
-  const handleDeductionChange = (ingredientId: string, actualUsage: number) => {
+  const handleDeductionChange = (ingredientId: string, remainingStock: number) => {
     setDeductionRows((prev) =>
-      prev.map((row) => (row.ingredientId === ingredientId ? { ...row, actualUsage } : row)),
+      prev.map((row) => (row.ingredientId === ingredientId ? { ...row, remainingStock } : row)),
     );
-  };
-
-  const handleAddExtra = (row: ExtraDeductionRow) => {
-    setExtraDeductions((prev) => {
-      const exists = prev.find((r) => r.ingredientId === row.ingredientId);
-      if (exists) {
-        return prev.map((r) =>
-          r.ingredientId === row.ingredientId ? { ...r, amount: r.amount + row.amount } : r,
-        );
-      }
-      return [...prev, row];
-    });
-    setExtraDialogOpen(false);
-  };
-
-  const handleExtraAmountChange = (ingredientId: string, amount: number) => {
-    setExtraDeductions((prev) =>
-      prev.map((r) => (r.ingredientId === ingredientId ? { ...r, amount } : r)),
-    );
-  };
-
-  const handleExtraRemove = (ingredientId: string) => {
-    setExtraDeductions((prev) => prev.filter((r) => r.ingredientId !== ingredientId));
   };
 
   const handleComplete = () => {
@@ -112,20 +84,12 @@ const ClosingPage = () => {
       return;
     }
 
-    const merged = new Map<string, number>();
-    deductionRows.forEach(({ ingredientId, actualUsage }) => {
-      merged.set(ingredientId, (merged.get(ingredientId) ?? 0) + actualUsage);
-    });
-    extraDeductions.forEach(({ ingredientId, amount }) => {
-      merged.set(ingredientId, (merged.get(ingredientId) ?? 0) + amount);
-    });
-
     submitClosing(
       {
         date: preview.date,
-        inventoryDeductions: Array.from(merged.entries()).map(([ingredientId, actualUsage]) => ({
+        inventoryDeductions: deductionRows.map(({ ingredientId, remainingStock }) => ({
           ingredientId,
-          actualUsage,
+          remainingStock,
         })),
       },
       {
@@ -225,14 +189,7 @@ const ClosingPage = () => {
           <ClosingSoldMenusSection menus={preview.soldMenus} />
 
           {/* 재고 차감 섹션 */}
-          <ClosingInventoryDeductionSection
-            rows={deductionRows}
-            onChange={handleDeductionChange}
-            extraRows={extraDeductions}
-            onAddExtra={() => setExtraDialogOpen(true)}
-            onExtraAmountChange={handleExtraAmountChange}
-            onExtraRemove={handleExtraRemove}
-          />
+          <ClosingInventoryDeductionSection rows={deductionRows} onChange={handleDeductionChange} />
         </div>
 
         {/* 하단 버튼 — sticky */}
@@ -257,12 +214,6 @@ const ClosingPage = () => {
           )}
         </div>
       </div>
-
-      <ClosingExtraDeductionDialog
-        open={extraDialogOpen}
-        onClose={() => setExtraDialogOpen(false)}
-        onAdd={handleAddExtra}
-      />
 
       {storeId && (
         <AfterClosingModal

--- a/src/pages/CustomerOrderPage.tsx
+++ b/src/pages/CustomerOrderPage.tsx
@@ -1,10 +1,11 @@
 import { useMemo, useState } from 'react';
 
 import { useQuery, useMutation } from '@tanstack/react-query';
-import { AlertCircle, CheckCircle, Loader2, Minus, Plus, ShoppingCart } from 'lucide-react';
+import { AlertCircle, CheckCircle, Clock, Loader2, Minus, Plus, ShoppingCart } from 'lucide-react';
 import { useParams } from 'react-router-dom';
 
 import {
+  fetchPublicStoreOpenStatus,
   fetchStoreMenuCategories,
   fetchStoreMenus,
   fetchStoreTheme,
@@ -58,7 +59,7 @@ const MenuItemListCard = ({ item, quantity, themeHex, onUpdate }: MenuItemCardPr
         className="size-16 rounded-lg object-cover shrink-0"
       />
     ) : (
-      <div className="size-16 rounded-lg bg-orange-50 flex items-center justify-center shrink-0 text-2xl select-none">
+      <div className="size-16 rounded-lg bg-baro-red/5 flex items-center justify-center shrink-0 text-2xl select-none">
         ☕
       </div>
     )}
@@ -89,7 +90,7 @@ const MenuItemGridCard = ({ item, quantity, themeHex, onUpdate }: MenuItemCardPr
     )}
     style={quantity > 0 ? ({ '--tw-ring-color': `${themeHex}60` } as React.CSSProperties) : {}}
   >
-    <div className="relative h-32 bg-orange-50">
+    <div className="relative h-32 bg-baro-red/5">
       {item.imageUrl ? (
         <img src={item.imageUrl} alt={item.name} className="h-full w-full object-cover" />
       ) : (
@@ -244,6 +245,22 @@ const OrderSuccess = ({
   );
 };
 
+/* ── 미개점 안내 화면 ── */
+const StoreClosed = ({ themeHex }: { themeHex: string }) => (
+  <div className="min-h-screen bg-gray-50 flex flex-col items-center justify-center px-6 gap-5">
+    <div
+      className="size-16 rounded-full flex items-center justify-center"
+      style={{ backgroundColor: `${themeHex}20` }}
+    >
+      <Clock className="size-8" style={{ color: themeHex }} />
+    </div>
+    <div className="text-center">
+      <h1 className="text-lg font-bold text-gray-900">현재 영업 중이 아닙니다</h1>
+      <p className="text-sm text-gray-400 mt-2">영업 시간을 확인하시거나 직원에게 문의해 주세요.</p>
+    </div>
+  </div>
+);
+
 /* ── 메인 페이지 ── */
 const CustomerOrderPage = () => {
   const { storeId, tableNumber } = useParams<{ storeId: string; tableNumber: string }>();
@@ -280,6 +297,12 @@ const CustomerOrderPage = () => {
     }
   });
 
+  const { data: openStatus } = useQuery({
+    queryKey: ['public-store-open-status', storeId],
+    queryFn: () => fetchPublicStoreOpenStatus(storeId!),
+    enabled: !!storeId,
+  });
+
   const {
     data: menus = [],
     isLoading: isMenuLoading,
@@ -304,8 +327,15 @@ const CustomerOrderPage = () => {
 
   const themeHex = THEME_HEX[theme.themeColor];
 
+  const [isStoreClosed, setIsStoreClosed] = useState(false);
+
   const orderMutation = useMutation({
     mutationFn: (data: Parameters<typeof createOrder>[1]) => createOrder(storeId!, data),
+    onError: (err: unknown) => {
+      const code = (err as { response?: { data?: { error?: { code?: string } } } })?.response?.data
+        ?.error?.code;
+      if (code === 'STORE_CLOSED') setIsStoreClosed(true);
+    },
     onSuccess: (order) => {
       const cartItems: CartItem[] = menus
         .filter((item) => (cart[item.id] ?? 0) > 0)
@@ -367,6 +397,10 @@ const CustomerOrderPage = () => {
       customerNote: customerNote || undefined,
     });
   };
+
+  if (openStatus?.isOpen === false || isStoreClosed) {
+    return <StoreClosed themeHex={themeHex} />;
+  }
 
   if (successInfo) {
     return (

--- a/src/pages/StoreHomePage.tsx
+++ b/src/pages/StoreHomePage.tsx
@@ -93,6 +93,7 @@ const StoreHomePage = () => {
   const { data: history, isLoading } = useClosingHistory(storeId);
   const businessDateClosed =
     history?.closings.some((c) => c.date.startsWith(businessDate)) ?? false;
+  const hasEverClosed = (history?.closings.length ?? 0) > 0;
 
   // 개점 시간 이후(휴무일 제외)에만 전날 마감 누락 여부 조회
   const { data: dashboardStats } = useDashboardStats(
@@ -108,7 +109,8 @@ const StoreHomePage = () => {
     if (businessSession.isOpen && businessSession.businessDate === businessDate)
       return 'already-open';
     if (isHoliday) return businessDateClosed ? 'holiday-closed' : 'holiday';
-    if (isBeforeOpen) return businessDateClosed ? 'before-open-closed' : 'before-open-not-closed';
+    if (isBeforeOpen)
+      return businessDateClosed || !hasEverClosed ? 'before-open-closed' : 'before-open-not-closed';
     return businessDateClosed ? 'today-closed' : 'normal';
   };
 


### PR DESCRIPTION
## 📌 요약

- v1.2.0 프로덕션 배포
- 재고 차감 시점을 마감 시 → 주문 수락 시로 전환하는 시스템 개편 포함

<br/>

## 🏷️ 관련 이슈

- Closes #211
- Related to #210

<br/>

## 📦 배포 버전

- **v1.2.0** (이전: v1.1.2)

<br/>

## 🔥 주요 변경사항

- 재고 차감 시점 변경: 마감 시 → **주문 수락 시 즉시 차감**
- SSE 기반 실시간 재고 부족 경고 배너
- 완료 주문 취소 시 재고 복원 선택 모달
- 마감 UX 전환: 실제 사용량 → **실제 잔량(remainingStock)** 입력
- 마감 중 미완료 주문 경고 다이얼로그
- 손님 주문 페이지 비영업 가드 UI
- 버그 수정 및 UI 색상 개선

<br/>

## 🧯 롤백 계획

- 이전 버전 태그: `v1.1.2`
- 롤백 방법: `git revert` 또는 v1.1.2 태그 기준 재배포