### PR TITLE
🐛 (#222) fix: StrictMode 이중 실행으로 인한 가게 설정 스크롤 복원 간헐적 실패 수정

### DIFF
--- a/src/app/layouts/AppLayout.tsx
+++ b/src/app/layouts/AppLayout.tsx
@@ -113,17 +113,27 @@ const AppLayout = () => {
       sessionStorage.setItem(SCROLL_STORAGE_KEY, String(settingsScrollTop));
       scrollRef.current?.scrollTo(0, 0);
     } else if (comingBackToSettings) {
-      // 하위 페이지 → 가게 설정: 복원할 위치를 미리 동기적으로 반영 후 레이아웃 완료 시 스크롤
+      // 하위 페이지 → 가게 설정: 컨텐츠 높이가 충분해질 때까지 rAF retry loop로 복원
       const saved = Number(sessionStorage.getItem(SCROLL_STORAGE_KEY) ?? 0);
       settingsScrollTop = saved;
-      requestAnimationFrame(() => {
-        scrollRef.current?.scrollTo({ top: saved, behavior: 'instant' });
-      });
+      if (saved === 0) return;
+      const el = scrollRef.current;
+      if (!el) return;
+      const deadline = performance.now() + 1000;
+      const tryRestore = () => {
+        el.scrollTo({ top: saved, behavior: 'instant' });
+        if (el.scrollTop < saved - 1 && performance.now() < deadline) {
+          requestAnimationFrame(tryRestore);
+        }
+      };
+      requestAnimationFrame(tryRestore);
     } else if (movingBetweenSubPages) {
       // 하위 페이지 간 이동: 저장된 위치는 유지하고 최상단으로만 이동
       scrollRef.current?.scrollTo(0, 0);
-    } else {
+    } else if (prev !== pathname) {
       // 설정 영역을 완전히 벗어남: 저장 위치 제거 후 최상단 이동
+      // prev === pathname인 경우(초기 마운트 or StrictMode 이중 실행)는 무시해서
+      // StrictMode 2번째 실행이 sessionStorage를 지우는 버그 방지
       sessionStorage.removeItem(SCROLL_STORAGE_KEY);
       settingsScrollTop = 0;
       scrollRef.current?.scrollTo(0, 0);


### PR DESCRIPTION
## 📌 요약

- StrictMode 이중 실행이 scroll 리스너를 통해 `settingsScrollTop`을 0으로 덮어쓰는 버그 수정
- rAF 단일 호출을 retry loop로 교체해 스켈레톤 상태에서의 클램핑 보조 원인도 함께 해결

<br/>

## 🏷️ 관련 이슈

- Closes #222

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- `else` → `else if (prev !== pathname)` 조건 변경으로 StrictMode 이중 실행 시 아무 동작도 하지 않도록 처리

<br/>

### 📂 세부 변경사항

- `src/app/layouts/AppLayout.tsx`: 스크롤 복원 effect 수정

**버그 원인 상세:**

1. 가게 설정 → 하위 페이지 이동 시 effect가 StrictMode로 인해 두 번 실행됨
2. 1번째 실행(`goingToSubPage`): sessionStorage에 스크롤 위치 저장 (예: 300)
3. 2번째 실행(`else` 분기): `scrollTo(0, 0)` 호출 → 이미 활성화된 scroll 리스너가 `settingsScrollTop = 0`으로 덮어씀
4. 하위 페이지에서 가게 설정으로 복귀 시 sessionStorage에 0이 저장되어 스크롤 복원 실패

**수정 내용:**

- `prev === pathname`인 경우(초기 마운트 또는 StrictMode 이중 실행)는 아무것도 하지 않도록 조건 추가
- rAF 단일 호출 → retry loop (최대 1000ms)로 교체해 React Query 캐시 미스 시 스켈레톤 상태에서 `scrollTo`가 클램핑되는 보조 원인도 해결

<br/>

## 📸 Screenshots

| Before | After |
| ------ | ----- |
| 하위 페이지 복귀 시 간헐적으로 스크롤이 최상단으로 이동 | 항상 이전 스크롤 위치로 복원 |

<br/>

## 🧪 테스트 방법

1. 가게 설정 페이지에서 아래로 스크롤
2. 메뉴 설정 등 하위 페이지로 이동
3. 뒤로가기(또는 ← 버튼)로 가게 설정 복귀
4. 스크롤 위치가 올바르게 복원되는지 확인
5. 여러 번 반복해도 일관되게 동작하는지 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [ ] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- 수정 대상 파일: `AppLayout.tsx` 단일 파일
- StrictMode는 개발 환경에서만 동작하지만, 프로덕션에서도 `prev === pathname` 조건은 초기 마운트 시에만 해당되어 동작에 영향 없음