### PR TITLE
🐛 (#224, #225) fix: 재고 부족 경고 동기화 및 UI 문구 개선

### DIFF
--- a/src/features/customer-order/components/CustomerOrderStatusCard.tsx
+++ b/src/features/customer-order/components/CustomerOrderStatusCard.tsx
@@ -119,7 +119,7 @@ const OrderCard = ({ order, storeId, onCancelCompleted }: OrderCardProps) => {
               {stockWarnings
                 .map(
                   (w) =>
-                    `${w.ingredientName} (필요 ${w.required}${w.unit}, 현재 ${w.currentStock}${w.unit})`,
+                    `${w.ingredientName} (필요 ${w.required}${w.unit}, 가용 재고 ${w.currentStock}${w.unit})`,
                 )
                 .join(', ')}
               이 부족해요.

--- a/src/features/customer-order/types/customerOrder.api.types.ts
+++ b/src/features/customer-order/types/customerOrder.api.types.ts
@@ -57,6 +57,7 @@ export interface ApiOrder {
   createdAt: string;
   updatedAt: string;
   items?: ApiOrderItem[];
+  stockWarnings?: StockWarning[];
 }
 
 export interface CreateOrderRequest {

--- a/src/features/dashboard/hooks/useOrders.ts
+++ b/src/features/dashboard/hooks/useOrders.ts
@@ -1,14 +1,34 @@
+import { useEffect } from 'react';
+
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import type { UpdateOrderStatusRequest } from '@/features/customer-order/types/customerOrder.api.types';
 import { fetchOrders, updateOrderStatus } from '@/features/dashboard/api/order.api';
+import useOrderWarningsStore from '@/features/dashboard/store/orderWarningsStore';
 
-export const useOrders = (storeId: string | null) =>
-  useQuery({
+export const useOrders = (storeId: string | null) => {
+  const setWarnings = useOrderWarningsStore((s) => s.setWarnings);
+  const clearWarnings = useOrderWarningsStore((s) => s.clearWarnings);
+
+  const query = useQuery({
     queryKey: ['orders', storeId],
     queryFn: () => fetchOrders(storeId!),
     enabled: !!storeId,
   });
+
+  useEffect(() => {
+    if (!query.data) return;
+    query.data.forEach((order) => {
+      if (order.stockWarnings?.length) {
+        setWarnings(order.id, order.stockWarnings);
+      } else {
+        clearWarnings(order.id);
+      }
+    });
+  }, [query.data, setWarnings, clearWarnings]);
+
+  return query;
+};
 
 export const useUpdateOrderStatus = (storeId: string | null) => {
   const qc = useQueryClient();


### PR DESCRIPTION
## 📌 요약

- `GET /orders` 응답에 추가된 `stockWarnings` 필드를 프론트엔드에서 읽어 재고 경고 스토어에 동기화
- 새로고침 후에도 재고 경고가 유지되도록 수정
- pending 주문 누적 소요량을 반영한 `currentStock`(가용 재고) 의미 변경에 맞춰 경고 문구 업데이트

<br/>

## 🏷️ 관련 이슈

- Closes #224
- Closes #225

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- `useOrders` 훅에서 주문 목록 조회 시 각 주문의 `stockWarnings`를 `useOrderWarningsStore`에 동기화하여 새로고침 후에도 경고 복원
- `ApiOrder` 타입에 `stockWarnings?: StockWarning[]` 필드 추가 (백엔드 PR: baro-backend#128 대응)

<br/>

### 📂 세부 변경사항

- `customerOrder.api.types.ts` — `ApiOrder`에 `stockWarnings?: StockWarning[]` 추가
- `useOrders.ts` — `useEffect`로 query.data 변경 시 warnings 스토어 동기화 (경고 있으면 `setWarnings`, 없으면 `clearWarnings`)
- `CustomerOrderStatusCard.tsx` — 경고 문구 "현재 Ng" → "가용 재고 Ng" (다른 pending 주문 소요량 차감 후 가용 재고임을 명확히 표시)

<br/>

## 📸 Screenshots

| Before | After |
| ------ | ----- |
| 휘핑크림 (필요 60g, 현재 60g) | 휘핑크림 (필요 60g, 가용 재고 20g) |

<br/>

## 🧪 테스트 방법

1. 재고가 60g인 재료를 사용하는 메뉴(레시피 20g)로 3잔(60g) 주문 접수 → 경고 없음 확인
2. 동일 메뉴로 2잔(40g) 주문 추가 접수 → 두 주문 모두 경고 표시 확인
3. 경고가 표시된 상태에서 페이지 새로고침 → 경고가 유지되는지 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [x] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- 백엔드 변경(baro-backend#128)으로 `currentStock`의 의미가 "실제 재고" → "가용 재고(pending 주문 누적 소요량 차감 후)"로 변경됨
- SSE `new-order` 이벤트의 `stockWarnings` 처리 로직은 기존과 동일하게 유지
