### PR TITLE
🐛 (#227) fix: OCR 포장 단위 항목 spec 파싱 및 단위 자동 반영

### DIFF
--- a/src/features/ocr-inbound/api/ocr.api.ts
+++ b/src/features/ocr-inbound/api/ocr.api.ts
@@ -2,8 +2,22 @@ import type {
   OcrApiResponse,
   OcrMetadata,
 } from '@/features/ocr-inbound/types/ocrInbound.api.types';
-import type { OcrInboundItem } from '@/features/ocr-inbound/types/ocrInbound.types';
+import type { OcrInboundItem, OcrUnit } from '@/features/ocr-inbound/types/ocrInbound.types';
 import axiosInstance from '@/shared/api/axiosInstance';
+
+const parseSpec = (spec: string | null): { factor: number; unit: OcrUnit } | undefined => {
+  if (!spec) return undefined;
+  const match = spec.match(/(\d+(?:\.\d+)?)\s*(개|g|ml|l|kg)/i);
+  if (!match) return undefined;
+  const num = Number(match[1]);
+  const rawUnit = match[2].toLowerCase();
+  if (rawUnit === '개') return { factor: num, unit: '개' };
+  if (rawUnit === 'g') return { factor: num, unit: 'g' };
+  if (rawUnit === 'ml') return { factor: num, unit: 'ml' };
+  if (rawUnit === 'l') return { factor: num * 1000, unit: 'ml' };
+  if (rawUnit === 'kg') return { factor: num * 1000, unit: 'g' };
+  return undefined;
+};
 
 export interface OcrUploadResult {
   metadata: OcrMetadata;
@@ -26,11 +40,12 @@ export async function uploadOcrImage(storeId: string, file: File): Promise<OcrUp
     metadata,
     items: items.map((item, i) => {
       const isNonStandard = item.amount === null;
+      const parsedSpec = isNonStandard ? parseSpec(item.spec) : undefined;
       return {
         id: `ocr-${Date.now()}-${i}`,
         name: item.name,
-        quantity: item.amount ?? 0,
-        unit: item.unit ?? 'g',
+        quantity: parsedSpec ? item.purchaseAmount * parsedSpec.factor : (item.amount ?? 0),
+        unit: parsedSpec?.unit ?? item.unit ?? 'g',
         unitPrice: item.unitPrice ?? null,
         supplyPrice: item.supplyPrice ?? null,
         expiryDate: null,
@@ -39,11 +54,12 @@ export async function uploadOcrImage(storeId: string, file: File): Promise<OcrUp
         matchedInventoryId: item.ingredientId ?? undefined,
         isWarning: item.is_warning,
         warningReason: item.warningReason,
-        // 비표준 단위: 사용자가 변환 계수 직접 입력
+        // 비표준 단위: spec에서 변환 계수·단위를 추출하거나 사용자가 직접 입력
         ...(isNonStandard && {
           purchaseUnit: item.purchaseUnit,
           purchaseQuantity: item.purchaseAmount,
           purchaseUnitPrice: item.unitPrice ?? undefined,
+          ...(parsedSpec !== undefined && { conversionFactor: parsedSpec.factor }),
         }),
       };
     }),

--- a/src/features/ocr-inbound/types/ocrInbound.api.types.ts
+++ b/src/features/ocr-inbound/types/ocrInbound.api.types.ts
@@ -15,6 +15,7 @@ export interface OcrApiItem {
   purchaseAmount: number; // 명세서 원본 수량
   amount: number | null; // 변환된 수량 (null = 비표준 단위, 변환 계수 필요)
   unit: OcrUnit | null; // 변환된 기본 단위 (null = 비표준 단위)
+  spec: string | null; // 1구매단위당 내용물 정보 (예: "20개", "1000ml")
   unitPrice: number | null;
   supplyPrice: number | null;
   memo: string | null;

--- a/src/pages/OcrInboundPage.tsx
+++ b/src/pages/OcrInboundPage.tsx
@@ -23,6 +23,7 @@ import type { OcrMetadata } from '@/features/ocr-inbound/types/ocrInbound.api.ty
 import type { OcrInboundItem } from '@/features/ocr-inbound/types/ocrInbound.types';
 import { confirmInbound } from '@/features/store-settings/api/ingredients.api';
 import { updateStoreSettings } from '@/features/store-settings/api/storeSettings.api';
+import { useIngredients } from '@/features/store-settings/hooks/useIngredients';
 import { useStoreSettings } from '@/features/store-settings/hooks/useStoreSettings';
 import { getApiErrorMessage } from '@/shared/utils/apiError';
 
@@ -88,6 +89,7 @@ const OcrInboundPage = () => {
   const { data: storeSettings } = useStoreSettings();
   const { data: conversionData } = useUnitConversions();
   const conversionMap = conversionData?.map;
+  const { data: ingredientList = [] } = useIngredients();
   const safetyStockPct = storeSettings?.safetyStockPct ?? 0;
 
   const locationState = location.state as { file?: File } | null;
@@ -127,6 +129,7 @@ const OcrInboundPage = () => {
   const [isConfirming, setIsConfirming] = useState(false);
   const handledInitialFile = useRef(false);
   const conversionApplied = useRef(false);
+  const unitSynced = useRef(false);
 
   // 검수 중 아이템·메타데이터 변경 시 sessionStorage 동기화
   useEffect(() => {
@@ -140,6 +143,23 @@ const OcrInboundPage = () => {
     conversionApplied.current = true;
     setItems((prev) => applyStoredConversions(prev, conversionMap));
   }, [conversionMap, step]);
+
+  // 매칭된 비표준 단위 항목의 unit을 재고 목록 기준으로 동기화 (1회만 실행)
+  useEffect(() => {
+    if (unitSynced.current || !ingredientList.length || step !== 'review') return;
+    unitSynced.current = true;
+    setItems((prev) => {
+      let changed = false;
+      const updated = prev.map((item) => {
+        if (!item.purchaseUnit || !item.matchedInventoryId) return item;
+        const ingredient = ingredientList.find((ing) => ing.id === item.matchedInventoryId);
+        if (!ingredient || item.unit === ingredient.unit) return item;
+        changed = true;
+        return { ...item, unit: ingredient.unit };
+      });
+      return changed ? updated : prev;
+    });
+  }, [ingredientList, step]);
 
   // onItemsChange: items 변경 시 연결된 항목에 저장된 변환 계수 자동 채움
   const handleItemsChange = useCallback(


### PR DESCRIPTION
## 📌 요약

- OCR 결과의 `spec` 필드를 파싱해 포장 단위 항목의 변환 계수(factor)와 단위(unit)를 자동으로 세팅
- 기존 재고와 매칭된 포장 단위 항목의 unit이 항상 'g'로 표시되던 버그 수정
- `kg → g`, `L → ml` 단위 환산 규칙을 spec 파싱 시에도 적용

<br/>

## 🏷️ 관련 이슈

- Closes #227

<br/>

## 🐛 어떤 문제가 있었나

### 문제 1: spec 필드를 전혀 활용하지 않음

백엔드가 `spec: "20개"`, `spec: "1000ml"` 형태로 포장 내용물 정보를 내려주기 시작했지만, 프론트엔드는 이 필드를 완전히 무시하고 있었습니다. 변환 계수 입력칸은 항상 빈 칸으로 표시됐고 사용자가 매번 수동 입력해야 했습니다.

### 문제 2: 포장 단위 항목의 단위(unit)가 항상 'g'로 표시됨

포장 단위 항목(`amount === null`)은 OCR API가 `unit: null`을 반환합니다. 기존 매핑 로직에서 `unit: item.unit ?? 'g'`로 처리해 무조건 'g'로 초기화됐습니다.

이로 인해 두 가지 상황에서 문제가 발생했습니다.

**미매칭 항목** (`ingredientId: null`):

```json
{ "name": "유스베리 티백", "purchaseUnit": "팩", "spec": "20개", "unit": null }
```

→ unit select가 'g'로 초기화됨. `spec`에 '개'라고 명시되어 있음에도 사용자가 직접 '개'로 바꿔야 했습니다.

**기존 재고와 매칭된 항목** (`ingredientId` 있음):

```json
{ "name": "레몬", "purchaseUnit": "BOX", "spec": "10개", "unit": null, "ingredientId": "71da..." }
```

재고 목록에 `레몬 → 단위: 개`가 등록되어 있음에도, OCR 검수 화면에서는 'g'로 고정 표시되고 수정도 불가능했습니다 (매칭된 항목의 unit 칸은 read-only).

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- `parseSpec` 함수 신규 작성 — spec 문자열에서 변환 계수와 단위를 동시에 추출
- OCR API 응답 매핑 시 `parsedSpec.unit`으로 단위 초기값 세팅
- `OcrInboundPage`에 재고 목록 기반 unit 동기화 effect 추가 (매칭된 포장 단위 항목 대상)

<br/>

### 📂 세부 변경사항

**`ocrInbound.api.types.ts`**
- `OcrApiItem`에 `spec: string | null` 필드 추가

**`ocr.api.ts`**
- `parseSpecNumber` 제거 → `parseSpec`으로 대체
  - 기존: 숫자만 추출 (`"20개"` → `20`)
  - 변경: 숫자 + 단위 함께 추출 (`"20개"` → `{ factor: 20, unit: '개' }`)
  - kg/L 환산 규칙 내장: `"1kg"` → `{ factor: 1000, unit: 'g' }`, `"2L"` → `{ factor: 2000, unit: 'ml' }`
- 매핑 로직: `unit: parsedSpec?.unit ?? item.unit ?? 'g'` (spec 단위 우선 적용)
- 매핑 로직: `quantity = purchaseAmount × parsedSpec.factor` (수량 자동 계산)

**`OcrInboundPage.tsx`**
- `useIngredients` 훅 추가
- `unitSynced` ref 가드 추가
- 매칭된 비표준 단위 항목의 unit을 재고 목록 기준으로 1회 동기화하는 effect 추가
  - `spec` 파싱으로 unit이 세팅되어도, 기존 재고 등록 단위가 truth이므로 재고 목록 기준으로 재확인

<br/>

### 🔑 parseSpec 단위 파싱 규칙

| spec 값 | factor | unit | 비고 |
|---------|--------|------|------|
| `"20개"` | 20 | `개` | |
| `"1000ml"` | 1000 | `ml` | |
| `"500g"` | 500 | `g` | |
| `"1kg"` | 1000 | `g` | kg→g ×1000 환산 |
| `"2L"` | 2000 | `ml` | L→ml ×1000 환산 |
| `null` | — | — | 기존 동작 유지 (빈 입력칸) |

<br/>

## 📸 Screenshots

| Before | After |
| ------ | ----- |
| 변환 계수 빈 칸, unit 'g' 고정 | `spec: "20개"` → 계수 20, unit '개' 자동 세팅 |

<br/>

## 🧪 테스트 방법

1. 포장 단위(BOX, 팩 등) 항목이 있는 명세서 업로드
2. `spec`이 있는 항목: 변환 계수와 단위가 자동으로 채워지는지 확인
3. 기존 재고와 매칭된 항목: 재고에 등록된 단위로 표시되는지 확인
4. `spec: null` 항목: 기존과 동일하게 빈 입력칸으로 표시되는지 확인
5. kg/L 항목: g/ml로 환산되어 factor가 곱해지는지 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [x] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- `/inbound` 전송 스키마는 변경 없음 (`spec` 필드는 저장하지 않음)
- 포장 단위 확인 로직 (`amount === null` 판단)도 변경 없음
- `unitSynced` ref 가드로 effect 1회만 실행 보장 (기존 `conversionApplied` ref와 동일 패턴)
