### PR TITLE
✨ (#229) feat: OCR 입고 검수 식자재 재연결·등록 취소·이름 잠금

### DIFF
--- a/src/features/ocr-inbound/api/ocr.api.ts
+++ b/src/features/ocr-inbound/api/ocr.api.ts
@@ -44,6 +44,7 @@ export async function uploadOcrImage(storeId: string, file: File): Promise<OcrUp
       return {
         id: `ocr-${Date.now()}-${i}`,
         name: item.name,
+        originalName: item.name,
         quantity: parsedSpec ? item.purchaseAmount * parsedSpec.factor : (item.amount ?? 0),
         unit: parsedSpec?.unit ?? item.unit ?? 'g',
         unitPrice: item.unitPrice ?? null,

--- a/src/features/ocr-inbound/components/IngredientLinkModal.tsx
+++ b/src/features/ocr-inbound/components/IngredientLinkModal.tsx
@@ -12,6 +12,7 @@ interface IngredientLinkModalProps {
   open: boolean;
   ocrName: string;
   ingredients: ExistingIngredient[];
+  currentIngredientId?: string;
   onClose: () => void;
   onConfirm: (ingredient: ExistingIngredient) => void;
 }
@@ -20,6 +21,7 @@ const IngredientLinkModal = ({
   open,
   ocrName,
   ingredients,
+  currentIngredientId,
   onClose,
   onConfirm,
 }: IngredientLinkModalProps) => {
@@ -72,30 +74,33 @@ const IngredientLinkModal = ({
               <p className="text-xs text-muted-foreground text-center py-6">검색 결과가 없습니다</p>
             ) : (
               <div className="flex flex-wrap gap-1.5">
-                {filtered.map((ingredient) => (
-                  <button
-                    key={ingredient.id}
-                    onClick={() => setSelected(ingredient)}
-                    className={cn(
-                      'inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-all select-none cursor-pointer',
-                      selected?.id === ingredient.id
-                        ? 'border-baro-blue bg-baro-blue/10 text-baro-blue'
-                        : 'text-foreground hover:border-baro-blue/60 hover:bg-baro-blue/5',
-                    )}
-                  >
-                    {ingredient.name}
-                    <span
+                {filtered.map((ingredient) => {
+                  const isActive =
+                    selected?.id === ingredient.id ||
+                    (!selected && ingredient.id === currentIngredientId);
+                  return (
+                    <button
+                      key={ingredient.id}
+                      onClick={() => setSelected(ingredient)}
                       className={cn(
-                        'text-[10px]',
-                        selected?.id === ingredient.id
-                          ? 'text-baro-blue/70'
-                          : 'text-muted-foreground',
+                        'inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-all select-none cursor-pointer',
+                        isActive
+                          ? 'border-baro-blue bg-baro-blue/10 text-baro-blue'
+                          : 'text-foreground hover:border-baro-blue/60 hover:bg-baro-blue/5',
                       )}
                     >
-                      ({ingredient.unit})
-                    </span>
-                  </button>
-                ))}
+                      {ingredient.name}
+                      <span
+                        className={cn(
+                          'text-[10px]',
+                          isActive ? 'text-baro-blue/70' : 'text-muted-foreground',
+                        )}
+                      >
+                        ({ingredient.unit})
+                      </span>
+                    </button>
+                  );
+                })}
               </div>
             )}
           </div>

--- a/src/features/ocr-inbound/components/OcrReviewStep.tsx
+++ b/src/features/ocr-inbound/components/OcrReviewStep.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
 
+import { useQueryClient } from '@tanstack/react-query';
 import {
   AlertCircle,
   Building2,
   CalendarIcon,
-  CheckCircle2,
   FileText,
   Hash,
   Link,
@@ -12,10 +12,13 @@ import {
   RotateCcw,
   Trash2,
   TriangleAlert,
+  X,
   ZoomIn,
   ZoomOut,
 } from 'lucide-react';
+import { toast } from 'sonner';
 
+import useAuthStore from '@/features/auth/store/authStore';
 import IngredientLinkModal from '@/features/ocr-inbound/components/IngredientLinkModal';
 import type { OcrMetadata } from '@/features/ocr-inbound/types/ocrInbound.api.types';
 import type {
@@ -23,6 +26,7 @@ import type {
   OcrInboundItem,
   OcrUnit,
 } from '@/features/ocr-inbound/types/ocrInbound.types';
+import { deleteIngredient } from '@/features/store-settings/api/ingredients.api';
 import { useIngredients } from '@/features/store-settings/hooks/useIngredients';
 import { cn } from '@/lib/utils';
 import { Button } from '@/shadcn/ui/button';
@@ -54,6 +58,8 @@ const OcrReviewStep = ({
   onReset,
   isConfirming = false,
 }: OcrReviewStepProps) => {
+  const storeId = useAuthStore((s) => s.storeId);
+  const qc = useQueryClient();
   const { data: ingredientList = [] } = useIngredients();
   const existingIngredients: ExistingIngredient[] = ingredientList.map((ing) => ({
     id: ing.id,
@@ -72,6 +78,7 @@ const OcrReviewStep = ({
     open: boolean;
     itemId: string;
     name: string;
+    currentIngredientId?: string;
   } | null>(null);
   const [dragging, setDragging] = useState(false);
   const dragRef = useRef({ startX: 0, startY: 0, posX: 0, posY: 0 });
@@ -136,12 +143,43 @@ const OcrReviewStep = ({
     onItemsChange(items.filter((item) => item.id !== id));
   };
 
+  const handleUnlink = (id: string) => {
+    onItemsChange(
+      items.map((item) =>
+        item.id === id
+          ? {
+              ...item,
+              name: item.originalName || item.name,
+              isMatched: false,
+              matchedInventoryId: undefined,
+            }
+          : item,
+      ),
+    );
+  };
+
+  const handleCancelRegistration = async (id: string, ingredientId: string) => {
+    if (!storeId) return;
+    try {
+      await deleteIngredient(storeId, ingredientId);
+      qc.invalidateQueries({ queryKey: ['ingredients', storeId] });
+      onItemsChange(
+        items.map((item) =>
+          item.id === id ? { ...item, isMatched: false, newIngredientId: undefined } : item,
+        ),
+      );
+    } catch {
+      toast.error('등록 취소에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+    }
+  };
+
   const handleAdd = () => {
     onItemsChange([
       ...items,
       {
         id: `new-${Date.now()}`,
         name: '',
+        originalName: '',
         quantity: 0,
         unit: 'g',
         unitPrice: null,
@@ -491,12 +529,6 @@ const OcrReviewStep = ({
                 </Popover>
               );
 
-              const matchedBadge = (
-                <span className="inline-flex items-center gap-1 text-xs text-baro-blue bg-blue-50 px-2 py-0.5 rounded-full border border-blue-200/60 whitespace-nowrap dark:bg-blue-950/40 dark:border-blue-800/40">
-                  <CheckCircle2 className="w-3 h-3" />
-                  기존
-                </span>
-              );
               const registerBtn = (
                 <button
                   onClick={() =>
@@ -522,22 +554,70 @@ const OcrReviewStep = ({
                   연결
                 </button>
               );
-              const statusField = item.isMatched ? (
-                matchedBadge
+              const relinkBtn = (
+                <button
+                  onClick={() =>
+                    setLinkModal({
+                      open: true,
+                      itemId: item.id,
+                      name: item.name,
+                      currentIngredientId: item.matchedInventoryId,
+                    })
+                  }
+                  className="inline-flex items-center gap-0.5 text-xs text-baro-blue bg-blue-50 hover:bg-blue-100 px-1.5 py-0.5 rounded-full border border-blue-200/60 whitespace-nowrap transition-colors cursor-pointer dark:bg-blue-950/40 dark:border-blue-800/40 dark:hover:bg-blue-950/60"
+                >
+                  <RotateCcw className="w-3 h-3" />
+                  재연결
+                </button>
+              );
+              const unlinkBtn = (
+                <button
+                  onClick={() => handleUnlink(item.id)}
+                  className="inline-flex items-center gap-0.5 text-xs text-muted-foreground bg-muted hover:bg-muted/70 px-1.5 py-0.5 rounded-full border whitespace-nowrap transition-colors cursor-pointer"
+                >
+                  <X className="w-3 h-3" />
+                  연결 해제
+                </button>
+              );
+              const cancelRegistrationBtn = (
+                <button
+                  onClick={() =>
+                    item.newIngredientId && handleCancelRegistration(item.id, item.newIngredientId)
+                  }
+                  className="inline-flex items-center gap-0.5 text-xs text-baro-red bg-red-50 hover:bg-red-100 px-1.5 py-0.5 rounded-full border border-red-200/60 whitespace-nowrap transition-colors cursor-pointer dark:bg-red-950/40 dark:border-red-800/40 dark:hover:bg-red-950/60"
+                >
+                  <X className="w-3 h-3" />
+                  등록 취소
+                </button>
+              );
+              const statusField = item.matchedInventoryId ? (
+                <div className="flex flex-col gap-1">
+                  {relinkBtn}
+                  {unlinkBtn}
+                </div>
+              ) : item.newIngredientId ? (
+                cancelRegistrationBtn
               ) : (
                 <div className="flex flex-col gap-1">
                   {registerBtn}
                   {linkBtn}
                 </div>
               );
-              const mobileStatusField = item.isMatched ? (
-                matchedBadge
-              ) : (
-                <div className="flex flex-col gap-1">
-                  {registerBtn}
-                  {linkBtn}
-                </div>
-              );
+              const mobileStatusField = statusField;
+
+              const nameField =
+                item.matchedInventoryId || item.newIngredientId ? (
+                  <span className="h-8 flex items-center px-3 rounded-md border bg-muted text-sm text-muted-foreground truncate">
+                    {item.name}
+                  </span>
+                ) : (
+                  <Input
+                    value={item.name}
+                    onChange={(e) => handleChange(item.id, 'name', e.target.value)}
+                    className="h-8 text-sm"
+                    placeholder="식자재명"
+                  />
+                );
 
               const deleteBtn = (
                 <button
@@ -559,12 +639,7 @@ const OcrReviewStep = ({
                     )}
                   >
                     <div className="flex items-center justify-center">{warningIcon}</div>
-                    <Input
-                      value={item.name}
-                      onChange={(e) => handleChange(item.id, 'name', e.target.value)}
-                      className="h-8 text-sm"
-                      placeholder="식자재명"
-                    />
+                    {nameField}
                     {quantityField}
                     {unitField}
                     {priceField}
@@ -586,12 +661,7 @@ const OcrReviewStep = ({
                     {/* 이름 + 상태 + 삭제 */}
                     <div className="flex items-center gap-2">
                       <div className="w-5 shrink-0 flex justify-center">{warningIcon}</div>
-                      <Input
-                        value={item.name}
-                        onChange={(e) => handleChange(item.id, 'name', e.target.value)}
-                        className="flex-1 h-8 text-sm min-w-0"
-                        placeholder="식자재명"
-                      />
+                      <div className="flex-1 min-w-0">{nameField}</div>
                       <div className="shrink-0">{mobileStatusField}</div>
                       {deleteBtn}
                     </div>
@@ -721,6 +791,7 @@ const OcrReviewStep = ({
           open={linkModal.open}
           ocrName={linkModal.name}
           ingredients={existingIngredients}
+          currentIngredientId={linkModal.currentIngredientId}
           onClose={() => setLinkModal(null)}
           onConfirm={(ingredient: ExistingIngredient) => {
             onItemsChange(
@@ -728,6 +799,10 @@ const OcrReviewStep = ({
                 item.id === linkModal.itemId
                   ? {
                       ...item,
+                      // 첫 연결 시에만 originalName 저장 (재연결 시 덮어쓰지 않음)
+                      ...(!item.matchedInventoryId && {
+                        originalName: item.originalName || item.name,
+                      }),
                       name: ingredient.name,
                       unit: ingredient.unit,
                       isMatched: true,

--- a/src/features/ocr-inbound/types/ocrInbound.types.ts
+++ b/src/features/ocr-inbound/types/ocrInbound.types.ts
@@ -3,6 +3,7 @@ export type OcrUnit = 'g' | 'ml' | '개';
 export interface OcrInboundItem {
   id: string;
   name: string;
+  originalName: string;
   quantity: number;
   unit: OcrUnit;
   unitPrice: number | null;


### PR DESCRIPTION
## 📌 요약

- OCR 입고 검수 화면에서 식자재 연결·등록을 잘못했을 때 수정할 수 있는 기능 추가
- 기존 재고 재연결 / 연결 해제 / 신규 등록 취소 + 이름 잠금 처리

<br/>

## 🏷️ 관련 이슈

- Closes #229

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

**상태별 버튼 구성 변경**

| 상태 | 기존 | 변경 후 |
|------|------|---------|
| 미매칭 | 신규 등록 / 기존 재고 연결 | 동일 |
| 기존 재고 연결됨 | "기존" 뱃지만 표시 | 재연결 / 연결 해제 버튼 |
| 신규 등록됨 | "기존" 뱃지만 표시 | 등록 취소 버튼 |

**이름 필드 잠금**
- 기존 재고 연결 또는 신규 등록 완료 시 이름 칸 read-only 처리 (단위 칸과 동일)

<br/>

### 📂 세부 변경사항

**`OcrReviewStep.tsx`**
- `handleUnlink`: 기존 재고 연결 해제 → OCR 원본 이름(`originalName`) 복원, `matchedInventoryId` 초기화
- `handleCancelRegistration`: 신규 등록 취소 → `DELETE /ingredients/:id` 호출 후 `newIngredientId` 초기화, 식자재 목록 캐시 무효화
- `nameField` 변수 도입: `matchedInventoryId` 또는 `newIngredientId`가 있으면 read-only span, 없으면 Input
- `relinkBtn / unlinkBtn / cancelRegistrationBtn` 분기 처리 (기존 `matchedBadge` 제거)
- 재연결 시 `IngredientLinkModal`에 `currentIngredientId` 전달
- 링크 시점에 `originalName` 저장 (최초 연결 시만, 재연결 시 덮어쓰지 않음)

**`IngredientLinkModal.tsx`**
- `currentIngredientId?: string` prop 추가
- 재연결 모달 오픈 시 현재 연결된 항목이 선택된 상태(파란색)로 표시 — 새 항목을 클릭하는 순간 이동

**`OcrInboundItem` 타입 / `ocr.api.ts`**
- `originalName: string` 필드 추가 — OCR 매핑 시 `item.name`으로 초기화
- 연결 취소 후 이름 복원에 활용 (`originalName || item.name` fallback으로 구버전 드래프트 호환)

<br/>

## 📸 Screenshots

| 상태 | UI |
|------|----|
| 미매칭 | 신규 등록 / 기존 재고 연결 버튼 |
| 기존 재고 연결됨 | 재연결(파란색) / 연결 해제(회색) 버튼, 이름 잠금 |
| 신규 등록됨 | 등록 취소(빨간색) 버튼, 이름 잠금 |
| 재연결 모달 | 현재 연결된 항목 파란색으로 선택된 상태 표시 |

<br/>

## 🧪 테스트 방법

1. OCR 검수 화면에서 항목을 기존 재고와 연결 → 이름 잠금, "재연결/연결 해제" 버튼 확인
2. "재연결" 클릭 → 현재 연결된 항목이 선택된 상태로 모달 오픈, 다른 항목 선택 후 확인
3. "연결 해제" 클릭 → OCR 원본 이름으로 복원, 미매칭 버튼으로 복귀 확인
4. 항목을 신규 등록 → 이름 잠금, "등록 취소" 버튼 확인
5. "등록 취소" 클릭 → 식자재 삭제, 미매칭 버튼으로 복귀 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [ ] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- `originalName || item.name` fallback: 세션스토리지 구버전 드래프트(originalName 없는 데이터)와의 호환성 보장
- 신규 등록 취소 시 `DELETE /ingredients/:id` 호출 — 방금 생성된 식자재이므로 연결된 데이터 없음
- `mobileStatusField = statusField`로 통합 (기존 중복 코드 제거)
