### PR TITLE
🐛 (#235) fix: StandalonePageWrapper 페이지 이동 시 스크롤 최상단 미복원 수정

### DIFF
--- a/src/app/routes/Router.tsx
+++ b/src/app/routes/Router.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 import { Routes, Route, useLocation } from 'react-router-dom';
 
 import AppLayout from '@/app/layouts/AppLayout';
@@ -34,6 +36,11 @@ import TermsOfServicePage from '@/pages/TermsOfServicePage';
 
 const StandalonePageWrapper = ({ element }: { element: React.ReactElement }) => {
   const { key } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [key]);
+
   return (
     <div key={key} className="animate-page-fade-in">
       {element}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,9 @@ import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App.tsx';
 
+// 브라우저의 자동 스크롤 복원 비활성화 — 앱에서 직접 관리
+history.scrollRestoration = 'manual';
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />


### PR DESCRIPTION
## 📌 요약

- 브라우저 자동 스크롤 복원(`history.scrollRestoration = 'auto'`) 비활성화
- `StandalonePageWrapper` 페이지 진입 시 `window.scrollTo(0, 0)` 명시적 처리

<br/>

## 🏷️ 관련 이슈

- Closes #235

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

**원인**

React Router SPA에서 브라우저 기본값 `history.scrollRestoration = 'auto'`는 URL별 window 스크롤 위치를 저장·복원함. AppLayout 내부 페이지는 커스텀 `scrollRef` 컨테이너를 사용해 window 스크롤과 무관하지만, `StandalonePageWrapper`로 감싸진 페이지들(`/store-home`, `/store-selection` 등)은 window 스크롤을 직접 사용하므로 이전 방문 시의 스크롤 위치가 복원되는 문제 발생.

**해결**

| 파일 | 변경 내용 |
|------|----------|
| `src/main.tsx` | `history.scrollRestoration = 'manual'` — 브라우저 자동 복원 전역 비활성화 |
| `src/app/routes/Router.tsx` | `StandalonePageWrapper`에 `useEffect(() => window.scrollTo(0, 0), [key])` 추가 |

<br/>

### 📂 세부 변경사항

- `main.tsx`: 앱 진입점에서 `history.scrollRestoration = 'manual'` 설정 (라우터 초기화 전)
- `Router.tsx`: `StandalonePageWrapper`가 location key 변경(=페이지 이동)마다 window를 최상단으로 이동

<br/>

## 🧪 테스트 방법

1. `/store-home` 등 AppLayout 밖 페이지로 이동 후 스크롤 다운
2. AppLayout 내 페이지(`/my-account` 등)로 이동
3. 다시 `/store-home`으로 이동 → **최상단**에서 시작 확인
4. AppLayout 내 가게 설정 스크롤 복원 기능 정상 동작 확인 (기존 기능 회귀 없음)

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [ ] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- `history.scrollRestoration = 'manual'`은 브라우저 뒤로가기/앞으로가기 시 자동 복원도 끔 — AppLayout의 `scrollRef` 기반 스크롤 복원(가게 설정 ↔ 하위 페이지)은 이미 수동 관리 중이므로 영향 없음
- `StandalonePageWrapper`에서 `key`를 의존성으로 쓰는 이유: React Router는 같은 컴포넌트로 다른 URL을 렌더링할 때 `location.key`를 변경하므로, 이를 기준으로 스크롤을 초기화함