### PR TITLE
💄 (#214) ui: 이번달 현황 카드 금액 포맷 개선 및 대시보드 태블릿 반응형

### DIFF
--- a/src/features/dashboard/components/SalesConsumptionCard.tsx
+++ b/src/features/dashboard/components/SalesConsumptionCard.tsx
@@ -73,6 +73,26 @@ const DonutChart = ({ salesRatio, hasData }: DonutChartProps) => {
   );
 };
 
+/* ── 금액 포맷 ── */
+const formatWon = (value: number): string => {
+  const abs = Math.abs(value);
+  const sign = value < 0 ? '-' : '';
+
+  if (abs >= 100_000_000) {
+    const rounded = Math.round((abs / 100_000_000) * 10) / 10;
+    if (rounded % 1 === 0) return `${sign}${rounded.toLocaleString()}억원`;
+    const [int, dec] = rounded.toFixed(1).split('.');
+    return `${sign}${Number(int).toLocaleString()}.${dec}억원`;
+  }
+  if (abs >= 1_000_000) {
+    const rounded = Math.round((abs / 10_000) * 10) / 10;
+    if (rounded % 1 === 0) return `${sign}${Math.round(rounded).toLocaleString()}만원`;
+    const [int, dec] = rounded.toFixed(1).split('.');
+    return `${sign}${Number(int).toLocaleString()}.${dec}만원`;
+  }
+  return `${sign}${abs.toLocaleString()}원`;
+};
+
 /* ── 메인 카드 ── */
 const SalesConsumptionCard = ({ data }: SalesConsumptionCardProps) => {
   const latest = data[data.length - 1];
@@ -92,7 +112,7 @@ const SalesConsumptionCard = ({ data }: SalesConsumptionCardProps) => {
   const consumptionRatio = total > 0 ? latest.consumption / total : 0;
 
   return (
-    <Card size="sm" className="md:h-full">
+    <Card size="sm" className="xl:h-full">
       <CardHeader className="border-b px-4">
         <CardTitle className="text-sm flex items-center gap-2">
           <PieChart className="w-4 h-4 text-muted-foreground" />
@@ -121,7 +141,7 @@ const SalesConsumptionCard = ({ data }: SalesConsumptionCardProps) => {
               <span className="text-xs text-muted-foreground">
                 {(total > 0 ? (1 - consumptionRatio) * 100 : 0).toFixed(1)}%
               </span>
-              <span className="text-sm font-bold">{(latest.sales / 10000).toFixed(0)}만원</span>
+              <span className="text-sm font-bold">{formatWon(latest.sales)}</span>
             </div>
           </div>
 
@@ -135,9 +155,7 @@ const SalesConsumptionCard = ({ data }: SalesConsumptionCardProps) => {
               <span className="text-xs text-muted-foreground">
                 {(consumptionRatio * 100).toFixed(1)}%
               </span>
-              <span className="text-sm font-bold">
-                {(latest.consumption / 10000).toFixed(0)}만원
-              </span>
+              <span className="text-sm font-bold">{formatWon(latest.consumption)}</span>
             </div>
           </div>
 
@@ -151,7 +169,7 @@ const SalesConsumptionCard = ({ data }: SalesConsumptionCardProps) => {
                 </span>
               )}
               <span className={`text-sm font-bold ${isDeficit ? 'text-baro-red' : ''}`}>
-                {(rawProfit / 10000).toFixed(0)}만원
+                {formatWon(rawProfit)}
               </span>
             </div>
           </div>

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -15,14 +15,14 @@ const DashboardPage = () => {
   const { data: salesData, isLoading: salesLoading } = useDashboardSales(storeId);
 
   return (
-    <main className="flex-1 min-h-0 overflow-y-auto md:overflow-hidden p-3 flex flex-col gap-4 md:flex-row">
+    <main className="flex-1 min-h-0 overflow-y-auto xl:overflow-hidden p-3 flex flex-col gap-4 xl:flex-row">
       {/* 주문 현황 */}
-      <div className="flex-1 min-w-0 md:min-h-0 md:overflow-hidden p-1">
+      <div className="flex-1 min-w-0 md:max-h-80 xl:max-h-none xl:min-h-0 xl:overflow-hidden p-1">
         <OrderStatusCard storeId={storeId} />
       </div>
 
       {/* 가게 현황 */}
-      <div className="flex-1 min-w-0 flex flex-col gap-4 md:min-h-0 p-1">
+      <div className="flex-1 min-w-0 flex flex-col gap-4 xl:min-h-0 p-1">
         {/* 오늘의 가게 현황 요약 */}
         {statsLoading || !stats ? (
           <Skeleton className="h-23 w-full rounded-xl" />
@@ -31,12 +31,12 @@ const DashboardPage = () => {
         )}
 
         {/* 이번달 현황 + OCR / 메모 */}
-        <div className="flex flex-col gap-4 flex-1 min-h-0 md:flex-row md:gap-5">
+        <div className="flex flex-col gap-4 md:flex-row md:gap-5 xl:flex-1 xl:min-h-0">
           {/* 이번달 현황 + OCR 빠른 입고 처리 */}
-          <div className="flex-1 min-w-0 flex flex-col gap-4 md:min-h-0">
-            <div className="md:flex-1 md:min-h-0">
+          <div className="flex-1 min-w-0 flex flex-col gap-4">
+            <div className="xl:flex-1 xl:min-h-0">
               {salesLoading || !salesData || salesData.length === 0 ? (
-                <Skeleton className="h-40 w-full rounded-xl md:h-full" />
+                <Skeleton className="h-40 w-full rounded-xl xl:h-full" />
               ) : (
                 <SalesConsumptionCard data={salesData} />
               )}


### PR DESCRIPTION
## 📌 요약

- 이번달 현황 카드(SalesConsumptionCard) 금액 표시 단위를 스마트 포맷으로 개선
- 대시보드 레이아웃 태블릿 반응형 추가

<br/>

## 🏷️ 관련 이슈

- Closes #214

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- `formatWon()` 추가: 100만원 미만 → 정확한 원(₩) 표기 / 100만원 이상 → 만원 / 1억 이상 → 억원 (반올림 없이 정확한 표기)
- 대시보드 중단점 조정: md(768px+)에서 주문현황 높이 제한 + 이번달현황·메모 나란히 배치, xl(1280px+)에서 기존 좌우 2열 데스크탑 레이아웃 적용

<br/>

### 📂 세부 변경사항

- `SalesConsumptionCard.tsx`: `formatWon` 헬퍼 추가, 매출·소비·순이익 표시 교체, `xl:h-full`로 중단점 조정
- `DashboardPage.tsx`: 메인 레이아웃 `md:flex-row` → `xl:flex-row`, 태블릿에서 OrderStatusCard `max-h-80` 제한, inner 섹션 `md:flex-row` 유지

<br/>

## 📸 Screenshots

| 구분 | Before | After |
| ------ | ----- | ----- |
| 금액 포맷 | `6만원`, `29만원` (toFixed 반올림) | `60,500원`, `289,960원` (정확한 원 표기) |
| 태블릿 레이아웃 | 768px~에서 좌우 2열 (cramped) | 1280px+에서만 2열, 태블릿은 세로 스택 |

<br/>

## 🧪 테스트 방법

1. 대시보드 접속 → 이번달 현황 카드 금액이 단위에 맞게 표시되는지 확인
   - 100만원 미만: `60,500원` 형태
   - 100만원 이상: `150만원`, `1,234.5만원` 형태
   - 1억 이상: `1.2억원` 형태
2. 브라우저 너비를 768px~1279px로 줄여 태블릿 레이아웃 확인
   - 주문현황 카드: 상단 배치, max-h-80 적용
   - 이번달 현황 + 메모: 나란히 배치
3. 브라우저 너비 1280px+ 에서 기존 좌우 2열 레이아웃 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [ ] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- `formatWon`은 100만원 미만 값에 대해 반올림 없이 정확한 원 단위로 표시 (기존 `toFixed(0)` 방식은 60,500원을 6만원으로 표시하는 부정확함이 있었음)
- 태블릿 레이아웃 변경은 #214 작업 중 발견된 UI 깨짐을 함께 수정