### PR TITLE
✨ (#238, #239) feat: OCR 거래명세서 이미지 보관 및 입고 이력 페이지 추가

### DIFF
--- a/src/app/routes/Router.tsx
+++ b/src/app/routes/Router.tsx
@@ -13,6 +13,7 @@ import CredentialLoginPage from '@/pages/CredentialLoginPage';
 import CustomerOrderPage from '@/pages/CustomerOrderPage';
 import DashboardPage from '@/pages/DashboardPage';
 import DayClosedPage from '@/pages/DayClosedPage';
+import InboundHistoryPage from '@/pages/InboundHistoryPage';
 import InitialSetupPage from '@/pages/InitialSetupPage';
 import InventoryPage from '@/pages/InventoryPage';
 import LandingPage from '@/pages/LandingPage';
@@ -125,6 +126,7 @@ export default function Router() {
         <Route element={<AppLayout />}>
           <Route path={routePaths.dashboard} element={<DashboardPage />} />
           <Route path={routePaths.inventory} element={<InventoryPage />} />
+          <Route path={routePaths.inboundHistory} element={<InboundHistoryPage />} />
           <Route path={routePaths.orderGuide} element={<OrderGuidePage />} />
           <Route path={routePaths.closing} element={<ClosingPage />} />
           {/* 가게 설정 */}

--- a/src/app/routes/routePaths.ts
+++ b/src/app/routes/routePaths.ts
@@ -11,6 +11,7 @@ export const routePaths = {
   dashboard: '/dashboard',
   inventory: '/inventory',
   ocrInbound: '/ocr-inbound',
+  inboundHistory: '/inbound-history',
   orderGuide: '/order-guide',
   closing: '/closing',
   closingOrderGuideDetail: '/closing/order-guide-detail',

--- a/src/features/inventory/components/InventoryTable.tsx
+++ b/src/features/inventory/components/InventoryTable.tsx
@@ -6,6 +6,7 @@ import {
   ArrowUpDown,
   BookOpen,
   CheckCircle2,
+  ClipboardList,
   MinusCircle,
   Package2,
   Pencil,
@@ -150,7 +151,7 @@ const InventoryRow = ({ item, onToggleFavorite, onEdit }: InventoryRowProps) => 
       {/* 데스크탑 행 */}
       <div
         className={cn(
-          'hidden md:grid gap-4 px-5 py-4 hover:bg-muted/20 transition-colors items-center',
+          'hidden lg:grid gap-4 px-5 py-4 hover:bg-muted/20 transition-colors items-center',
           GRID,
           config.rowClass,
         )}
@@ -236,7 +237,7 @@ const InventoryRow = ({ item, onToggleFavorite, onEdit }: InventoryRowProps) => 
 
       {/* 모바일 카드 */}
       <div
-        className={cn('md:hidden px-4 py-3 hover:bg-muted/20 transition-colors', config.rowClass)}
+        className={cn('lg:hidden px-4 py-3 hover:bg-muted/20 transition-colors', config.rowClass)}
       >
         <div className="flex items-start justify-between gap-2">
           <div className="flex items-center gap-2 min-w-0">
@@ -428,13 +429,13 @@ const InventoryTable = () => {
               })}
             </div>
 
-            {/* 액션 버튼 — 모바일: 2행 / 데스크탑: 1행 */}
-            <div className="flex flex-col gap-2 w-full min-w-0 sm:flex-row sm:flex-wrap sm:items-center sm:w-auto">
-              {/* 1행(모바일): 보관함 + 즐찾 + 정렬 — 좁은 화면에서 가로 스크롤 */}
+            {/* 액션 버튼 — 모바일: 2행 / 태블릿(sm+): 버튼 1줄·탭 아래 / 데스크탑(xl+): 탭 옆 1행 */}
+            <div className="flex flex-col gap-2 w-full min-w-0 sm:flex-row sm:flex-wrap sm:items-center xl:w-auto">
+              {/* 1행: 보관함 + 즐찾 + 입고 이력 + 정렬 */}
               <div className="flex items-center gap-2 overflow-x-auto">
                 <button
                   onClick={() => setArchivedOpen(true)}
-                  className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium border border-input text-muted-foreground hover:bg-muted/50 transition-colors"
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium border border-input text-muted-foreground hover:bg-muted/50 transition-colors shrink-0"
                 >
                   <Archive className="w-3.5 h-3.5" />
                   <span className="hidden sm:inline">보관된 식자재</span>
@@ -447,7 +448,7 @@ const InventoryTable = () => {
                 <button
                   onClick={() => setShowFavoritesOnly((prev) => !prev)}
                   className={cn(
-                    'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium border transition-colors',
+                    'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium border transition-colors shrink-0',
                     showFavoritesOnly
                       ? 'bg-baro-yellow/10 border-baro-yellow/50 text-baro-yellow-text'
                       : 'border-input text-muted-foreground hover:bg-muted/50',
@@ -466,11 +467,18 @@ const InventoryTable = () => {
                     </span>
                   )}
                 </button>
-                {/* 모바일: 드롭다운 */}
+                <button
+                  onClick={() => navigate(routePaths.inboundHistory)}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium border border-input text-muted-foreground hover:bg-muted/50 transition-colors shrink-0"
+                >
+                  <ClipboardList className="w-3.5 h-3.5" />
+                  <span className="hidden sm:inline">입고 이력</span>
+                </button>
+                {/* 모바일/태블릿: 정렬 드롭다운 */}
                 <DropdownMenu>
                   <DropdownMenuTrigger
                     className={cn(
-                      'sm:hidden inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium border transition-colors shrink-0',
+                      'lg:hidden inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium border transition-colors shrink-0',
                       sortKey !== 'default'
                         ? 'border-baro-blue/50 text-baro-blue bg-baro-blue/5'
                         : 'border-input text-muted-foreground hover:bg-muted/50',
@@ -505,8 +513,8 @@ const InventoryTable = () => {
                     ))}
                   </DropdownMenuContent>
                 </DropdownMenu>
-                {/* 데스크탑: 버튼 그룹 */}
-                <div className="hidden sm:flex items-center gap-0.5 border rounded-md px-1.5 py-0.5">
+                {/* 데스크탑(xl+): 정렬 버튼 그룹 */}
+                <div className="hidden lg:flex items-center gap-0.5 border rounded-md px-1.5 py-0.5">
                   <ArrowUpDown className="w-3 h-3 text-muted-foreground mr-0.5 shrink-0" />
                   {(
                     [
@@ -533,7 +541,7 @@ const InventoryTable = () => {
                   })}
                 </div>
               </div>
-              {/* 2행(모바일): 등록 + 검색 */}
+              {/* 2행: 등록 + 검색 */}
               <div className="flex items-center gap-2 min-w-0">
                 <button
                   onClick={() => navigate(routePaths.ocrInbound)}
@@ -567,7 +575,7 @@ const InventoryTable = () => {
         <CardContent className="p-0 flex-1 min-h-0 flex flex-col overflow-hidden">
           {/* 컬럼 헤더 */}
           <div
-            className={`hidden md:grid ${GRID} gap-4 px-5 py-2.5 bg-muted/40 border-b text-xs font-semibold text-muted-foreground uppercase tracking-wide`}
+            className={`hidden lg:grid ${GRID} gap-4 px-5 py-2.5 bg-muted/40 border-b text-xs font-semibold text-muted-foreground uppercase tracking-wide`}
           >
             <span />
             <span>식자재명</span>
@@ -585,7 +593,7 @@ const InventoryTable = () => {
             <div className="divide-y flex-1 overflow-y-auto">
               {Array.from({ length: 5 }).map((_, i) => (
                 <div key={i}>
-                  <div className={`hidden md:grid ${GRID} gap-4 px-5 py-4 items-center`}>
+                  <div className={`hidden lg:grid ${GRID} gap-4 px-5 py-4 items-center`}>
                     <Skeleton className="w-4 h-4 rounded-full" />
                     <Skeleton className="h-4 w-3/4" />
                     <Skeleton className="h-4 w-16" />
@@ -595,7 +603,7 @@ const InventoryTable = () => {
                     <Skeleton className="h-4 w-12" />
                     <Skeleton className="h-6 w-16 rounded-full mx-auto" />
                   </div>
-                  <div className="md:hidden px-4 py-3 space-y-2">
+                  <div className="lg:hidden px-4 py-3 space-y-2">
                     <div className="flex items-center justify-between">
                       <Skeleton className="h-4 w-32" />
                       <Skeleton className="h-5 w-14 rounded-full" />

--- a/src/features/ocr-inbound/api/inboundHistory.api.ts
+++ b/src/features/ocr-inbound/api/inboundHistory.api.ts
@@ -1,0 +1,22 @@
+import type {
+  InboundRecord,
+  InboundRecordDetail,
+} from '@/features/ocr-inbound/types/ocrInbound.api.types';
+import axiosInstance from '@/shared/api/axiosInstance';
+
+export async function fetchInboundHistory(storeId: string): Promise<InboundRecord[]> {
+  const res = await axiosInstance.get<{ success: boolean; data: InboundRecord[] }>(
+    `/stores/${storeId}/ingredients/inbound`,
+  );
+  return res.data.data;
+}
+
+export async function fetchInboundDetail(
+  storeId: string,
+  recordId: string,
+): Promise<InboundRecordDetail> {
+  const res = await axiosInstance.get<{ success: boolean; data: InboundRecordDetail }>(
+    `/stores/${storeId}/ingredients/inbound/${recordId}`,
+  );
+  return res.data.data;
+}

--- a/src/features/ocr-inbound/api/ocr.api.ts
+++ b/src/features/ocr-inbound/api/ocr.api.ts
@@ -22,6 +22,7 @@ const parseSpec = (spec: string | null): { factor: number; unit: OcrUnit } | und
 export interface OcrUploadResult {
   metadata: OcrMetadata;
   items: OcrInboundItem[];
+  invoiceImageUrl: string | null;
 }
 
 export async function uploadOcrImage(storeId: string, file: File): Promise<OcrUploadResult> {
@@ -34,10 +35,11 @@ export async function uploadOcrImage(storeId: string, file: File): Promise<OcrUp
     { headers: { 'Content-Type': 'multipart/form-data' } },
   );
 
-  const { metadata, items } = res.data.data;
+  const { metadata, items, imageUrl } = res.data.data;
 
   return {
     metadata,
+    invoiceImageUrl: imageUrl ?? null,
     items: items.map((item, i) => {
       const isNonStandard = item.amount === null;
       const parsedSpec = isNonStandard ? parseSpec(item.spec) : undefined;
@@ -65,4 +67,10 @@ export async function uploadOcrImage(storeId: string, file: File): Promise<OcrUp
       };
     }),
   };
+}
+
+export async function deleteInvoiceImage(storeId: string, imageUrl: string): Promise<void> {
+  await axiosInstance.delete(`/stores/${storeId}/ocr/invoice-image`, {
+    params: { imageUrl },
+  });
 }

--- a/src/features/ocr-inbound/components/InboundDetailModal.tsx
+++ b/src/features/ocr-inbound/components/InboundDetailModal.tsx
@@ -1,0 +1,194 @@
+import { useState } from 'react';
+
+import { Download, FileImage, Package } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { useInboundDetail } from '@/features/ocr-inbound/hooks/useInboundHistory';
+import { Button } from '@/shadcn/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/shadcn/ui/dialog';
+import { Skeleton } from '@/shadcn/ui/skeleton';
+
+interface InboundDetailModalProps {
+  recordId: string | null;
+  onClose: () => void;
+}
+
+const downloadImage = async (url: string) => {
+  const response = await fetch(url);
+  const blob = await response.blob();
+  const blobUrl = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = blobUrl;
+  a.download = 'invoice.jpg';
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(blobUrl);
+};
+
+const InboundDetailModal = ({ recordId, onClose }: InboundDetailModalProps) => {
+  const { data, isLoading } = useInboundDetail(recordId);
+  const [isDownloading, setIsDownloading] = useState(false);
+
+  const formatAmount = (val: string | null) =>
+    val != null ? `${Number(val).toLocaleString()}원` : '—';
+
+  const handleDownload = async () => {
+    if (!data?.invoiceImageUrl) return;
+    setIsDownloading(true);
+    try {
+      await downloadImage(data.invoiceImageUrl);
+    } catch {
+      toast.error('이미지 저장에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+    } finally {
+      setIsDownloading(false);
+    }
+  };
+
+  return (
+    <Dialog open={!!recordId} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-[95vw] md:max-w-5xl max-h-[90vh] flex flex-col p-0 gap-0 overflow-hidden">
+        <DialogHeader className="px-5 py-4 border-b shrink-0">
+          <DialogTitle className="flex items-center gap-2 text-base">
+            <Package className="w-4 h-4 text-baro-blue" />
+            입고 상세
+          </DialogTitle>
+        </DialogHeader>
+
+        {isLoading ? (
+          <div className="space-y-3 p-5">
+            <Skeleton className="h-5 w-1/3 rounded" />
+            <Skeleton className="h-24 w-full rounded-lg" />
+            <Skeleton className="h-52 w-full rounded-lg" />
+          </div>
+        ) : data ? (
+          <div className="flex flex-col md:flex-row min-h-0 flex-1 overflow-hidden">
+            {/* 이미지 패널 */}
+            {data.invoiceImageUrl && (
+              <div className="flex flex-col md:w-[42%] shrink-0 border-b md:border-b-0 md:border-r bg-muted/20">
+                <div className="flex-1 overflow-auto flex items-start justify-center p-4 max-h-56 md:max-h-none">
+                  <img
+                    src={data.invoiceImageUrl}
+                    alt="거래명세서 이미지"
+                    className="max-w-full rounded-md shadow-sm object-contain"
+                  />
+                </div>
+                <div className="shrink-0 px-4 py-2.5 border-t bg-background/90 flex items-center justify-between">
+                  <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                    <FileImage className="w-3.5 h-3.5" />
+                    거래명세서
+                  </span>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleDownload}
+                    disabled={isDownloading}
+                    className="flex items-center gap-1.5 text-xs h-7 px-2.5"
+                  >
+                    <Download className="w-3 h-3" />
+                    {isDownloading ? '저장 중...' : '저장'}
+                  </Button>
+                </div>
+              </div>
+            )}
+
+            {/* 상세 정보 패널 */}
+            <div
+              className={`flex flex-col gap-4 overflow-y-auto p-5 ${
+                data.invoiceImageUrl ? 'md:flex-1' : 'w-full'
+              }`}
+            >
+              {/* 메타데이터 그리드 */}
+              <div className="rounded-lg border bg-muted/30 p-4 grid grid-cols-[auto_1fr] gap-x-6 gap-y-2 text-sm shrink-0">
+                {data.transactionDate && (
+                  <>
+                    <span className="text-muted-foreground whitespace-nowrap">거래일자</span>
+                    <span className="font-medium">{data.transactionDate}</span>
+                  </>
+                )}
+                {data.supplierName && (
+                  <>
+                    <span className="text-muted-foreground whitespace-nowrap">공급업체</span>
+                    <span className="font-medium">{data.supplierName}</span>
+                  </>
+                )}
+                {data.invoiceNumber && (
+                  <>
+                    <span className="text-muted-foreground whitespace-nowrap">명세서 번호</span>
+                    <span className="font-medium">{data.invoiceNumber}</span>
+                  </>
+                )}
+                {data.totalSupplyAmount != null && (
+                  <>
+                    <span className="text-muted-foreground whitespace-nowrap">공급가액</span>
+                    <span className="font-medium">{formatAmount(data.totalSupplyAmount)}</span>
+                  </>
+                )}
+                {data.totalTax != null && (
+                  <>
+                    <span className="text-muted-foreground whitespace-nowrap">세액</span>
+                    <span className="font-medium">{formatAmount(data.totalTax)}</span>
+                  </>
+                )}
+                {data.totalAmount != null && (
+                  <>
+                    <span className="text-muted-foreground whitespace-nowrap">총 거래금액</span>
+                    <span className="font-semibold">{formatAmount(data.totalAmount)}</span>
+                  </>
+                )}
+              </div>
+
+              {/* 품목 목록 */}
+              <div className="flex flex-col gap-1.5 shrink-0">
+                <p className="text-sm font-semibold">
+                  입고 품목{' '}
+                  <span className="text-muted-foreground font-normal">({data.items.length}개)</span>
+                </p>
+                <div className="rounded-lg border overflow-x-auto">
+                  <table className="w-full text-sm min-w-[440px]">
+                    <thead className="bg-muted/50">
+                      <tr className="text-xs text-muted-foreground font-medium">
+                        <th className="text-left px-3 py-2">식자재명</th>
+                        <th className="text-right px-3 py-2">수량</th>
+                        <th className="text-right px-3 py-2">단가</th>
+                        <th className="text-right px-3 py-2">공급가</th>
+                        <th className="text-left px-3 py-2">유통기한</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y">
+                      {data.items.map((item) => (
+                        <tr key={item.id} className="hover:bg-muted/20 transition-colors">
+                          <td className="px-3 py-2 font-medium whitespace-nowrap">
+                            {item.ingredientName}
+                          </td>
+                          <td className="px-3 py-2 text-right tabular-nums whitespace-nowrap">
+                            {Number(item.amount).toLocaleString()} {item.unit}
+                          </td>
+                          <td className="px-3 py-2 text-right tabular-nums text-muted-foreground whitespace-nowrap">
+                            {item.unitPrice != null
+                              ? `${Number(item.unitPrice).toLocaleString()}원`
+                              : '—'}
+                          </td>
+                          <td className="px-3 py-2 text-right tabular-nums text-muted-foreground whitespace-nowrap">
+                            {item.supplyPrice != null
+                              ? `${Number(item.supplyPrice).toLocaleString()}원`
+                              : '—'}
+                          </td>
+                          <td className="px-3 py-2 text-muted-foreground whitespace-nowrap">
+                            {item.expiryDate ?? '—'}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+          </div>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default InboundDetailModal;

--- a/src/features/ocr-inbound/hooks/useInboundHistory.ts
+++ b/src/features/ocr-inbound/hooks/useInboundHistory.ts
@@ -1,0 +1,25 @@
+import { useQuery } from '@tanstack/react-query';
+
+import useAuthStore from '@/features/auth/store/authStore';
+import {
+  fetchInboundDetail,
+  fetchInboundHistory,
+} from '@/features/ocr-inbound/api/inboundHistory.api';
+
+export function useInboundHistory() {
+  const storeId = useAuthStore((s) => s.storeId);
+  return useQuery({
+    queryKey: ['inboundHistory', storeId],
+    queryFn: () => fetchInboundHistory(storeId!),
+    enabled: !!storeId,
+  });
+}
+
+export function useInboundDetail(recordId: string | null) {
+  const storeId = useAuthStore((s) => s.storeId);
+  return useQuery({
+    queryKey: ['inboundDetail', storeId, recordId],
+    queryFn: () => fetchInboundDetail(storeId!, recordId!),
+    enabled: !!storeId && !!recordId,
+  });
+}

--- a/src/features/ocr-inbound/types/ocrInbound.api.types.ts
+++ b/src/features/ocr-inbound/types/ocrInbound.api.types.ts
@@ -28,6 +28,36 @@ export interface OcrApiResponse {
   metadata: OcrMetadata;
   items: OcrApiItem[];
   rawText: string;
+  imageUrl: string | null;
+}
+
+export interface InboundRecord {
+  id: string;
+  transactionDate: string | null;
+  supplierName: string | null;
+  invoiceNumber: string | null;
+  totalSupplyAmount: string | null;
+  totalTax: string | null;
+  totalAmount: string | null;
+  invoiceImageUrl: string | null;
+  createdAt: string;
+  itemCount: number;
+}
+
+export interface InboundRecordItem {
+  id: string;
+  ingredientId: string;
+  ingredientName: string;
+  unit: 'g' | 'ml' | '개';
+  amount: string;
+  unitPrice: string | null;
+  supplyPrice: string | null;
+  expiryDate: string | null;
+  memo: string | null;
+}
+
+export interface InboundRecordDetail extends Omit<InboundRecord, 'itemCount'> {
+  items: InboundRecordItem[];
 }
 
 export interface UnitConversionDto {

--- a/src/features/store-settings/api/ingredients.api.ts
+++ b/src/features/store-settings/api/ingredients.api.ts
@@ -48,9 +48,11 @@ export async function confirmInbound(
     memo?: string | null;
   }[],
   metadata?: OcrMetadata,
+  imageUrl?: string | null,
 ): Promise<void> {
   await axiosInstance.post(`/stores/${storeId}/ingredients/inbound`, {
     ...(metadata ? { metadata } : {}),
+    ...(imageUrl ? { imageUrl } : {}),
     items,
   });
 }

--- a/src/pages/InboundHistoryPage.tsx
+++ b/src/pages/InboundHistoryPage.tsx
@@ -1,0 +1,111 @@
+import { useState } from 'react';
+
+import { ArrowLeft, FileImage, Package } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+
+import { routePaths } from '@/app/routes/routePaths';
+import InboundDetailModal from '@/features/ocr-inbound/components/InboundDetailModal';
+import { useInboundHistory } from '@/features/ocr-inbound/hooks/useInboundHistory';
+import type { InboundRecord } from '@/features/ocr-inbound/types/ocrInbound.api.types';
+import { Button } from '@/shadcn/ui/button';
+import { Card, CardContent } from '@/shadcn/ui/card';
+import { Skeleton } from '@/shadcn/ui/skeleton';
+
+const InboundHistoryPage = () => {
+  const navigate = useNavigate();
+  const { data: records = [], isLoading } = useInboundHistory();
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const formatDate = (record: InboundRecord) =>
+    record.transactionDate ?? record.createdAt.slice(0, 10);
+
+  const formatAmount = (val: string | null) =>
+    val != null ? `${Number(val).toLocaleString()}원` : null;
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden bg-background">
+      <header className="shrink-0 flex items-center gap-3 border-b px-4 py-3 bg-background md:px-6 md:py-4">
+        <Button variant="ghost" size="icon" onClick={() => navigate(routePaths.inventory)}>
+          <ArrowLeft className="size-4" />
+        </Button>
+        <div className="min-w-0">
+          <p className="text-sm font-semibold">입고 이력</p>
+          <p className="text-xs text-muted-foreground">OCR로 처리한 입고 기록을 확인하세요</p>
+        </div>
+      </header>
+
+      {/* 목록 */}
+      <div className="flex-1 overflow-y-auto p-4">
+        {isLoading ? (
+          <div className="space-y-3">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton key={i} className="h-24 w-full rounded-xl" />
+            ))}
+          </div>
+        ) : records.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-64 text-muted-foreground gap-3">
+            <Package className="w-12 h-12 opacity-20" />
+            <p className="text-sm">아직 입고 이력이 없어요</p>
+            <p className="text-xs">OCR 입고 처리를 완료하면 여기에 기록됩니다</p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {records.map((record) => (
+              <Card key={record.id} className="hover:shadow-sm transition-shadow">
+                <CardContent className="px-4 py-3 sm:px-5 sm:py-4">
+                  <div className="flex items-center gap-3 sm:gap-4">
+                    {/* 날짜 */}
+                    <div className="shrink-0 w-16 sm:w-20 text-center">
+                      <p className="text-[10px] sm:text-xs text-muted-foreground leading-tight">
+                        {formatDate(record).slice(0, 7)}
+                      </p>
+                      <p className="text-base sm:text-lg font-bold tabular-nums leading-tight">
+                        {formatDate(record).slice(8, 10)}일
+                      </p>
+                    </div>
+
+                    <div className="w-px h-9 bg-border shrink-0" />
+
+                    {/* 정보 */}
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-1.5 mb-0.5">
+                        <p className="font-semibold text-sm truncate">
+                          {record.supplierName ?? '공급업체 정보 없음'}
+                        </p>
+                        {record.invoiceImageUrl && (
+                          <span className="shrink-0 inline-flex items-center gap-0.5 text-[10px] text-baro-blue bg-blue-50 border border-blue-200/60 px-1.5 py-0.5 rounded-full dark:bg-blue-950/40 dark:border-blue-800/40">
+                            <FileImage className="w-2.5 h-2.5" />
+                            명세서
+                          </span>
+                        )}
+                      </div>
+                      <p className="text-xs text-muted-foreground truncate">
+                        품목 {record.itemCount}개
+                        {record.totalAmount != null && ` · ${formatAmount(record.totalAmount)}`}
+                        {record.invoiceNumber && ` · ${record.invoiceNumber}`}
+                      </p>
+                    </div>
+
+                    {/* 상세보기 */}
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="shrink-0 text-xs"
+                      onClick={() => setSelectedId(record.id)}
+                    >
+                      상세보기
+                    </Button>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <InboundDetailModal recordId={selectedId} onClose={() => setSelectedId(null)} />
+    </div>
+  );
+};
+
+export default InboundHistoryPage;

--- a/src/pages/OcrInboundPage.tsx
+++ b/src/pages/OcrInboundPage.tsx
@@ -7,7 +7,7 @@ import { toast } from 'sonner';
 
 import { routePaths } from '@/app/routes/routePaths';
 import useAuthStore from '@/features/auth/store/authStore';
-import { uploadOcrImage } from '@/features/ocr-inbound/api/ocr.api';
+import { deleteInvoiceImage, uploadOcrImage } from '@/features/ocr-inbound/api/ocr.api';
 import {
   saveUnitConversions,
   type UnitConversionSaveDto,
@@ -25,6 +25,15 @@ import { confirmInbound } from '@/features/store-settings/api/ingredients.api';
 import { updateStoreSettings } from '@/features/store-settings/api/storeSettings.api';
 import { useIngredients } from '@/features/store-settings/hooks/useIngredients';
 import { useStoreSettings } from '@/features/store-settings/hooks/useStoreSettings';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/shadcn/ui/alert-dialog';
+import { Button } from '@/shadcn/ui/button';
 import { getApiErrorCode, getApiErrorMessage } from '@/shared/utils/apiError';
 
 type Step = 'upload' | 'analyzing' | 'review';
@@ -126,7 +135,10 @@ const OcrInboundPage = () => {
   const [step, setStep] = useState<Step>(initialStep);
   const [items, setItems] = useState<OcrInboundItem[]>(initialItems);
   const [metadata, setMetadata] = useState<OcrMetadata | null>(initialMetadata);
+  const [invoiceImageUrl, setInvoiceImageUrl] = useState<string | null>(null);
   const [isConfirming, setIsConfirming] = useState(false);
+  const [showCancelDialog, setShowCancelDialog] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
   const handledInitialFile = useRef(false);
   const conversionApplied = useRef(false);
   const unitSynced = useRef(false);
@@ -194,6 +206,7 @@ const OcrInboundPage = () => {
         setImageBase64(base64);
         setMetadata(result.metadata);
         setItems(processedItems);
+        setInvoiceImageUrl(result.invoiceImageUrl);
         setStep('review');
         saveDraft({ imageBase64: base64, metadata: result.metadata, items: processedItems });
       } catch (err) {
@@ -223,11 +236,36 @@ const OcrInboundPage = () => {
     if (imageUrl?.startsWith('blob:')) URL.revokeObjectURL(imageUrl);
     clearDraft();
     conversionApplied.current = false;
+    unitSynced.current = false;
     setStep('upload');
     setImageUrl(null);
     setImageBase64(null);
     setItems([]);
     setMetadata(null);
+    setInvoiceImageUrl(null);
+  };
+
+  const requestCancel = () => {
+    if (invoiceImageUrl) {
+      setShowCancelDialog(true);
+    } else {
+      handleReset();
+    }
+  };
+
+  const handleDeleteAndReset = async () => {
+    if (invoiceImageUrl && storeId) {
+      setIsDeleting(true);
+      try {
+        await deleteInvoiceImage(storeId, invoiceImageUrl);
+      } catch {
+        toast.error('명세서 이미지 삭제에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+      } finally {
+        setIsDeleting(false);
+      }
+    }
+    setShowCancelDialog(false);
+    handleReset();
   };
 
   const handleConfirm = async () => {
@@ -286,7 +324,7 @@ const OcrInboundPage = () => {
         qc.invalidateQueries({ queryKey: ['unitConversions', storeId] });
       }
 
-      await confirmInbound(storeId, inboundItems, metadata ?? undefined);
+      await confirmInbound(storeId, inboundItems, metadata ?? undefined, invoiceImageUrl);
 
       if (safetyStockPct > 0) {
         try {
@@ -313,7 +351,7 @@ const OcrInboundPage = () => {
     if (step === 'upload') {
       navigate(-1);
     } else {
-      handleReset();
+      requestCancel();
     }
   };
 
@@ -360,11 +398,38 @@ const OcrInboundPage = () => {
             metadata={metadata}
             onItemsChange={handleItemsChange}
             onConfirm={handleConfirm}
-            onReset={handleReset}
+            onReset={requestCancel}
             isConfirming={isConfirming}
           />
         )}
       </div>
+
+      <AlertDialog open={showCancelDialog} onOpenChange={(o) => !o && setShowCancelDialog(false)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>입고를 취소할까요?</AlertDialogTitle>
+            <AlertDialogDescription>
+              취소하면 인식된 내용과 저장된 명세서 이미지가 삭제됩니다.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setShowCancelDialog(false)}
+              disabled={isDeleting}
+            >
+              계속 검수
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => void handleDeleteAndReset()}
+              disabled={isDeleting}
+            >
+              {isDeleting ? '삭제 중...' : '삭제 후 나가기'}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 };

--- a/src/shared/components/IngredientRegisterModal.tsx
+++ b/src/shared/components/IngredientRegisterModal.tsx
@@ -79,7 +79,6 @@ const IngredientRegisterModal = ({
       initial[c.id] = c.factor;
     });
     // open될 때 서버 데이터로 로컬 편집 상태 초기화 — 외부 상태와 동기화 목적으로 허용
-
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setLocalFactors(initial);
   }, [open, conversions.length]);


### PR DESCRIPTION
## 📌 요약

- OCR 입고 처리 시 거래명세서 이미지를 서버에 보관하고, 취소 시 삭제하는 플로우 추가
- 입고 이력 목록 페이지 및 상세 모달 추가 (전체 재고현황에서 접근)

<br/>

## 🏷️ 관련 이슈

- Closes #238
- Closes #239

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- OCR 업로드 응답에서 `invoiceImageUrl` 수신 및 입고 확정 시 전달
- 검수 취소/리셋 시 저장된 명세서 이미지 DELETE API 호출 (AlertDialog 확인)
- 입고 이력 목록 페이지 추가: 날짜·공급업체·품목 수·금액 표시
- 상세 모달: 거래명세서 이미지 인라인 뷰어 + 저장 버튼, 데스크탑 2열 레이아웃

<br/>

### 📂 세부 변경사항

- `ocr.api.ts`: `invoiceImageUrl` 반환, `deleteInvoiceImage` 추가
- `ingredients.api.ts`: `confirmInbound`에 `imageUrl` 파라미터 추가
- `OcrInboundPage.tsx`: 이미지 URL 상태 관리 및 취소 다이얼로그 연동
- `inboundHistory.api.ts` / `useInboundHistory.ts`: 목록·상세 API 훅 추가
- `InboundHistoryPage.tsx`: 입고 이력 목록 페이지 (헤더 뒤로가기 포함)
- `InboundDetailModal.tsx`: 상세 모달 (이미지 뷰어, 다운로드, 품목 테이블)
- `InventoryTable.tsx`: 상단에 "입고 이력" 버튼 추가, 태블릿 반응형 개선 (lg 기준)
- `AppSidebar.tsx`: 입고 이력 사이드바 항목 제거

<br/>

## 🧪 테스트 방법

1. OCR 입고 처리 후 취소 → "삭제 후 나가기" 클릭 시 이미지 삭제 확인
2. OCR 입고 처리 완료 후 전체 재고현황 → "입고 이력" 버튼 클릭
3. 입고 이력 목록에서 "상세보기" → 명세서 이미지 인라인 확인 및 저장 버튼 동작
4. 태블릿(768~1023px) 사이즈에서 재고 목록이 카드 뷰로 표시되는지 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [x] Backend
- [x] API

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음

<br/>

## 💬 Additional Notes

- `IngredientRegisterModal`, `MenuRegistrationModal`의 기존 `eslint-disable` 주석이 lint --fix로 제거되었다가 복원됨
