### PR TITLE
💄 (#217)(#216) ui/fix: 랜딩 페이지 실시간 재고 차감 내용 반영 및 돌아가기 버그 수정

### DIFF
--- a/src/features/landing/components/HeroSection.tsx
+++ b/src/features/landing/components/HeroSection.tsx
@@ -17,8 +17,13 @@ const HeroSection = () => {
 
   const handleStartClick = () => {
     if (isLoggedIn) {
-      if (canGoBack) navigate(-1);
-      else navigate(routePaths.myStores);
+      const returnPath = sessionStorage.getItem('landingReturnPath');
+      if (returnPath) {
+        sessionStorage.removeItem('landingReturnPath');
+        navigate(returnPath);
+      } else {
+        navigate(canGoBack ? routePaths.dashboard : routePaths.myStores);
+      }
     } else {
       navigate(routePaths.login);
     }
@@ -153,7 +158,9 @@ const HeroSection = () => {
                     <p className="text-[10px] font-black text-baro-black-muted tracking-tighter uppercase mb-0.5">
                       Closing
                     </p>
-                    <p className="text-sm font-bold leading-none">오늘 마감 완료, 재고 자동 차감</p>
+                    <p className="text-sm font-bold leading-none">
+                      마감 완료, 실제 잔량 확인 후 재고 확정
+                    </p>
                   </div>
                 </div>
               </div>

--- a/src/features/landing/components/HowItWorksSection.tsx
+++ b/src/features/landing/components/HowItWorksSection.tsx
@@ -17,7 +17,7 @@ const timeline = [
     icon: <QrCode size={20} />,
     title: '점심 주문이 쏟아져요',
     description:
-      '손님이 QR을 스캔하면 주문이 실시간으로 들어옵니다. 사장님은 응대 대신 운영에만 집중하세요.',
+      '손님이 QR을 스캔하면 주문이 실시간으로 들어오고, 수락하는 순간 재고가 즉시 차감됩니다. 재고가 부족하면 바로 알림이 와요.',
     color: 'bg-baro-blue',
   },
   {
@@ -32,7 +32,8 @@ const timeline = [
     time: '오후 10:00',
     icon: <ClipboardCheck size={20} />,
     title: '마감, 1분이면 끝',
-    description: '당일 판매 메뉴 기반으로 재고가 자동 차감됩니다. 30분짜리 손계산은 이제 없어요.',
+    description:
+      '예상 잔량을 보고 실제 남은 재고를 입력하면 끝. 마감 때 재고 계산에 30분 쓰는 일은 없어요.',
     color: 'bg-baro-black dark:bg-neutral-600',
   },
 ];

--- a/src/features/landing/components/Navbar.tsx
+++ b/src/features/landing/components/Navbar.tsx
@@ -9,6 +9,17 @@ import ThemeToggle from '@/features/theme/components/ThemeToggle';
 import { useTheme } from '@/features/theme/hooks/useTheme';
 import { Button } from '@/shadcn/ui/button';
 
+const LANDING_RETURN_KEY = 'landingReturnPath';
+
+const PUBLIC_PATHS = new Set<string>([
+  routePaths.landing,
+  routePaths.notices,
+  routePaths.terms,
+  routePaths.privacy,
+  routePaths.support,
+  routePaths.login,
+]);
+
 const Navbar = () => {
   const navigate = useNavigate();
   const location = useLocation();
@@ -18,14 +29,22 @@ const Navbar = () => {
   const canGoBack = location.key !== 'default';
 
   const handleLogoClick = () => {
+    if (isLoggedIn && !PUBLIC_PATHS.has(location.pathname)) {
+      sessionStorage.setItem(LANDING_RETURN_KEY, location.pathname);
+    }
     navigate(routePaths.landing);
     setIsMenuOpen(false);
   };
 
   const handleCtaClick = () => {
     if (isLoggedIn) {
-      if (canGoBack) navigate(-1);
-      else navigate(routePaths.myStores);
+      const returnPath = sessionStorage.getItem(LANDING_RETURN_KEY);
+      if (returnPath) {
+        sessionStorage.removeItem(LANDING_RETURN_KEY);
+        navigate(returnPath);
+      } else {
+        navigate(canGoBack ? routePaths.dashboard : routePaths.myStores);
+      }
     } else {
       navigate(routePaths.login);
     }

--- a/src/features/landing/constants/landing.constants.ui.tsx
+++ b/src/features/landing/constants/landing.constants.ui.tsx
@@ -28,9 +28,9 @@ export const features: Feature[] = [
   },
   {
     icon: <Zap size={32} />,
-    title: '마감 자동화',
+    title: '실시간 재고 관리',
     description:
-      '당일 판매 메뉴와 레시피를 기반으로 이론 사용량을 계산하고, 검토 후 재고를 자동 차감합니다.',
+      '주문 수락 시 레시피 기반으로 재고가 즉시 차감됩니다. 마감엔 실제 잔량을 확인하고 차이만 보정하면 끝.',
     color: 'text-baro-black',
     bgColor: 'bg-baro-black-muted/5',
   },

--- a/src/widgets/AppSidebar.tsx
+++ b/src/widgets/AppSidebar.tsx
@@ -1,5 +1,5 @@
 import { LayoutDashboard, Package, Truck, Store, Settings, Home, Globe, User } from 'lucide-react';
-import { NavLink, useLocation } from 'react-router-dom';
+import { NavLink, useLocation, useNavigate } from 'react-router-dom';
 
 import { routePaths } from '@/app/routes/routePaths';
 import useAuthStore from '@/features/auth/store/authStore';
@@ -21,11 +21,12 @@ import {
 import { Skeleton } from '@/shadcn/ui/skeleton';
 import BaroLogo from '@/shared/assets/images/baro-logo.png';
 
+const LANDING_RETURN_KEY = 'landingReturnPath';
+
 const BOTTOM_NAV_ITEMS = [
   { label: '회원 설정', icon: Settings, to: routePaths.settings },
   { label: '계정 홈', icon: User, to: routePaths.myStores },
   { label: '가게 홈', icon: Home, to: routePaths.storeHome },
-  { label: '서비스 소개', icon: Globe, to: routePaths.landing },
 ];
 
 const BUSINESS_TYPE_LABEL: Record<string, string> = {
@@ -47,6 +48,7 @@ const AppSidebar = ({
   businessType,
   isLoading = false,
 }: AppSidebarProps) => {
+  const navigate = useNavigate();
   const location = useLocation();
   const storeId = useAuthStore((s) => s.storeId);
   const { isCompleted } = useClosingStatus(storeId);
@@ -149,6 +151,19 @@ const AppSidebar = ({
               </SidebarMenuButton>
             </SidebarMenuItem>
           ))}
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              isActive={location.pathname === routePaths.landing}
+              tooltip="서비스 소개"
+              onClick={() => {
+                sessionStorage.setItem(LANDING_RETURN_KEY, location.pathname);
+                navigate(routePaths.landing);
+              }}
+            >
+              <Globe />
+              <span>서비스 소개</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
         </SidebarMenu>
 
         <SidebarSeparator className="mx-0" />


### PR DESCRIPTION
## 📌 요약

- v1.2.0 실시간 재고 차감 설계에 맞게 랜딩 페이지 문구 전반 업데이트
- `navigate(-1)` 기반 돌아가기 버그 수정 — sessionStorage로 복귀 경로 저장

<br/>

## 🏷️ 관련 이슈

- Closes #217
- Closes #216

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- **랜딩 문구 개편**: QR 주문 타임라인에 "수락 즉시 차감·재고 부족 알림" 추가, 마감 타임라인은 "예상 잔량 확인 후 실제 잔량 입력" 방식으로 수정, 기능 카드 '마감 자동화' → '실시간 재고 관리' 변경
- **돌아가기 버그 수정**: 서비스 페이지 → 랜딩 진입 시 출발 경로를 `sessionStorage('landingReturnPath')`에 저장, 돌아가기 클릭 시 저장된 경로로 이동 (서브 페이지 중간 방문 여부 무관)

<br/>

### 📂 세부 변경사항

- `HowItWorksSection.tsx`: QR 주문·마감 타임라인 설명 수정
- `landing.constants.ui.tsx`: 기능 카드 제목·설명 수정
- `HeroSection.tsx`: 마감 데코 카드 문구 수정 + 돌아가기 핸들러 sessionStorage 방식으로 변경
- `Navbar.tsx`: 로고 클릭 시 현재 경로 저장, CTA 버튼 sessionStorage 방식으로 변경
- `AppSidebar.tsx`: '서비스 소개' NavLink → onClick으로 변경하여 동일하게 경로 저장

<br/>

## 📸 Screenshots

| Before | After |
| ------ | ----- |
| QR 주문: "사장님은 응대 대신 운영에만 집중하세요." | QR 주문: "수락하는 순간 재고가 즉시 차감됩니다. 재고가 부족하면 바로 알림이 와요." |
| 마감: "당일 판매 메뉴 기반으로 재고가 자동 차감됩니다." | 마감: "예상 잔량을 보고 실제 남은 재고를 입력하면 끝." |
| 기능 카드: '마감 자동화' | 기능 카드: '실시간 재고 관리' |

<br/>

## 🧪 테스트 방법

1. 서비스 페이지(예: 가게 설정)에서 사이드바 '서비스 소개' 클릭 → 랜딩 이동 확인
2. 랜딩에서 공지사항·약관 등 서브 페이지 방문 후 돌아와서 '돌아가기' 클릭 → 원래 서비스 페이지로 정상 복귀 확인
3. Navbar 로고 클릭으로 랜딩 진입 후 동일하게 확인
4. 직접 URL(`/`)로 랜딩 접속 시 '계정 홈으로 가기' 클릭 → myStores 이동 확인
5. 랜딩 페이지 문구 데스크탑·모바일 반응형 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [ ] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [ ] 기존 기능 영향 없음
- [ ] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- 버그 수정 흐름: `/store-settings` → 랜딩(`sessionStorage` 저장) → `/notices` → 랜딩 → "돌아가기" → `/store-settings` ✅
- `landingReturnPath` 키는 Navbar·AppSidebar 양쪽에서 동일하게 사용하므로 어느 쪽 경로로 진입해도 동일하게 동작