### PR TITLE
🐛 (#242, #243) fix: 대표 메뉴 설정 및 품절 처리 관련 기능 개선

### DIFF
--- a/src/features/customer-order/components/CustomerOrderStatusCard.tsx
+++ b/src/features/customer-order/components/CustomerOrderStatusCard.tsx
@@ -8,6 +8,7 @@ import type { ApiOrder } from '@/features/customer-order/types/customerOrder.api
 import { useOrders, useUpdateOrderStatus } from '@/features/dashboard/hooks/useOrders';
 import { useOrderSSE } from '@/features/dashboard/hooks/useOrderSSE';
 import useOrderWarningsStore from '@/features/dashboard/store/orderWarningsStore';
+import { useUpdateMenu } from '@/features/store-settings/hooks/useMenus';
 import {
   AlertDialog,
   AlertDialogContent,
@@ -80,6 +81,75 @@ const CancelCompletedOrderModal = ({
   </AlertDialog>
 );
 
+/* ── 재고 부족 주문 취소 시 품절 모달 ── */
+interface SoldOutConfirmModalProps {
+  open: boolean;
+  menuNames: string[];
+  onSoldOut: () => void;
+  onCancelOnly: () => void;
+  onClose: () => void;
+  isPending: boolean;
+}
+
+const SoldOutConfirmModal = ({
+  open,
+  menuNames,
+  onSoldOut,
+  onCancelOnly,
+  onClose,
+  isPending,
+}: SoldOutConfirmModalProps) => (
+  <AlertDialog open={open} onOpenChange={(o) => !o && onClose()}>
+    <AlertDialogContent className="w-full">
+      <AlertDialogHeader className="w-full">
+        <AlertDialogTitle className="w-full">주문을 취소할까요?</AlertDialogTitle>
+        <AlertDialogDescription className="w-full">
+          <div className="w-full space-y-3 text-sm text-muted-foreground">
+            <p>재고가 부족한 메뉴가 포함된 주문입니다.</p>
+            <div className="w-full rounded-lg border bg-muted/50 p-3 space-y-2.5">
+              <p className="font-medium text-foreground">아래 메뉴를 품절 처리할까요?</p>
+              <div className="flex flex-wrap gap-1.5">
+                {menuNames.map((name, i) => (
+                  <span
+                    key={i}
+                    className="rounded-full bg-background border px-2.5 py-0.5 text-xs font-medium text-foreground"
+                  >
+                    {name}
+                  </span>
+                ))}
+              </div>
+              <ul className="text-xs space-y-1">
+                <li>• 품절 처리된 메뉴는 손님 주문 화면에 표시되지 않습니다.</li>
+                <li>• 재고가 충분해지면 자동으로 품절이 해제됩니다.</li>
+              </ul>
+            </div>
+          </div>
+        </AlertDialogDescription>
+      </AlertDialogHeader>
+      <AlertDialogFooter className="flex-col gap-2 sm:flex-col sm:space-x-0">
+        <Button
+          className="h-10 w-full bg-baro-red text-white hover:bg-baro-red/80"
+          onClick={onSoldOut}
+          disabled={isPending}
+        >
+          품절 처리하고 취소
+        </Button>
+        <Button
+          variant="outline"
+          className="h-10 w-full"
+          onClick={onCancelOnly}
+          disabled={isPending}
+        >
+          그냥 취소만
+        </Button>
+        <Button variant="ghost" className="h-10 w-full" onClick={onClose} disabled={isPending}>
+          돌아가기
+        </Button>
+      </AlertDialogFooter>
+    </AlertDialogContent>
+  </AlertDialog>
+);
+
 /* ── 개별 주문 카드 ── */
 interface OrderCardProps {
   order: ApiOrder;
@@ -89,110 +159,145 @@ interface OrderCardProps {
 
 const OrderCard = ({ order, storeId, onCancelCompleted }: OrderCardProps) => {
   const { mutate: changeStatus, isPending } = useUpdateOrderStatus(storeId);
+  const { mutate: updateMenu, isPending: isMarkingSoldOut } = useUpdateMenu();
   const stockWarnings = useOrderWarningsStore((s) => s.warnings[order.id]);
+  const [showSoldOutModal, setShowSoldOutModal] = useState(false);
 
   const itemSummary = order.items?.map((i) => `${i.menu.name} x${i.quantity}`).join(' · ') ?? '';
+  const orderMenuNames = order.items?.map((i) => i.menu.name) ?? [];
+
+  const handlePendingCancel = () => {
+    if (stockWarnings?.length) {
+      setShowSoldOutModal(true);
+    } else {
+      changeStatus({ orderId: order.id, status: 'cancelled' });
+    }
+  };
+
+  const handleSoldOut = () => {
+    order.items?.forEach((item) => {
+      updateMenu({ menuId: item.menuId, data: { isAvailable: false } });
+    });
+    changeStatus({ orderId: order.id, status: 'cancelled' });
+    setShowSoldOutModal(false);
+  };
+
+  const handleCancelOnly = () => {
+    changeStatus({ orderId: order.id, status: 'cancelled' });
+    setShowSoldOutModal(false);
+  };
 
   return (
-    <div className="rounded-lg border bg-card p-3 space-y-3">
-      <div className="flex items-center justify-between gap-2">
-        <div className="flex items-center gap-2 min-w-0">
-          <span className="text-sm font-medium truncate">{order.tableNumber}번 테이블</span>
-          <span className="text-xs text-muted-foreground shrink-0">
-            #{order.id.slice(-4).toUpperCase()}
-          </span>
-          <OrderStatusBadge status={order.status} />
-        </div>
-        <div className="flex items-center gap-1 text-xs text-muted-foreground shrink-0">
-          <Clock className="size-3" />
-          {formatTimeAgo(order.createdAt)}
-        </div>
-      </div>
-
-      {/* 재고 부족 경고 배너 */}
-      {stockWarnings && stockWarnings.length > 0 && (
-        <div className="flex items-start gap-2 rounded-md bg-baro-red/5 border border-baro-red/30 px-3 py-2 text-xs">
-          <AlertTriangle className="size-3.5 text-baro-red shrink-0 mt-0.5" />
-          <div>
-            <p className="font-semibold text-baro-red">사장님! 수락 전 확인해 주세요.</p>
-            <p className="text-baro-red/80 mt-0.5">
-              {stockWarnings
-                .map(
-                  (w) =>
-                    `${w.ingredientName} (필요 ${w.required}${w.unit}, 가용 재고 ${w.currentStock}${w.unit})`,
-                )
-                .join(', ')}
-              이 부족해요.
-            </p>
+    <>
+      <div className="rounded-lg border bg-card p-3 space-y-3">
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2 min-w-0">
+            <span className="text-sm font-medium truncate">{order.tableNumber}번 테이블</span>
+            <span className="text-xs text-muted-foreground shrink-0">
+              #{order.id.slice(-4).toUpperCase()}
+            </span>
+            <OrderStatusBadge status={order.status} />
+          </div>
+          <div className="flex items-center gap-1 text-xs text-muted-foreground shrink-0">
+            <Clock className="size-3" />
+            {formatTimeAgo(order.createdAt)}
           </div>
         </div>
-      )}
 
-      {itemSummary && <p className="text-xs text-muted-foreground line-clamp-2">{itemSummary}</p>}
+        {/* 재고 부족 경고 배너 */}
+        {stockWarnings && stockWarnings.length > 0 && (
+          <div className="flex items-start gap-2 rounded-md bg-baro-red/5 border border-baro-red/30 px-3 py-2 text-xs">
+            <AlertTriangle className="size-3.5 text-baro-red shrink-0 mt-0.5" />
+            <div>
+              <p className="font-semibold text-baro-red">사장님! 수락 전 확인해 주세요.</p>
+              <p className="text-baro-red/80 mt-0.5">
+                {stockWarnings
+                  .map(
+                    (w) =>
+                      `${w.ingredientName} (필요 ${w.required}${w.unit}, 가용 재고 ${w.currentStock}${w.unit})`,
+                  )
+                  .join(', ')}
+                이 부족해요.
+              </p>
+            </div>
+          </div>
+        )}
 
-      {order.customerNote && (
-        <p className="text-xs text-muted-foreground line-clamp-2 py-1">💬 {order.customerNote}</p>
-      )}
+        {itemSummary && <p className="text-xs text-muted-foreground line-clamp-2">{itemSummary}</p>}
 
-      <div className="flex items-center justify-between">
-        <span className="text-sm font-semibold">{order.totalPrice.toLocaleString()}원</span>
-        <div className="flex gap-1.5">
-          {order.status === 'pending' && (
-            <>
-              <Button
-                size="sm"
-                className="h-7 px-2.5 text-xs bg-baro-blue text-white hover:bg-baro-blue/80"
-                disabled={isPending}
-                onClick={() => changeStatus({ orderId: order.id, status: 'preparing' })}
-              >
-                수락
-              </Button>
+        {order.customerNote && (
+          <p className="text-xs text-muted-foreground line-clamp-2 py-1">💬 {order.customerNote}</p>
+        )}
+
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-semibold">{order.totalPrice.toLocaleString()}원</span>
+          <div className="flex gap-1.5">
+            {order.status === 'pending' && (
+              <>
+                <Button
+                  size="sm"
+                  className="h-7 px-2.5 text-xs bg-baro-blue text-white hover:bg-baro-blue/80"
+                  disabled={isPending}
+                  onClick={() => changeStatus({ orderId: order.id, status: 'preparing' })}
+                >
+                  수락
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-7 px-2.5 text-xs"
+                  disabled={isPending}
+                  onClick={handlePendingCancel}
+                >
+                  취소
+                </Button>
+              </>
+            )}
+            {order.status === 'preparing' && (
+              <>
+                <Button
+                  size="sm"
+                  className="h-7 px-2.5 text-xs bg-baro-blue text-white hover:bg-baro-blue/80"
+                  disabled={isPending}
+                  onClick={() => changeStatus({ orderId: order.id, status: 'completed' })}
+                >
+                  완료처리
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-7 px-2.5 text-xs"
+                  disabled={isPending}
+                  onClick={() => changeStatus({ orderId: order.id, status: 'cancelled' })}
+                >
+                  취소
+                </Button>
+              </>
+            )}
+            {order.status === 'completed' && (
               <Button
                 size="sm"
                 variant="outline"
-                className="h-7 px-2.5 text-xs"
+                className="h-7 px-2.5 text-xs text-muted-foreground"
                 disabled={isPending}
-                onClick={() => changeStatus({ orderId: order.id, status: 'cancelled' })}
+                onClick={() => onCancelCompleted(order.id)}
               >
                 취소
               </Button>
-            </>
-          )}
-          {order.status === 'preparing' && (
-            <>
-              <Button
-                size="sm"
-                className="h-7 px-2.5 text-xs bg-baro-blue text-white hover:bg-baro-blue/80"
-                disabled={isPending}
-                onClick={() => changeStatus({ orderId: order.id, status: 'completed' })}
-              >
-                완료처리
-              </Button>
-              <Button
-                size="sm"
-                variant="outline"
-                className="h-7 px-2.5 text-xs"
-                disabled={isPending}
-                onClick={() => changeStatus({ orderId: order.id, status: 'cancelled' })}
-              >
-                취소
-              </Button>
-            </>
-          )}
-          {order.status === 'completed' && (
-            <Button
-              size="sm"
-              variant="outline"
-              className="h-7 px-2.5 text-xs text-muted-foreground"
-              disabled={isPending}
-              onClick={() => onCancelCompleted(order.id)}
-            >
-              취소
-            </Button>
-          )}
+            )}
+          </div>
         </div>
       </div>
-    </div>
+
+      <SoldOutConfirmModal
+        open={showSoldOutModal}
+        menuNames={orderMenuNames}
+        onSoldOut={handleSoldOut}
+        onCancelOnly={handleCancelOnly}
+        onClose={() => setShowSoldOutModal(false)}
+        isPending={isPending || isMarkingSoldOut}
+      />
+    </>
   );
 };
 

--- a/src/features/customer-order/types/customerOrder.api.types.ts
+++ b/src/features/customer-order/types/customerOrder.api.types.ts
@@ -31,6 +31,7 @@ export interface ApiMenu {
   description: string | null;
   imageUrl: string | null;
   isAvailable: boolean;
+  isFeatured: boolean;
   categoryId: string | null;
   createdAt: string;
   updatedAt: string;

--- a/src/features/store-settings/api/menus.api.ts
+++ b/src/features/store-settings/api/menus.api.ts
@@ -7,6 +7,7 @@ export interface MenuDto {
   description: string | null;
   imageUrl: string | null;
   isAvailable: boolean;
+  isFeatured: boolean;
   categoryId: string | null;
 }
 

--- a/src/pages/CustomerOrderPage.tsx
+++ b/src/pages/CustomerOrderPage.tsx
@@ -10,6 +10,7 @@ import {
   Minus,
   Plus,
   ShoppingCart,
+  Star,
   UtensilsCrossed,
 } from 'lucide-react';
 import { useParams } from 'react-router-dom';
@@ -75,6 +76,9 @@ const MenuItemListCard = ({ item, quantity, themeHex, onUpdate }: MenuItemCardPr
     )}
     <div className="flex-1 min-w-0">
       <div className="flex items-center gap-1.5">
+        {item.isFeatured && (
+          <Star className="size-3.5 shrink-0 fill-baro-yellow text-baro-yellow" />
+        )}
         <p className="text-sm font-semibold text-gray-900 truncate">{item.name}</p>
         {!item.isAvailable && (
           <span className="text-xs text-gray-400 bg-gray-100 px-1.5 py-0.5 rounded shrink-0">
@@ -106,6 +110,14 @@ const MenuItemGridCard = ({ item, quantity, themeHex, onUpdate }: MenuItemCardPr
       ) : (
         <div className="flex h-full items-center justify-center">
           <ImageOff className="size-8 text-gray-300" />
+        </div>
+      )}
+      {item.isFeatured && (
+        <div className="absolute left-1.5 top-1.5">
+          <span className="flex items-center gap-0.5 rounded-full bg-white/90 px-1.5 py-0.5 text-[10px] font-medium text-baro-yellow-text shadow-sm">
+            <Star className="size-2.5 fill-baro-yellow text-baro-yellow" />
+            대표
+          </span>
         </div>
       )}
       {!item.isAvailable && (

--- a/src/pages/SettingsMenusPage.tsx
+++ b/src/pages/SettingsMenusPage.tsx
@@ -2,6 +2,7 @@ import { useMemo, useRef, useState } from 'react';
 
 import {
   ArrowLeft,
+  Ban,
   ChevronDown,
   ChevronUp,
   ImageOff,
@@ -11,6 +12,7 @@ import {
   Plus,
   ScanLine,
   Search,
+  Star,
   Trash2,
   UtensilsCrossed,
   X,
@@ -52,6 +54,7 @@ type MenuForm = {
   price: string;
   imageUrl: string | null;
   categoryId: string;
+  isFeatured: boolean;
 };
 
 const EMPTY_FORM: MenuForm = {
@@ -60,6 +63,7 @@ const EMPTY_FORM: MenuForm = {
   price: '',
   imageUrl: null,
   categoryId: '',
+  isFeatured: false,
 };
 
 /* ── 메뉴 등록/수정 모달 ── */
@@ -89,6 +93,7 @@ const MenuModal = ({
           price: String(editing.price),
           imageUrl: editing.imageUrl,
           categoryId: editing.categoryId ?? '',
+          isFeatured: editing.isFeatured,
         }
       : EMPTY_FORM,
   );
@@ -135,6 +140,7 @@ const MenuModal = ({
       price: Number(form.price),
       imageUrl: form.imageUrl,
       categoryId: form.categoryId || null,
+      isFeatured: form.isFeatured,
     });
   };
 
@@ -244,27 +250,45 @@ const MenuModal = ({
             />
           </div>
 
-          {/* 가격 */}
-          <div className="space-y-1.5">
-            <Label htmlFor="menu-price">
-              가격 <span className="text-red-500">*</span>
-            </Label>
-            <div className="relative">
-              <Input
-                id="menu-price"
-                type="number"
-                placeholder="0"
-                min={0}
-                value={form.price}
-                onChange={(e) => setForm((p) => ({ ...p, price: e.target.value }))}
-                aria-invalid={!!errors.price}
-                className="h-10 pr-8"
-              />
-              <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">
-                원
-              </span>
+          {/* 가격 + 대표 메뉴 */}
+          <div className="flex items-end gap-3">
+            <div className="flex-1 space-y-1.5">
+              <Label htmlFor="menu-price">
+                가격 <span className="text-red-500">*</span>
+              </Label>
+              <div className="relative">
+                <Input
+                  id="menu-price"
+                  type="number"
+                  placeholder="0"
+                  min={0}
+                  value={form.price}
+                  onChange={(e) => setForm((p) => ({ ...p, price: e.target.value }))}
+                  aria-invalid={!!errors.price}
+                  className="h-10 pr-8"
+                />
+                <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">
+                  원
+                </span>
+              </div>
+              {errors.price && <p className="text-xs text-destructive">{errors.price}</p>}
             </div>
-            {errors.price && <p className="text-xs text-destructive">{errors.price}</p>}
+
+            {/* 대표 메뉴 토글 */}
+            <button
+              type="button"
+              onClick={() => setForm((p) => ({ ...p, isFeatured: !p.isFeatured }))}
+              className="mb-0.5 flex h-10 items-center gap-1.5 rounded-lg border px-3 transition-colors hover:bg-baro-yellow/10"
+            >
+              <Star
+                className={
+                  form.isFeatured
+                    ? 'size-4 fill-baro-yellow text-baro-yellow'
+                    : 'size-4 text-gray-300'
+                }
+              />
+              <span className="text-xs font-medium text-muted-foreground">대표 메뉴</span>
+            </button>
           </div>
         </div>
 
@@ -291,12 +315,18 @@ const MenuCard = ({
   menu,
   onEdit,
   onDelete,
+  onToggleFeatured,
+  onToggleAvailable,
 }: {
   menu: MenuDto;
   onEdit: () => void;
   onDelete: () => void;
+  onToggleFeatured: () => void;
+  onToggleAvailable: () => void;
 }) => (
-  <div className="group overflow-hidden rounded-xl border bg-card transition-shadow hover:shadow-md">
+  <div
+    className={`group overflow-hidden rounded-xl border bg-card transition-shadow hover:shadow-md${!menu.isAvailable ? ' opacity-60' : ''}`}
+  >
     <div className="relative h-28 bg-gray-100 dark:bg-gray-800">
       {menu.imageUrl ? (
         <img src={menu.imageUrl} alt={menu.name} className="h-full w-full object-cover" />
@@ -305,10 +335,39 @@ const MenuCard = ({
           <ImageOff className="size-8 text-gray-300" />
         </div>
       )}
-      <div className="absolute right-2 top-2 flex gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+      {!menu.isAvailable && (
+        <div className="absolute inset-0 flex items-center justify-center">
+          <span className="rounded-full bg-black/60 px-2.5 py-0.5 text-xs font-medium text-white">
+            품절
+          </span>
+        </div>
+      )}
+      {/* 모바일: 항상 표시 / 데스크탑: hover 시 표시 */}
+      <div className="absolute right-2 top-2 flex gap-1 transition-opacity sm:opacity-0 sm:group-hover:opacity-100">
+        <button
+          type="button"
+          onClick={onToggleFeatured}
+          title={menu.isFeatured ? '대표 메뉴 해제' : '대표 메뉴 설정'}
+          className="flex size-6 items-center justify-center rounded-full bg-white/90 shadow-sm transition-colors hover:bg-baro-yellow/10"
+        >
+          <Star
+            className={
+              menu.isFeatured ? 'size-3 fill-baro-yellow text-baro-yellow' : 'size-3 text-gray-400'
+            }
+          />
+        </button>
+        <button
+          type="button"
+          onClick={onToggleAvailable}
+          title={menu.isAvailable ? '품절 처리' : '품절 해제'}
+          className="flex size-6 items-center justify-center rounded-full bg-white/90 shadow-sm transition-colors hover:bg-red-50"
+        >
+          <Ban className={menu.isAvailable ? 'size-3 text-gray-400' : 'size-3 text-baro-red'} />
+        </button>
         <button
           type="button"
           onClick={onEdit}
+          title="메뉴 수정"
           className="flex size-6 items-center justify-center rounded-full bg-white/90 text-gray-600 shadow-sm transition-colors hover:text-baro-blue"
         >
           <Pencil className="size-3" />
@@ -316,6 +375,7 @@ const MenuCard = ({
         <button
           type="button"
           onClick={onDelete}
+          title="메뉴 삭제"
           className="flex size-6 items-center justify-center rounded-full bg-white/90 text-gray-600 shadow-sm transition-colors hover:text-red-500"
         >
           <Trash2 className="size-3" />
@@ -323,7 +383,10 @@ const MenuCard = ({
       </div>
     </div>
     <div className="px-3 py-2.5">
-      <p className="truncate text-sm font-semibold">{menu.name}</p>
+      <p className="flex items-center gap-1 truncate text-sm font-semibold">
+        {menu.isFeatured && <Star className="size-3 shrink-0 fill-baro-yellow text-baro-yellow" />}
+        {menu.name}
+      </p>
       {menu.description && (
         <p className="mt-0.5 line-clamp-1 text-xs text-muted-foreground">{menu.description}</p>
       )}
@@ -518,11 +581,15 @@ const MenuGrid = ({
   categories,
   onEdit,
   onDelete,
+  onToggleFeatured,
+  onToggleAvailable,
 }: {
   menus: MenuDto[];
   categories: MenuCategoryDto[];
   onEdit: (menu: MenuDto) => void;
   onDelete: (menuId: string) => void;
+  onToggleFeatured: (menu: MenuDto) => void;
+  onToggleAvailable: (menu: MenuDto) => void;
 }) => {
   const grouped = useMemo(() => {
     const result: { category: MenuCategoryDto | null; items: MenuDto[] }[] = [];
@@ -559,6 +626,8 @@ const MenuGrid = ({
                 menu={menu}
                 onEdit={() => onEdit(menu)}
                 onDelete={() => onDelete(menu.id)}
+                onToggleFeatured={() => onToggleFeatured(menu)}
+                onToggleAvailable={() => onToggleAvailable(menu)}
               />
             ))}
           </div>
@@ -580,17 +649,19 @@ const SettingsMenusPage = () => {
     isPending: isCreating,
   } = useCreateMenu();
   const { mutate: updateMenu, isPending: isUpdating } = useUpdateMenu();
-  const { mutate: deleteMenu } = useDeleteMenu();
+  const { mutate: deleteMenu, isPending: isDeleting } = useDeleteMenu();
 
   const [searchQuery, setSearchQuery] = useState('');
   const [open, setOpen] = useState(false);
   const [editing, setEditing] = useState<MenuDto | null>(null);
   const [modalKey, setModalKey] = useState(0);
   const [ocrOpen, setOcrOpen] = useState(false);
+  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
 
   const filteredMenus = menus?.filter((m) =>
     m.name.toLowerCase().includes(searchQuery.toLowerCase()),
   );
+  const deleteTargetName = menus?.find((m) => m.id === deleteTargetId)?.name;
 
   const handleOpenNew = () => {
     setEditing(null);
@@ -615,6 +686,19 @@ const SettingsMenusPage = () => {
     }
   };
 
+  const handleToggleFeatured = (menu: MenuDto) => {
+    updateMenu({ menuId: menu.id, data: { isFeatured: !menu.isFeatured } });
+  };
+
+  const handleToggleAvailable = (menu: MenuDto) => {
+    updateMenu({ menuId: menu.id, data: { isAvailable: !menu.isAvailable } });
+  };
+
+  const handleDeleteConfirm = () => {
+    if (!deleteTargetId) return;
+    deleteMenu(deleteTargetId, { onSuccess: () => setDeleteTargetId(null) });
+  };
+
   const handleOcrConfirm = async (items: OcrMenuConfirmItem[]) => {
     for (const item of items) {
       let imageUrl: string | null = null;
@@ -631,6 +715,7 @@ const SettingsMenusPage = () => {
         description: item.description,
         imageUrl,
         categoryId: null,
+        isFeatured: item.isFeatured,
       });
     }
   };
@@ -715,7 +800,9 @@ const SettingsMenusPage = () => {
             menus={filteredMenus}
             categories={categories}
             onEdit={handleOpenEdit}
-            onDelete={(id) => deleteMenu(id)}
+            onDelete={setDeleteTargetId}
+            onToggleFeatured={handleToggleFeatured}
+            onToggleAvailable={handleToggleAvailable}
           />
         )}
       </div>
@@ -738,6 +825,42 @@ const SettingsMenusPage = () => {
         onConfirm={handleOcrConfirm}
         isConfirming={isCreating}
       />
+
+      {/* 삭제 확인 모달 */}
+      <Dialog open={!!deleteTargetId} onOpenChange={(v) => !v && setDeleteTargetId(null)}>
+        <DialogContent showCloseButton={false} className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Trash2 className="size-4 text-destructive" />
+              메뉴 삭제
+            </DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            <span className="font-medium text-foreground">{deleteTargetName}</span> 메뉴를
+            삭제하시겠습니까?
+            <br />
+            삭제 후에는 복구할 수 없습니다.
+          </p>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setDeleteTargetId(null)}
+              disabled={isDeleting}
+            >
+              취소
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={handleDeleteConfirm}
+              disabled={isDeleting}
+            >
+              {isDeleting ? <Loader2 className="size-4 animate-spin" /> : '삭제'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 };


### PR DESCRIPTION
## 📌 요약

<!-- 이 PR에서 무엇을 했는지 간단히 요약 -->

- 가게 메뉴에 대하 대표 메뉴 설정과 품절 처리 기능을 추가 및 개선함

<br/>

## 🏷️ 관련 이슈

<!-- 연결된 이슈 번호 -->

- Closes #242, #243
- Related to #242, #243

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- 대표 메뉴 설정 기능 누락건 해결
- 주문 취소 시 품절 처리 기능 추가

<br/>

### 📂 세부 변경사항

- 가게 설정 페이지 > 메뉴 설정 페이지 내에서 품절 처리/해제 + 대표 메뉴 설정 가능하도록 함
- 재고가 부족한 주문이 들어왔을 때 사장님에게 품절 처리 여부를 묻는 기능 추가
- 품절 처리 시, 손님 메뉴판에서는 해당 메뉴 확인 못하도록 함
- 재고가 채워졌을 때 자동으로 품절 해제 기능 추가
- 재고 유무와 상관없이 설정페이지에서는 품절 해제/설정 가능
- 모바일 환경에서 (hover 개념이 없는 환경) 메뉴 설정 페이지 내 메뉴 카드에 4가지 버튼 상시 고정되도록 함
- 누락된 isFeatured 값 백엔드와 연계하여 수정 완료

<br/>

## 📸 Screenshots

<img width="400" alt="image" src="https://github.com/user-attachments/assets/f2424762-c4c8-4780-b349-757e727cee84" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/16e85b28-9f9e-422e-8ddd-a1138eb7ddc3" />
<img width="800" alt="image" src="https://github.com/user-attachments/assets/e9e09c69-690e-4c87-b882-e9b06b7f8e2f" />

<br/>

## 🧪 테스트 방법

<!-- 리뷰어가 어떻게 테스트하면 되는지 작성 -->

1. 메뉴 설정 페이지에서 각 기능 테스트 진행
2. 재고가 부족한 자재가 있는 메뉴 주문 > 주문 대시보드 확인 > 취소 시도 > 모달 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [ ] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [x] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

<!-- 리뷰어가 꼭 알아야 할 내용 -->

- X
