### PR TITLE
🚀 (#251) deploy: v1.3.1 버그 수정 패치 배포

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,61 +37,139 @@
 ```
 src/
 ├─ app/         # 레이아웃, 라우팅, 전역 스타일, AppInitializer
-├─ features/    # 도메인별 기능 모듈 (auth, dashboard, order, inventory, ocr-inbound, order-guide, closing, settings, account-settings)
-│  └─ [domain]/ # components/, hooks/, api/, store/, types/
+├─ features/    # 도메인별 기능 모듈
+│  ├─ auth/              # 로그인, 회원가입, 인증 상태
+│  ├─ dashboard/         # 메인 대시보드
+│  ├─ customer-order/    # 손님 주문 메뉴판
+│  ├─ inventory/         # 재고 현황
+│  ├─ ocr-inbound/       # OCR 입고 처리
+│  ├─ order-guide/       # 발주 가이드
+│  ├─ closing/           # 마감하기
+│  ├─ store-settings/    # 가게 설정 (메뉴, 레시피, 식자재, 테이블 등)
+│  ├─ store-registration/ # 가게 등록, 계정 홈(내 가게 목록)
+│  ├─ account-settings/  # 회원 설정
+│  ├─ initial-setup/     # 가게 초기 세팅
+│  ├─ landing/           # 랜딩 페이지
+│  ├─ notification/      # 알림
+│  └─ theme/             # 다크/라이트 테마
+│  (각 도메인: components/, hooks/, api/, store/, types/)
 ├─ pages/       # 라우팅 페이지 — UI·로직 없이 features 조합만 담당
-├─ widgets/     # 2개 이상 페이지에서 쓰는 조합형 UI
+├─ widgets/     # 2개 이상 페이지에서 쓰는 조합형 UI (AppHeader, AppSidebar)
+├─ lib/         # shadcn 유틸 (cn 함수)
 ├─ shadcn/      # Shadcn 컴포넌트 (수정 금지)
 └─ shared/      # 도메인 무관 공용 리소스
    ├─ api/      # Axios 인스턴스, interceptor
+   ├─ assets/   # 이미지, 폰트 등 정적 파일
    ├─ components/, hooks/, constants/, utils/
-   ├─ design-token/  # colors.css, spacing.css, typography.css
-   ├─ lib/      # queryClient 등
-   ├─ store/    # 전역 상태 (사용자 정보, 인증 토큰)
    └─ types/    # 공용 타입
+   (디자인 토큰은 src/index.css @theme inline에 정의)
 ```
 
 ## 페이지 목록
 
-| 경로               | 페이지               | 접근 주체         |
-| ------------------ | -------------------- | ----------------- |
-| `/`                | 랜딩 페이지          | 전체              |
-| `/login`           | 로그인 (카카오 소셜) | 비회원            |
-| `/initial-setup`   | 가게 초기 세팅       | 사장님 (최초 1회) |
-| `/dashboard`       | 메인 대시보드        | 사장님            |
-| `/inventory`       | 전체 재고 현황       | 사장님            |
-| `/ocr-inbound`     | OCR 재고 입고 처리   | 사장님            |
-| `/order-guide`     | 발주 가이드          | 사장님            |
-| `/closing`         | 마감하기             | 사장님            |
-| `/settings`        | 가게 설정            | 사장님            |
-| `/my-account`      | 회원 설정            | 사장님            |
-| `/order?table={n}` | 손님 주문 메뉴판     | 손님 (비회원)     |
+| 경로                                    | 페이지                       | 접근 주체         |
+| --------------------------------------- | ---------------------------- | ----------------- |
+| `/`                                     | 랜딩 페이지                  | 전체              |
+| `/login`                                | 로그인 (카카오 소셜)         | 비회원            |
+| `/credential-login`                     | 로그인 (아이디/비밀번호)     | 비회원            |
+| `/register`                             | 회원가입 (서비스 초대코드 필요) | 비회원          |
+| `/auth/callback`                        | 카카오 OAuth 콜백 처리       | 자동 처리         |
+| `/my-stores`                            | 계정 홈 (가게 선택)          | 사장님            |
+| `/store-selection`                      | 새 가게 등록 또는 초대코드 합류 | 사장님          |
+| `/initial-setup`                        | 가게 초기 세팅               | 사장님            |
+| `/store-home`                           | 가게 홈 (영업 시작/마감 관리) | 사장님           |
+| `/dashboard`                            | 메인 대시보드                | 사장님            |
+| `/inventory`                            | 전체 재고 현황               | 사장님            |
+| `/inbound-history`                      | 입고 내역                    | 사장님            |
+| `/ocr-inbound`                          | OCR 재고 입고 처리           | 사장님            |
+| `/order-guide`                          | 발주 가이드                  | 사장님            |
+| `/closing`                              | 마감하기                     | 사장님            |
+| `/closing/order-guide-detail`           | 마감 후 발주 가이드 상세      | 사장님           |
+| `/day-closed`                           | 영업 종료 화면               | 사장님            |
+| `/store-settings`                       | 가게 설정 (메인)             | 사장님            |
+| `/store-settings/menus`                 | 메뉴 관리                    | 사장님            |
+| `/store-settings/menu-board`            | 메뉴판 설정                  | 사장님            |
+| `/store-settings/table`                 | 테이블 설정                  | 사장님            |
+| `/store-settings/recipes`               | 레시피 관리                  | 사장님            |
+| `/store-settings/ingredients`           | 식자재 관리                  | 사장님            |
+| `/settings`                             | 회원 설정 (계정 설정)        | 사장님            |
+| `/order/:storeId/table/:tableNumber`    | 손님 주문 메뉴판             | 손님 (비회원)     |
+| `/notices`                              | 공지사항                     | 전체              |
+| `/terms`                                | 이용약관                     | 전체              |
+| `/privacy`                              | 개인정보처리방침             | 전체              |
 
 ## API 연동
 
 - Base URL: `https://api.baro.com/v1` (임시)
-- 로그인: 카카오 OAuth 소셜 로그인 → JWT 발급 (이메일/일반 회원가입 없음)
+- 로그인 방식:
+  - 카카오 OAuth 소셜 로그인 (`/login` 페이지)
+  - 아이디/비밀번호 로그인 (`/credential-login` 페이지)
+  - 회원가입 (`/register` 페이지) — 서비스 초대코드 필요 (서버 환경변수로 관리하는 코드, 가게 멤버 초대코드와 별개)
+- 로그인 후 리다이렉트: 항상 `/my-stores` (계정 홈)으로 이동
+  - 카카오 OAuth: `/auth/callback`에서 토큰 파싱 후 `/my-stores`로 이동
+  - 가게가 없으면 계정 홈에서 "가게 추가하기" → `/store-selection`
 - 인증: JWT Bearer Token (Authorization 헤더)
 - 토큰 갱신: refresh token → `/auth/refresh`
 - 401 감지 시 Axios interceptor에서 자동 로그아웃
-- 실시간 주문 수신: WebSocket 또는 SSE (Server-Sent Events)
+- 실시간 주문 수신: SSE (Server-Sent Events)
 
 ## 상태 관리 전략
 
 - **서버 상태**: React Query — 모든 서버 데이터는 무조건 React Query
-- **클라이언트 전역 상태**: Zustand — 사용자 정보, 인증 토큰, 사이드바, 모달 등 순수 UI 상태만
+- **클라이언트 전역 상태**: Zustand
+  - `authStore` (persist): accessToken, refreshToken, storeId, operatingHours
+  - `closingStore` (persist): businessSession(isOpen/businessDate), todayClosing
+  - `orderWarningsStore`: 주문별 재고 경고 (품절 처리용)
+  - `customerOrderStore`: 손님 주문 목록 (현재 mock 데이터 사용)
+  - `inventoryStore`: 재고 목록 (현재 mock 데이터 사용)
 - **로컬 상태**: `useState`
 - **폼 상태**: React Hook Form
 
 ## 디자인 토큰
 
-| 토큰         | Primary | 용도                 |
-| ------------ | ------- | -------------------- |
-| `baro-blue`  | #449CD4 | 주요 액션 버튼, 링크 |
-| `baro-red`   | #BD5535 | 삭제, 경고           |
-| `baro-green` | #679436 | 입고 완료, 정상 상태 |
-| `baro-black` | #111111 | 텍스트               |
-| `baro-ivory` | #F2E9E1 | 배경 포인트          |
+| 토큰           | Primary | 용도                    |
+| -------------- | ------- | ----------------------- |
+| `baro-blue`    | #449CD4 | 주요 액션 버튼, 링크    |
+| `baro-red`     | #BD5535 | 삭제, 경고              |
+| `baro-green`   | #679436 | 입고 완료, 정상 상태    |
+| `baro-yellow`  | #FFD94D | 주의, 경고 (누락 알림)  |
+| `baro-black`   | #111111 | 텍스트                  |
+| `baro-ivory`   | #F2E9E1 | 배경 포인트             |
+
+각 색상에 `-dark` 변형 존재 (`baro-blue-dark`, `baro-red-dark` 등). 정의 위치: `src/index.css`
+
+## 네비게이션 구조
+
+### 사이드바 (AppSidebar) — AppLayout이 적용된 페이지에서만 표시
+
+메인 메뉴:
+- 대시보드 (`/dashboard`) — 영업 중이 아니거나 마감 완료 시 비활성화
+- 전체 재고 현황 (`/inventory`)
+- 발주 가이드 (`/order-guide`)
+- 가게 설정 (`/store-settings`)
+
+하단 메뉴:
+- 회원 설정 (`/settings`)
+- 계정 홈 (`/my-stores`)
+- 가게 홈 (`/store-home`)
+- 서비스 소개 (`/`)
+
+**OCR 입고(`/ocr-inbound`)는 사이드바에 없음** — 대시보드 카드 또는 직접 URL 접근
+
+### 헤더 (AppHeader) — AppLayout이 적용된 페이지에서만 표시
+
+- **마감하기** 버튼: 영업 중(`isOpen`)이고 오늘 마감 미완료일 때 활성화. 사이드바가 아닌 헤더에 위치.
+- 전날 마감 누락 경고 버튼: 조건부 표시
+
+### AppLayout 적용 페이지
+
+`/dashboard`, `/inventory`, `/inbound-history`, `/order-guide`, `/closing`, `/store-settings/*`, `/settings`
+→ 사이드바 + 헤더 있음
+
+### 사이드바 없는 독립 페이지
+
+`/ocr-inbound`, `/store-home`, `/my-stores`, `/store-selection`, `/initial-setup`, `/day-closed`, `/closing/order-guide-detail`, `/order/:storeId/table/:tableNumber`
+→ 사이드바 없음
 
 ## UI/UX 지침
 
@@ -135,7 +213,7 @@ src/
 - **전역 에러**: ErrorBoundary
 - **API 에러**: Axios interceptor 공통 처리 + 토스트 피드백
 - **폼 유효성**: Zod 스키마 → 서버 에러는 `setError`로 필드 바인딩
-- **로딩**: Suspense + Skeleton UI
+- **로딩**: React Query `isLoading` + Skeleton UI (Suspense 미사용)
 - **404/권한 없음**: 전용 에러 페이지 리다이렉트
 
 ## 금지 사항
@@ -154,7 +232,7 @@ src/
 - 식자재 단위: `g`, `ml`, `개` 세 가지만 사용
 - OCR 단위 환산: `kg→g` (×1000), `L→ml` (×1000) — 프론트엔드에서 처리 후 서버에 표준 단위로 전송
 - 재고 미등록 시 재고 관련 기능 비활성화(disabled) 처리 + 안내 문구 표시
-- 회원 탈퇴: 가게 데이터(재고·메뉴·레시피 등) 초기화 선행 필수
+- 회원 탈퇴: 프론트엔드에서 별도 초기화 단계 없이 `DELETE /users/me` 호출 → 백엔드에서 가게 데이터(재고·메뉴·레시피 등) 일괄 삭제 처리
 
 ## 이슈 & PR 규칙
 

--- a/src/features/closing/components/AfterClosingModal.tsx
+++ b/src/features/closing/components/AfterClosingModal.tsx
@@ -2,11 +2,12 @@ import { useEffect, useState } from 'react';
 
 import {
   AlertTriangle,
+  CalendarCheck,
+  CalendarDays,
   CheckCircle2,
   ChevronRight,
   ClipboardList,
   LogOut,
-  CalendarCheck,
   ShoppingCart,
   Siren,
 } from 'lucide-react';
@@ -47,7 +48,14 @@ const URGENCY_CONFIG: Record<
     borderClass: 'border-l-2 border-l-baro-red',
     icon: <AlertTriangle className="w-3 h-3" />,
   },
-  recommended: {
+  expiry: {
+    label: '만료',
+    badgeClass:
+      'bg-orange-100 text-orange-700 border border-orange-200 dark:bg-orange-950/40 dark:border-orange-800/40',
+    borderClass: 'border-l-2 border-l-orange-400',
+    icon: <CalendarDays className="w-3 h-3" />,
+  },
+  recommend: {
     label: '권장',
     badgeClass:
       'bg-blue-100 text-baro-blue border border-blue-200 dark:bg-blue-950/40 dark:border-blue-800/40',
@@ -255,8 +263,9 @@ const AfterClosingModal = ({
                     </div>
                     <div className="flex flex-col items-end gap-1 shrink-0">
                       <span className="text-sm font-bold tabular-nums">
-                        {item.recommendedOrderQty}
-                        {item.recommendedOrderUnit}
+                        {item.urgency === 'recommend'
+                          ? '소진 후 재발주'
+                          : `${item.recommendedOrderQty}${item.recommendedOrderUnit}`}
                       </span>
                       <span
                         className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[11px] font-semibold ${cfg.badgeClass}`}

--- a/src/features/closing/hooks/useCancelClosing.ts
+++ b/src/features/closing/hooks/useCancelClosing.ts
@@ -1,14 +1,22 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { cancelClosing } from '@/features/closing/api/closing.api';
+import { cancelClosing, fetchBusinessOpenStatus } from '@/features/closing/api/closing.api';
+import useClosingStore from '@/features/closing/store/closingStore';
 
 export const useCancelClosing = (storeId: string) => {
   const queryClient = useQueryClient();
+  const setBusinessSession = useClosingStore((s) => s.setBusinessSession);
 
   return useMutation({
     mutationFn: (closingId: string) => cancelClosing(storeId, closingId),
-    onSuccess: () => {
+    onSuccess: async () => {
       queryClient.invalidateQueries({ queryKey: ['closing-history', storeId] });
+      try {
+        const status = await fetchBusinessOpenStatus(storeId);
+        setBusinessSession({ isOpen: status.isOpen, businessDate: status.businessDate });
+      } catch {
+        // 동기화 실패 시에도 마감 취소 자체는 성공이므로 무시
+      }
     },
   });
 };

--- a/src/features/ocr-inbound/components/OcrReviewStep.tsx
+++ b/src/features/ocr-inbound/components/OcrReviewStep.tsx
@@ -419,14 +419,13 @@ const OcrReviewStep = ({
                   ? Math.round((item.purchaseUnitPrice / item.conversionFactor) * 10) / 10
                   : null;
 
-              const rowBg = cn(
-                item.isWarning && 'bg-red-50/40 dark:bg-red-950/20',
-                !item.isWarning && !item.isMatched && 'bg-green-50/20 dark:bg-green-950/10',
-                !item.isWarning &&
-                  item.purchaseUnit &&
-                  !item.conversionFactor &&
-                  'bg-baro-yellow/10',
-              );
+              const rowBg = item.isWarning
+                ? 'bg-red-50/60 dark:bg-red-950/20'
+                : item.purchaseUnit && !item.conversionFactor
+                  ? 'bg-baro-yellow/10'
+                  : !item.isMatched
+                    ? 'bg-baro-green/10 dark:bg-baro-green/5'
+                    : '';
 
               const warningIcon = item.isWarning ? (
                 <Tooltip>

--- a/src/features/order-guide/api/orderGuide.api.ts
+++ b/src/features/order-guide/api/orderGuide.api.ts
@@ -11,7 +11,7 @@ interface BackendOrderGuideItem {
   unit: string;
   currentStock: number;
   safetyStock: number;
-  status: 'critical' | 'warning' | 'expiry';
+  status: 'critical' | 'warning' | 'expiry' | 'recommend';
   recommendedOrderAmount: number;
   reason: string;
   purchaseConversions: PurchaseConversion[];
@@ -29,10 +29,7 @@ export interface OrderGuideResponse {
   items: OrderGuideItem[];
 }
 
-const mapStatus = (status: BackendOrderGuideItem['status']): UrgencyLevel => {
-  if (status === 'expiry') return 'warning';
-  return status;
-};
+const mapStatus = (status: BackendOrderGuideItem['status']): UrgencyLevel => status;
 
 const mapItem = (item: BackendOrderGuideItem): OrderGuideItem => ({
   id: item.ingredientId,

--- a/src/features/order-guide/components/OrderGuideList.tsx
+++ b/src/features/order-guide/components/OrderGuideList.tsx
@@ -24,7 +24,8 @@ const FILTER_TABS: { key: FilterTab; label: string }[] = [
   { key: 'all', label: '전체' },
   { key: 'critical', label: '긴급' },
   { key: 'warning', label: '주의' },
-  { key: 'recommended', label: '권장' },
+  { key: 'expiry', label: '만료' },
+  { key: 'recommend', label: '권장' },
 ];
 
 const URGENCY_CONFIG: Record<
@@ -44,7 +45,14 @@ const URGENCY_CONFIG: Record<
     rowClass: 'border-l-4 border-l-baro-yellow/50',
     icon: <AlertTriangle className="w-3.5 h-3.5" />,
   },
-  recommended: {
+  expiry: {
+    label: '만료',
+    badgeClass:
+      'bg-orange-100 text-orange-700 border border-orange-200 dark:bg-orange-950/40 dark:text-orange-400',
+    rowClass: 'border-l-4 border-l-orange-400/50',
+    icon: <CalendarDays className="w-3.5 h-3.5" />,
+  },
+  recommend: {
     label: '권장',
     badgeClass:
       'bg-blue-100 text-baro-blue-dark border border-blue-200 dark:bg-blue-950/40 dark:text-blue-400',
@@ -78,7 +86,7 @@ const OrderGuideList = ({ items, generatedAt }: OrderGuideListProps) => {
           </CardTitle>
         </div>
 
-        <div className="flex gap-1">
+        <div className="flex gap-1 overflow-x-auto">
           {FILTER_TABS.map((tab) => {
             const count =
               tab.key === 'all' ? items.length : countByUrgency(tab.key as UrgencyLevel);
@@ -89,7 +97,7 @@ const OrderGuideList = ({ items, generatedAt }: OrderGuideListProps) => {
                 key={tab.key}
                 onClick={() => setActiveTab(tab.key)}
                 className={`
-                  px-3 py-2 text-xs font-medium rounded-t-md border-b-2 transition-colors
+                  flex items-center whitespace-nowrap px-2.5 py-2 text-xs font-medium rounded-t-md border-b-2 transition-colors
                   ${
                     isActive
                       ? 'border-b-baro-blue text-baro-blue-dark bg-blue-50/50 dark:bg-blue-950/20'
@@ -99,13 +107,15 @@ const OrderGuideList = ({ items, generatedAt }: OrderGuideListProps) => {
               >
                 {tab.label}
                 <span
-                  className={`ml-1.5 inline-flex items-center justify-center w-4 h-4 rounded-full text-[10px] font-bold
+                  className={`ml-1.5 inline-flex items-center justify-center min-w-4 h-4 px-1 rounded-full text-[10px] font-bold
                   ${
                     isActive
                       ? 'bg-baro-blue text-white'
                       : tab.key === 'critical' && count > 0
                         ? 'bg-red-100 text-baro-red'
-                        : 'bg-muted text-muted-foreground'
+                        : tab.key === 'expiry' && count > 0
+                          ? 'bg-orange-100 text-orange-700'
+                          : 'bg-muted text-muted-foreground'
                   }
                 `}
                 >
@@ -136,7 +146,7 @@ const OrderGuideList = ({ items, generatedAt }: OrderGuideListProps) => {
         ) : (
           <>
             {/* 고정 컬럼 헤더 (스크롤 내 sticky) */}
-            <div className="hidden md:grid grid-cols-[2fr_1fr_1fr_1fr_3fr_80px] gap-4 px-5 py-2.5 bg-muted/40 border-b text-xs font-semibold text-muted-foreground uppercase tracking-wide sticky top-0 z-10">
+            <div className="hidden md:grid grid-cols-[2fr_1fr_1fr_1fr_3fr_80px] gap-4 px-5 py-2.5 bg-background border-b text-xs font-semibold text-muted-foreground uppercase tracking-wide sticky top-0 z-10">
               <span>재료명</span>
               <span>현재 재고</span>
               <span>안전 재고 기준</span>
@@ -188,15 +198,21 @@ const OrderGuideList = ({ items, generatedAt }: OrderGuideListProps) => {
                       <span className="md:hidden text-xs text-muted-foreground mb-0.5">
                         권장 발주량
                       </span>
-                      <span className="text-sm font-semibold text-baro-blue-dark">
-                        {formatStock(item.recommendedOrderQty, item.recommendedOrderUnit)}
-                      </span>
-                      {item.purchaseConversions.map((c) => (
-                        <span key={c.purchaseUnit} className="text-xs text-muted-foreground">
-                          약 {c.purchaseAmount} × {c.purchaseUnit} ({c.factor.toLocaleString()}
-                          {item.recommendedOrderUnit})
-                        </span>
-                      ))}
+                      {item.urgency === 'recommend' ? (
+                        <span className="text-sm text-muted-foreground">소진 후 재발주</span>
+                      ) : (
+                        <>
+                          <span className="text-sm font-semibold text-baro-blue-dark">
+                            {formatStock(item.recommendedOrderQty, item.recommendedOrderUnit)}
+                          </span>
+                          {item.purchaseConversions.map((c) => (
+                            <span key={c.purchaseUnit} className="text-xs text-muted-foreground">
+                              약 {c.purchaseAmount} × {c.purchaseUnit} ({c.factor.toLocaleString()}
+                              {item.recommendedOrderUnit})
+                            </span>
+                          ))}
+                        </>
+                      )}
                     </div>
 
                     <div className="flex flex-col justify-center gap-1">

--- a/src/features/order-guide/types/orderGuide.types.ts
+++ b/src/features/order-guide/types/orderGuide.types.ts
@@ -1,4 +1,4 @@
-export type UrgencyLevel = 'critical' | 'warning' | 'recommended';
+export type UrgencyLevel = 'critical' | 'warning' | 'expiry' | 'recommend';
 
 export interface DemandFactor {
   icon: string;

--- a/src/pages/ClosingPage.tsx
+++ b/src/pages/ClosingPage.tsx
@@ -6,6 +6,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { toast } from 'sonner';
 
 import useAuthStore from '@/features/auth/store/authStore';
+import { fetchBusinessOpenStatus } from '@/features/closing/api/closing.api';
 import AfterClosingModal from '@/features/closing/components/AfterClosingModal';
 import ClosingInventoryDeductionSection, {
   type DeductionRow,
@@ -44,6 +45,7 @@ const ClosingPage = () => {
   const queryClient = useQueryClient();
   const storeId = useAuthStore((s) => s.storeId);
   const clearBusinessSession = useClosingStore((s) => s.clearBusinessSession);
+  const setBusinessSession = useClosingStore((s) => s.setBusinessSession);
   const [searchParams] = useSearchParams();
   const dateParam = searchParams.get('date') ?? undefined;
   const isRetroactive = !!dateParam;
@@ -93,12 +95,21 @@ const ClosingPage = () => {
         })),
       },
       {
-        onSuccess: (res) => {
+        onSuccess: async (res) => {
           setFinalRevenue(res.totalRevenue);
           setClosingId(res.closingId);
           setClosingDate(res.date);
-          // 소급 마감은 오늘 영업 세션과 무관하므로 세션을 유지
-          if (!isRetroactive) clearBusinessSession();
+          if (!isRetroactive) {
+            clearBusinessSession();
+          } else {
+            // 소급 마감이 현재 businessDate를 닫은 경우를 포함해 서버 상태를 동기화
+            try {
+              const status = await fetchBusinessOpenStatus(storeId!);
+              setBusinessSession({ isOpen: status.isOpen, businessDate: status.businessDate });
+            } catch {
+              // 동기화 실패 시에도 마감 자체는 성공이므로 무시
+            }
+          }
           void queryClient.invalidateQueries({ queryKey: ['closing', 'preview'] });
           setAfterModalOpen(true);
         },


### PR DESCRIPTION
## 📌 요약

- v1.3.0 이후 develop에 누적된 버그 수정 3건을 패치 버전으로 배포
- 마감 취소·소급 마감 후 영업 상태가 새로고침 없이 즉시 동기화되도록 수정

<br/>

## 🏷️ 관련 이슈

- Closes #251
- Related to #250
- Related to #249

<br/>

## 🔥 변경사항

### ✨ 주요 변경사항

- 마감 취소·소급 마감 완료 시 서버에서 영업 상태(isOpen/businessDate)를 재조회해 Zustand businessSession 즉시 동기화

<br/>

### 📂 세부 변경사항

- `src/features/closing/hooks/useCancelClosing.ts`: onSuccess에서 fetchBusinessOpenStatus 호출 후 setBusinessSession
- `src/pages/ClosingPage.tsx`: 소급 마감 성공 시 fetchBusinessOpenStatus 호출 후 setBusinessSession
- `CLAUDE.md`: 실제 구현 내용에 맞게 문서 업데이트 (페이지 목록, 상태관리, 네비게이션 구조 등)
- 🐛 (#249) 발주 가이드 recommend 상태 추가 및 런타임 오류 수정
- 💄 OCR 인식 결과 행 배경색 우선순위 및 가시성 개선

<br/>

## 📸 Screenshots

| Before | After |
| ------ | ----- |
| 마감 취소 후 대시보드에서 영업 상태가 새로고침 전까지 stale 상태 유지 | 마감 취소·소급 마감 즉시 영업 상태 동기화 |

<br/>

## 🧪 테스트 방법

1. 영업 중 상태에서 마감 완료 → 마감 취소 → 대시보드 확인 (새로고침 없이 상태 정상 반영 확인)
2. 전날 마감 누락 상태에서 소급 마감 진행 → 영업 상태 즉시 변경 확인

<br/>

## 🚨 영향 범위

- [x] Frontend
- [ ] Backend
- [ ] API
- [ ] Database
- [ ] Build / Deploy
- [ ] Dev Environment only

<br/>

## 🔎 체크리스트

- [x] 빌드 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 타입 에러 없음
- [x] 기존 기능 영향 없음
- [x] 관련 문서 수정 (필요 시)

<br/>

## 💬 Additional Notes

- 마감 취소/소급 마감 후 동기화 실패 시(네트워크 오류 등) catch 블록에서 무시 처리 — 마감 작업 자체는 성공이므로 영향 없음
- 이전 버전 롤백: `git checkout v1.3.0`